### PR TITLE
Add coverage workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,33 @@
+name: Coverage
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+    env:
+      CARGO_TERM_COLOR: always
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
+
+      - uses: taiki-e/install-action@cargo-llvm-cov@v2
+
+      - name: Generate coverage
+        run: |
+          cargo llvm-cov --workspace --all-features \
+                         --lcov --output-path lcov.info \
+                         --codecov --output-path codecov.json
+
+      - uses: codecov/codecov-action@v4
+        with:
+          files: lcov.info,codecov.json
+          fail_ci_if_error: true
+          flags: unittests
+          verbose: true

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,8 @@
+coverage:
+  status:
+    patch:
+      target: 80%
+    project:
+      threshold: 0.5%
+comment:
+  layout: "condensed_header, condensed_files, condensed_footer"

--- a/src/main.rs
+++ b/src/main.rs
@@ -520,6 +520,7 @@ fn locale_is_utf8() -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::fmt::Write;
     use std::fs;
     use tempfile::tempdir;
 
@@ -677,7 +678,7 @@ mod tests {
     fn format_comment_diff_caps_output() {
         let mut diff = String::from("@@ -1,30 +1,30 @@\n");
         for i in 0..30 {
-            diff.push_str(&format!(" line{}\n", i));
+            writeln!(&mut diff, " line{i}").unwrap();
         }
         let comment = ReviewComment {
             body: String::new(),


### PR DESCRIPTION
## Summary
- add coverage job to CI using cargo-llvm-cov and Codecov
- enforce coverage thresholds with codecov.yml
- fix clippy warnings in test module

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_6848ae1b0000832297338218057f0e05