### PR TITLE
Add diff hunks display

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,6 +77,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.98"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
+
+[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -350,6 +356,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "diffy"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b545b8c50194bdd008283985ab0b31dba153cfd5b3066a92770634fbc0d7d291"
+dependencies = [
+ "nu-ansi-term",
 ]
 
 [[package]]
@@ -882,6 +897,15 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4a28e057d01f97e61255210fcff094d74ed0466038633e95017f5beb68e4399"
+dependencies = [
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1634,7 +1658,9 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 name = "vk"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "clap",
+ "diffy",
  "once_cell",
  "regex",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,8 @@ thiserror = "1.0.57"
 url = "2.5.0"
 regex = "1.10.3"
 once_cell = "1.19.0"
+diffy = "0.4.2"
+anyhow = "1.0"
 
 [dev-dependencies]
 tempfile = "3.20.0"


### PR DESCRIPTION
## Summary
- show diff hunks for comments
- print colorized patches with diffy
- include new dependencies

## Testing
- `cargo clippy -- -D warnings`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68448aaa27548322b0e037f0debaf55b

## Summary by Sourcery

Add support for fetching and colorizing diff hunks in review comments by extending the data model, updating queries, and centralizing rendering logic

New Features:
- Fetch and display diff hunks for review comments by including diffHunk and path fields
- Render and colorize comment diff patches using diffy with a fallback to raw hunk output

Enhancements:
- Consolidate comment printing into a new print_comment function

Build:
- Add diffy and anyhow as dependencies