### PR TITLE
Configure clippy pedantic warnings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1739,7 +1739,6 @@ dependencies = [
  "anyhow",
  "clap",
  "diffy",
- "once_cell",
  "regex",
  "reqwest",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,10 +14,13 @@ termimad = "0.33.0"
 thiserror = "1.0.57"
 url = "2.5.0"
 regex = "1.10.3"
-once_cell = "1.19.0"
 diffy = "0.4.2"
 anyhow = "1.0"
 
 [dev-dependencies]
 tempfile = "3.20.0"
 serial_test = "3.2.0"
+
+[lints.clippy]
+# make every pedantic lint emit a warning
+pedantic = "warn"


### PR DESCRIPTION
## Summary
- enable clippy pedantic lints as warnings
- use `LazyLock` from std instead of once_cell
- refine `format_comment_diff` logic and output
- improve formatting in `print_comment`
- clean up unused dependency

## Testing
- `cargo clippy -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68475332830c832283a1ce21aca8e754

## Summary by Sourcery

Configure Clippy pedantic lints as warnings, migrate regex statics to std::sync::LazyLock, refine diff formatting and comment printing, and remove unused dependency

Enhancements:
- Replace once_cell::Lazy with std::sync::LazyLock for regex initialization
- Refine format_comment_diff to use let-else, string interpolation, error propagation, and improved writeln output
- Improve print_comment formatting to use inline interpolation and propagate errors

Build:
- Enable all Clippy pedantic lints as warnings in Cargo.toml

Chores:
- Remove unused once_cell dependency