### PR TITLE
Improve diff hunk display

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -349,8 +349,7 @@ fn format_comment_diff(comment: &ReviewComment) -> String {
     }
 
     let target = lines.iter().position(|(o, n, _)| {
-        comment.original_position.is_some_and(|p| Some(p) == *o)
-            || comment.position.is_some_and(|p| Some(p) == *n)
+        comment.original_position == *o || comment.position == *n
     });
     let (start, end) = if let Some(idx) = target {
         (idx.saturating_sub(5), std::cmp::min(lines.len(), idx + 6))

--- a/src/main.rs
+++ b/src/main.rs
@@ -347,10 +347,11 @@ fn format_comment_diff(comment: &ReviewComment) -> String {
     let end = std::cmp::min(lines.len(), idx + 6);
 
     let mut out = String::new();
+    use std::fmt::Write;
     for (o, n, text) in &lines[start..end] {
-        let old_disp = o.map_or("    ".to_string(), |n| format!("{:>4}", n));
-        let new_disp = n.map_or("    ".to_string(), |n| format!("{:>4}", n));
-        out.push_str(&format!("{old_disp} {new_disp} {text}\n"));
+        let old_disp = o.map_or("    ", |n| format!("{:>4}", n));
+        let new_disp = n.map_or("    ", |n| format!("{:>4}", n));
+        write!(&mut out, "{} {} {}\n", old_disp, new_disp, text).unwrap();
     }
     out
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -370,8 +370,6 @@ fn format_comment_diff(comment: &ReviewComment) -> Result<String, std::fmt::Erro
         Some(idx) => (idx.saturating_sub(5), std::cmp::min(lines.len(), idx + 6)),
         None => (0, std::cmp::min(lines.len(), 20)),
     };
-    let diff = format_comment_diff(comment)?;
-    print!("{}", diff);
 
     let mut out = String::new();
     use std::fmt::Write;

--- a/src/main.rs
+++ b/src/main.rs
@@ -309,67 +309,61 @@ async fn fetch_review_threads(
 fn format_comment_diff(comment: &ReviewComment) -> Result<String, std::fmt::Error> {
     use std::fmt::Write;
 
+    fn parse_diff_lines<'a, I>(
+        lines: I,
+        mut old_line: i32,
+        mut new_line: i32,
+    ) -> Vec<(Option<i32>, Option<i32>, String)>
+    where
+        I: Iterator<Item = &'a str>,
+    {
+        let mut parsed = Vec::new();
+        for l in lines {
+            if l.starts_with('+') {
+                parsed.push((None, Some(new_line), l.to_string()));
+                new_line += 1;
+            } else if l.starts_with('-') {
+                parsed.push((Some(old_line), None, l.to_string()));
+                old_line += 1;
+            } else {
+                let text = l.strip_prefix(' ').unwrap_or(l);
+                parsed.push((Some(old_line), Some(new_line), format!(" {}", text)));
+                old_line += 1;
+                new_line += 1;
+            }
+        }
+        parsed
+    }
+
     let mut lines_iter = comment.diff_hunk.lines();
     let header = match lines_iter.next() {
         Some(h) => h,
         None => return Ok(String::new()),
     };
 
-    let caps = match HUNK_RE.captures(header) {
-        Some(c) => c,
-        None => {
-            let mut out = String::new();
-            let mut old_line = 0;
-            let mut new_line = 0;
-            for l in comment.diff_hunk.lines() {
-                if l.starts_with('+') {
-                    writeln!(&mut out, "     {:>4} {}", new_line + 1, l)?;
-                    new_line += 1;
-                } else if l.starts_with('-') {
-                    writeln!(&mut out, "{:>4}      {}", old_line + 1, l)?;
-                    old_line += 1;
-                } else {
-                    writeln!(&mut out, "{:>4} {:>4} {}", old_line + 1, new_line + 1, l)?;
-                    old_line += 1;
-                    new_line += 1;
-                }
-            }
-            return Ok(out);
-        }
-    };
+    let lines: Vec<(Option<i32>, Option<i32>, String)> =
+        if let Some(caps) = HUNK_RE.captures(header) {
+            let old_start: i32 = caps
+                .name("old")
+                .and_then(|m| m.as_str().parse().ok())
+                .unwrap_or(0);
+            let new_start: i32 = caps
+                .name("new")
+                .and_then(|m| m.as_str().parse().ok())
+                .unwrap_or(0);
+            let _old_count: usize = caps
+                .name("old_count")
+                .and_then(|m| m.as_str().parse().ok())
+                .unwrap_or(1);
+            let _new_count: usize = caps
+                .name("new_count")
+                .and_then(|m| m.as_str().parse().ok())
+                .unwrap_or(1);
 
-    let mut old_line: i32 = caps
-        .name("old")
-        .and_then(|m| m.as_str().parse().ok())
-        .unwrap_or(0);
-    let mut new_line: i32 = caps
-        .name("new")
-        .and_then(|m| m.as_str().parse().ok())
-        .unwrap_or(0);
-    let _old_count: usize = caps
-        .name("old_count")
-        .and_then(|m| m.as_str().parse().ok())
-        .unwrap_or(1);
-    let _new_count: usize = caps
-        .name("new_count")
-        .and_then(|m| m.as_str().parse().ok())
-        .unwrap_or(1);
-
-    let mut lines: Vec<(Option<i32>, Option<i32>, String)> = Vec::new();
-    for l in lines_iter {
-        if l.starts_with('+') {
-            lines.push((None, Some(new_line), l.to_string()));
-            new_line += 1;
-        } else if l.starts_with('-') {
-            lines.push((Some(old_line), None, l.to_string()));
-            old_line += 1;
+            parse_diff_lines(lines_iter, old_start, new_start)
         } else {
-            let text = l.strip_prefix(' ').unwrap_or(l);
-            lines.push((Some(old_line), Some(new_line), format!(" {}", text)));
-            old_line += 1;
-            new_line += 1;
-        }
-    }
+            parse_diff_lines(comment.diff_hunk.lines(), 0, 0)
+        };
 
     let target_idx = lines.iter().position(|(o, n, _)| {
     let (start, end) = match target_idx {

--- a/src/main.rs
+++ b/src/main.rs
@@ -371,19 +371,13 @@ fn format_comment_diff(comment: &ReviewComment) -> Result<String, std::fmt::Erro
         }
     }
 
-    let target = lines.iter().position(|(o, n, _)| {
-    let (start, end);
-    if let Some(idx) = target {
-        start = idx.saturating_sub(5);
-        end = std::cmp::min(lines.len(), idx + 6);
-        start = 0;
-        end = std::cmp::min(lines.len(), 20);
-    }
-        Ok(diff) => print!("{}", diff),
-        Err(_) => print!("{}", comment.diff_hunk),
-    }
-        (0, lines.len())
+    let target_idx = lines.iter().position(|(o, n, _)| {
+    let (start, end) = match target_idx {
+        Some(idx) => (idx.saturating_sub(5), std::cmp::min(lines.len(), idx + 6)),
+        None => (0, std::cmp::min(lines.len(), 20)),
     };
+    let diff = format_comment_diff(comment).map_err(|e| anyhow::anyhow!(e))?;
+    print!("{}", diff);
 
     let mut out = String::new();
     use std::fmt::Write;

--- a/src/main.rs
+++ b/src/main.rs
@@ -372,10 +372,13 @@ fn format_comment_diff(comment: &ReviewComment) -> Result<String, std::fmt::Erro
     }
 
     let target = lines.iter().position(|(o, n, _)| {
-        (0, std::cmp::min(lines.len(), 20))
-        writeln!(&mut out, "{old_disp} {new_disp} {text}")?;
-    Ok(out)
-    match format_comment_diff(comment) {
+    let (start, end);
+    if let Some(idx) = target {
+        start = idx.saturating_sub(5);
+        end = std::cmp::min(lines.len(), idx + 6);
+        start = 0;
+        end = std::cmp::min(lines.len(), 20);
+    }
         Ok(diff) => print!("{}", diff),
         Err(_) => print!("{}", comment.diff_hunk),
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -370,7 +370,7 @@ fn format_comment_diff(comment: &ReviewComment) -> Result<String, std::fmt::Erro
         Some(idx) => (idx.saturating_sub(5), std::cmp::min(lines.len(), idx + 6)),
         None => (0, std::cmp::min(lines.len(), 20)),
     };
-    let diff = format_comment_diff(comment).map_err(|e| anyhow::anyhow!(e))?;
+    let diff = format_comment_diff(comment)?;
     print!("{}", diff);
 
     let mut out = String::new();

--- a/tests/fixtures/review_comment.json
+++ b/tests/fixtures/review_comment.json
@@ -1,0 +1,69 @@
+{
+  "url": "https://api.github.com/repos/leynos/bournemouth/pulls/comments/2134344072",
+  "pull_request_review_id": 2908037305,
+  "id": 2134344072,
+  "node_id": "PRRC_kwDOO0MSNs5_N4GI",
+  "diffHunk": "@@ -2,48 +2,125 @@\n \n from __future__ import annotations\n \n-import dataclasses\n import typing\n \n import falcon\n+import msgspec\n+from sqlalchemy import select, update\n \n+if typing.TYPE_CHECKING:  # pragma: no cover\n+    from sqlalchemy.ext.asyncio import AsyncSession\n \n-@dataclasses.dataclass(slots=True)\n-class ChatRequest:\n+from .models import UserAccount\n+from .openrouter import ChatMessage, Role\n+from .openrouter_service import (\n+    OpenRouterService,\n+    OpenRouterServiceBadGatewayError,\n+    OpenRouterServiceTimeoutError,\n+    chat_with_service,\n+)\n+\n+\n+class ChatRequest(msgspec.Struct):\n     \"\"\"Request body for the chat endpoint.\"\"\"\n \n     message: str\n     history: list[dict[str, typing.Any]] | None = None\n+    model: str | None = None\n \n \n class ChatResource:\n     \"\"\"Handle chat requests.\"\"\"\n \n-    async def on_post(self, req: falcon.Request, resp: falcon.Response) -> None:\n-        data = await req.get_media()\n-        if not data or \"message\" not in data:\n-            raise falcon.HTTPBadRequest(description=\"`message` field required\")\n+    def __init__(\n+        self,\n+        service: OpenRouterService,\n+        session_factory: typing.Callable[[], AsyncSession],\n+    ) -> None:\n+        self._service = service\n+        self._session_factory = session_factory\n \n-        # TODO(pmcintosh): plug in RAG and LLM call\n-        # https://github.com/example/repo/issues/1\n-        raise falcon.HTTPNotImplemented(\n-            description=\"This endpoint is not yet implemented.\"\n-        )\n+    async def on_post(self, req: falcon.Request, resp: falcon.Response) -> None:\n+        raw = await typing.cast(\"typing.Awaitable[bytes]\", req.bounded_stream.read())\n+        try:\n+            data = msgspec.json.decode(raw)\n+        except msgspec.DecodeError:\n+            raise falcon.HTTPBadRequest(description=\"invalid JSON\") from None\n+\n+        match data:\n+            case {\"message\": str(msg), **extra}:\n+                pass\n+            case _:\n+                raise falcon.HTTPBadRequest(description=\"`message` field required\")\n+        history: list[ChatMessage] = []\n+        if isinstance(extra.get(\"history\"), list):\n+            valid_roles = typing.get_args(Role)\n+            for item in extra[\"history\"]:\n+                match item:\n+                    case {\"role\": role, \"content\": str(content)} if role in valid_roles:\n+                        history.append(\n+                            ChatMessage(\n+                                role=typing.cast(\"Role\", role),\n+                                content=content,\n+                            )\n+                        )\n+                    case _:\n+                        raise falcon.HTTPBadRequest(description=\"invalid history item\")\n+\n+        history.append(ChatMessage(role=\"user\", content=msg))\n+\n+        model = typing.cast(\"str | None\", extra.get(\"model\"))\n+\n+        async with self._session_factory() as session:\n+            stmt = select(UserAccount.openrouter_token_enc).where(\n+                UserAccount.google_sub == typing.cast(\"str\", req.context[\"user\"])\n+            )\n+            result = await session.execute(stmt)\n+            token = typing.cast(\"bytes | str | None\", result.scalar_one_or_none())\n+        if not token:\n+            raise falcon.HTTPBadRequest(description=\"missing OpenRouter token\")\n+\n+        api_key = token.decode() if isinstance(token, bytes) else token\n+\n+        try:\n+            completion = await chat_with_service(\n+                self._service,\n+                api_key,\n+                history,\n+                model=model,\n+            )\n+        except OpenRouterServiceTimeoutError:\n+            raise falcon.HTTPGatewayTimeout() from None\n+        except OpenRouterServiceBadGatewayError as exc:\n+            raise falcon.HTTPBadGateway(description=str(exc)) from None  # pyright: ignore[reportUnknownArgumentType]\n+\n+        answer = completion.choices[0].message.content or \"\"",
+  "path": "src/bournemouth/resources.py",
+  "commit_id": "c0b0926a1b8c233e5679450b297189852f175a7a",
+  "original_commit_id": "d55871f7f53a113e9fb79f06e25cc5ce7fd08d01",
+  "user": {
+    "login": "sourcery-ai[bot]",
+    "id": 58596630,
+    "node_id": "MDM6Qm90NTg1OTY2MzA=",
+    "avatar_url": "https://avatars.githubusercontent.com/in/48477?v=4",
+    "gravatar_id": "",
+    "url": "https://api.github.com/users/sourcery-ai%5Bbot%5D",
+    "html_url": "https://github.com/apps/sourcery-ai",
+    "followers_url": "https://api.github.com/users/sourcery-ai%5Bbot%5D/followers",
+    "following_url": "https://api.github.com/users/sourcery-ai%5Bbot%5D/following{/other_user}",
+    "gists_url": "https://api.github.com/users/sourcery-ai%5Bbot%5D/gists{/gist_id}",
+    "starred_url": "https://api.github.com/users/sourcery-ai%5Bbot%5D/starred{/owner}{/repo}",
+    "subscriptions_url": "https://api.github.com/users/sourcery-ai%5Bbot%5D/subscriptions",
+    "organizations_url": "https://api.github.com/users/sourcery-ai%5Bbot%5D/orgs",
+    "repos_url": "https://api.github.com/users/sourcery-ai%5Bbot%5D/repos",
+    "events_url": "https://api.github.com/users/sourcery-ai%5Bbot%5D/events{/privacy}",
+    "received_events_url": "https://api.github.com/users/sourcery-ai%5Bbot%5D/received_events",
+    "type": "Bot",
+    "user_view_type": "public",
+    "site_admin": false
+  },
+  "body": "**suggestion:** Handle case when completion.choices is empty\n\nAdd a check to ensure choices is not empty before accessing choices[0] to prevent IndexError.",
+  "created_at": "2025-06-08T02:11:15Z",
+  "updated_at": "2025-06-08T02:11:15Z",
+  "html_url": "https://github.com/leynos/bournemouth/pull/17#discussion_r2134344072",
+  "pull_request_url": "https://api.github.com/repos/leynos/bournemouth/pulls/17",
+  "author_association": "CONTRIBUTOR",
+  "_links": {
+    "self": {
+      "href": "https://api.github.com/repos/leynos/bournemouth/pulls/comments/2134344072"
+    },
+    "html": {
+      "href": "https://github.com/leynos/bournemouth/pull/17#discussion_r2134344072"
+    },
+    "pull_request": {
+      "href": "https://api.github.com/repos/leynos/bournemouth/pulls/17"
+    }
+  },
+  "reactions": {
+    "url": "https://api.github.com/repos/leynos/bournemouth/pulls/comments/2134344072/reactions",
+    "total_count": 2,
+    "+1": 1,
+    "-1": 1,
+    "laugh": 0,
+    "hooray": 0,
+    "confused": 0,
+    "heart": 0,
+    "rocket": 0,
+    "eyes": 0
+  },
+  "start_line": null,
+  "original_start_line": null,
+  "start_side": null,
+  "line": 97,
+  "original_line": 97,
+  "side": "RIGHT",
+  "originalPosition": 108,
+  "position": 108,
+  "subject_type": "line"
+}


### PR DESCRIPTION
## Summary
- add regex parser for diff hunk
- show 5 lines of context around comments with line numbers
- include behavioural test using sample data from leynos/bournemouth#17

## Testing
- `cargo clippy -- -D warnings`
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_6845660a2e888322a1e4b34a2e9b16b7

## Summary by Sourcery

Improve diff hunk display for review comments by parsing unified diff headers, extracting line numbers, and printing a custom context-aware output.

New Features:
- Add HUNK_RE regex to parse unified diff hunk headers and extract old/new line positions
- Replace diffy-based patch rendering with a custom formatter that shows five lines of context with line numbers

Enhancements:
- Include `originalPosition` and `position` fields in GraphQL queries and ReviewComment struct
- Cap formatted context to 20 lines when header parsing fails

Tests:
- Add behavioural tests for hunk regex variants, invalid headers, context capping, and sample fixture formatting

Chores:
- Add JSON fixture for review_comment tests