### PR TITLE
Improve locale UTF-8 detection

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -39,6 +39,8 @@ enum VkError {
 static GITHUB_RE: Lazy<Regex> =
     Lazy::new(|| Regex::new(r"github\.com[/:](?P<owner>[^/]+)/(?P<repo>[^/.]+)").unwrap());
 
+static UTF8_RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"UTF-?8").unwrap());
+
 #[derive(Deserialize)]
 struct GraphQlResponse<T> {
     data: Option<T>,
@@ -426,7 +428,7 @@ fn repo_from_env() -> Option<RepoInfo> {
 fn locale_is_utf8() -> bool {
     env::var("LC_ALL")
         .or_else(|_| env::var("LANG"))
-        .map(|v| v.to_uppercase().contains("UTF-8"))
+        .map(|v| UTF8_RE.is_match(&v.to_uppercase()))
         .unwrap_or(false)
 }
 
@@ -499,6 +501,9 @@ mod tests {
 
         set_var("LC_ALL", "en_GB.UTF-8");
         remove_var("LANG");
+        assert!(locale_is_utf8());
+
+        set_var("LC_ALL", "en_GB.UTF8");
         assert!(locale_is_utf8());
 
         set_var("LC_ALL", "C");

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,7 +39,7 @@ enum VkError {
 static GITHUB_RE: Lazy<Regex> =
     Lazy::new(|| Regex::new(r"github\.com[/:](?P<owner>[^/]+)/(?P<repo>[^/.]+)").unwrap());
 
-static UTF8_RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"UTF-?8").unwrap());
+static UTF8_RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"(?i)\bUTF-?8\b").unwrap());
 
 #[derive(Deserialize)]
 struct GraphQlResponse<T> {
@@ -428,7 +428,7 @@ fn repo_from_env() -> Option<RepoInfo> {
 fn locale_is_utf8() -> bool {
     env::var("LC_ALL")
         .or_else(|_| env::var("LANG"))
-        .map(|v| UTF8_RE.is_match(&v.to_uppercase()))
+        .map(|v| UTF8_RE.is_match(&v))
         .unwrap_or(false)
 }
 
@@ -504,6 +504,9 @@ mod tests {
         assert!(locale_is_utf8());
 
         set_var("LC_ALL", "en_GB.UTF8");
+        assert!(locale_is_utf8());
+
+        set_var("LC_ALL", "en_GB.utf8");
         assert!(locale_is_utf8());
 
         set_var("LC_ALL", "C");


### PR DESCRIPTION
## Summary
- detect `UTF8` locale strings in addition to `UTF-8`
- test for both locale spellings

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68450280815c8322bd23f1df7db02a4d

## Summary by Sourcery

Improve locale detection to recognize both "UTF8" and "UTF-8" variants and include LC_CTYPE fallback, with expanded tests covering multiple environment variables and spellings

Enhancements:
- Use a case-insensitive regex to match UTF-8 or UTF8 in locale strings
- Fall back to LC_CTYPE before LANG when checking for UTF-8 locale

Tests:
- Expand locale detection tests to cover LC_ALL, LC_CTYPE, and LANG variables
- Add test cases for multiple UTF-8 spelling variations and non-UTF8 values