### PR TITLE
Fix parse_reference for missing URL segments

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -87,6 +87,7 @@ struct ReviewThreadConnection {
 struct ReviewThread {
     id: String,
     #[serde(rename = "isResolved")]
+    #[allow(dead_code)]
     is_resolved: bool,
     comments: CommentConnection,
 }
@@ -326,7 +327,8 @@ async fn main() -> Result<(), VkError> {
 fn parse_reference(input: &str) -> Result<(RepoInfo, u64), VkError> {
     if let Ok(url) = Url::parse(input) {
         if url.host_str() == Some("github.com") {
-            let segments: Vec<_> = url.path_segments().unwrap().collect();
+            let segments_iter = url.path_segments().ok_or(VkError::InvalidRef)?;
+            let segments: Vec<_> = segments_iter.collect();
             if segments.len() >= 4 && segments[2] == "pull" {
                 let owner = segments[0].to_string();
                 let name = segments[1]


### PR DESCRIPTION
## Summary
- avoid panicking when parsing PR URLs
- suppress dead-code warning for `is_resolved`

## Testing
- `cargo clippy -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68441f4cb9b4832298902c09e1da2173

## Summary by Sourcery

Fix parse_reference to handle missing GitHub URL segments gracefully and suppress dead-code warnings for the `is_resolved` field.

Bug Fixes:
- Make `parse_reference` return an `InvalidRef` error instead of panicking when URL path segments are missing.

Enhancements:
- Add `#[allow(dead_code)]` to the `is_resolved` field in `ReviewThread` to suppress dead-code warnings.