### PR TITLE
Update README with AI agent context

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 `vk` stands for **View Komments** because `vc` was already taken back in the 1970s and no one argues with a greybeard. This command line tool fetches unresolved GitHub code review comments for a pull request and displays them with colourful terminal markdown using [Termimad](https://crates.io/crates/termimad).
 
+This tool is intended for use by AI coding agents such as Aider, OpenAI Codex or Claude Code (without implying association with any of these companies).
+
 ## Usage
 
 ```bash
@@ -10,7 +12,7 @@ vk <pull-request-url-or-number>
 
 If you pass just a pull request number, `vk` tries to work out which repository
 you meant. It first examines `.git/FETCH_HEAD` for a GitHub remote URL and, if
-found, extracts the `owner/repo` from it. Failing that, it falls back to the
+found, extracts the `owner/repo` from it. As Codex does not put the upstream URL in `.git/config`, we must obtain this from `FETCH_HEAD` for now. Failing that, it falls back to the
 `VK_REPO` environment variable which should be set to `owner/repo` (with or
 without a `.git` suffix). If neither source is available, `vk` will refuse to
 run with only a number.


### PR DESCRIPTION
## Summary
- clarify that vk is meant for AI coding agents
- note that Codex doesn't write upstream URLs to `.git/config`

## Testing
- `cargo fmt`
- `cargo clippy -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_6845047774dc8322bc2eadc4912906e8

## Summary by Sourcery

Update README to clarify vk’s intended use by AI coding agents and document Codex’s limitation with upstream URLs

Documentation:
- Clarify that vk is intended for use by AI coding agents such as Aider, OpenAI Codex, and Claude Code
- Note that OpenAI Codex does not write upstream URLs to `.git/config`, requiring retrieval from `FETCH_HEAD`