### PR TITLE
Refactor issue parsing and add GraphQL helper

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -178,11 +178,10 @@ impl GraphQLClient {
         V: serde::Serialize,
         for<'de> T: serde::Deserialize<'de>,
     {
-        let mut req = self.client.post(&self.endpoint);
-        for (k, v) in &self.headers {
-            req = req.header(k, v);
-        }
-        let resp: GraphQlResponse<T> = req
+        let resp: GraphQlResponse<T> = self
+            .client
+            .post(&self.endpoint)
+            .headers(self.headers.clone())
             .json(&json!({ "query": query, "variables": variables }))
             .send()
             .await?
@@ -389,7 +388,11 @@ async fn fetch_issue(
     let data: IssueData = client
         .run_query(
             ISSUE_QUERY,
-            json!({ "owner": repo.owner, "name": repo.name, "number": number }),
+            json!({
+                "owner": repo.owner.as_str(),
+                "name": repo.name.as_str(),
+                "number": number
+            }),
         )
         .await?;
     Ok(data.repository.issue)
@@ -405,8 +408,8 @@ async fn fetch_thread_page(
         .run_query(
             THREADS_QUERY,
             json!({
-                "owner": repo.owner,
-                "name": repo.name,
+                "owner": repo.owner.as_str(),
+                "name": repo.name.as_str(),
                 "number": number,
                 "cursor": cursor,
             }),


### PR DESCRIPTION
## Summary
- unify parsing logic for PRs and issues
- add `run_query` helper for GraphQL requests
- render issues with `termimad`
- update tests and formatting

## Testing
- `cargo clippy -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_684e2310e92483228e02d368d449cda9

## Summary by Sourcery

Introduce a reusable GraphQL client, unify issue/PR parsing, and enhance output formatting

New Features:
- Add GraphQLClient.run_query helper for executing typed GraphQL requests
- Render issue titles and bodies using termimad for styled terminal output

Enhancements:
- Consolidate PR and issue reference parsing into a single parse_reference function with a ResourceType enum
- Refactor fetch_* functions to use GraphQLClient instead of manual reqwest calls and headers
- Simplify parse_pr_reference and parse_issue_reference by delegating to the unified parser
- Add GITHUB_GRAPHQL_URL constant and ResourceType enum to streamline API interactions

Tests:
- Add tests for parse_pr_reference and parse_issue_reference covering both URL and numeric reference cases

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Streamlined GraphQL request handling for improved reliability and consistency.
	- Unified parsing logic for pull request and issue references, reducing duplication.
- **New Features**
	- Enhanced issue display with improved markdown styling for better readability.
- **Tests**
	- Added unit tests for pull request and issue number parsing with default repository support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->