### PR TITLE
Fix GitHub query

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -133,7 +133,7 @@ const THREADS_QUERY: &str = r#"
     query($owner: String!, $name: String!, $number: Int!, $cursor: String) {
       repository(owner: $owner, name: $name) {
         pullRequest(number: $number) {
-          reviewThreads(first: 100, after: $cursor, states: [UNRESOLVED]) {
+          reviewThreads(first: 100, after: $cursor) {
             nodes {
               id
               isResolved
@@ -254,6 +254,7 @@ async fn fetch_review_threads(
 ) -> Result<Vec<ReviewThread>, VkError> {
     let mut threads =
         paginate(|cursor| fetch_thread_page(client, headers, repo, number, cursor)).await?;
+    threads.retain(|t| !t.is_resolved);
 
     for thread in &mut threads {
         let initial = std::mem::replace(


### PR DESCRIPTION
## Summary
- stop using the `states` argument in the GraphQL query
- filter resolved review threads in code

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all`


------
https://chatgpt.com/codex/tasks/task_e_68443fd947348322be1bed627ddac36b

## Summary by Sourcery

Stop using the unsupported ‘states’ filter in the GitHub reviewThreads GraphQL query and instead filter out resolved review threads in code

Bug Fixes:
- Remove the ‘states: [UNRESOLVED]’ argument from the reviewThreads GraphQL query

Enhancements:
- Filter out resolved review threads client-side by retaining only threads with isResolved == false