### PR TITLE
Add GITHUB_TOKEN scope guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ run with only a number.
 `vk` uses the GitHub GraphQL API. Set `GITHUB_TOKEN` to authenticate. If it's not
 set you'll get a warning and anonymous requests may be rate limited.
 
+The token only needs read access. Select the `public_repo` scope (or `repo` for
+private repositories). See [docs/GITHUB_TOKEN.md](docs/GITHUB_TOKEN.md) for a
+detailed guide to creating one.
+
 ## Example
 
 ```

--- a/docs/GITHUB_TOKEN.md
+++ b/docs/GITHUB_TOKEN.md
@@ -1,0 +1,23 @@
+# Creating a GitHub Token for vk
+
+vk authenticates to the GitHub GraphQL API using a personal access token (PAT).
+Follow these steps to create one:
+
+1. Visit <https://github.com/settings/tokens> and choose **Generate new token**.
+   GitHub may prompt you to pick a classic or fine‑grained token – either
+   works.
+2. Give the token a note and set an expiration.
+3. Under **Select scopes**, enable `public_repo`. If you need to access private
+   repositories, select the broader `repo` scope instead.
+4. Click **Generate token** and copy the value.
+5. Export the token as `GITHUB_TOKEN`:
+
+```bash
+export GITHUB_TOKEN=YOUR_TOKEN
+```
+
+Once set you can run `vk` normally:
+
+```bash
+vk <pull-request-url-or-number>
+```


### PR DESCRIPTION
## Summary
- detail required scopes for GITHUB_TOKEN
- document how to create a personal access token

## Testing
- `cargo fmt`
- `cargo clippy`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68441f795a6c8322905f4c9f3fbe11b7

## Summary by Sourcery

Add documentation for setting up GITHUB_TOKEN with the necessary scopes

Documentation:
- Clarify in README that GITHUB_TOKEN only requires public_repo (or repo for private repos)
- Add docs/GITHUB_TOKEN.md with step-by-step instructions to generate and export a personal access token