### PR TITLE
Add summary to vk pr output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -590,6 +590,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -602,6 +613,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
 
 [[package]]
+name = "futures-timer"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+
+[[package]]
 name = "futures-util"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -610,6 +627,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-io",
+ "futures-macro",
  "futures-sink",
  "futures-task",
  "memchr",
@@ -656,6 +674,12 @@ name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+
+[[package]]
+name = "glob"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "h2"
@@ -1284,6 +1308,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-crate"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35"
+dependencies = [
+ "toml_edit",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1359,6 +1392,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
+name = "relative-path"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
+
+[[package]]
 name = "reqwest"
 version = "0.11.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1417,10 +1456,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "rstest"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fc39292f8613e913f7df8fa892b8944ceb47c247b78e1b1ae2f09e019be789d"
+dependencies = [
+ "futures-timer",
+ "futures-util",
+ "rstest_macros",
+ "rustc_version",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f168d99749d307be9de54d23fd226628d99768225ef08f6ffb52e0182a27746"
+dependencies = [
+ "cfg-if",
+ "glob",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "relative-path",
+ "rustc_version",
+ "syn",
+ "unicode-ident",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
 
 [[package]]
 name = "rustix"
@@ -1540,6 +1618,12 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 
 [[package]]
 name = "serde"
@@ -2079,6 +2163,7 @@ dependencies = [
  "ortho_config",
  "regex",
  "reqwest",
+ "rstest",
  "serde",
  "serde_json",
  "serial_test",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ yaml = ["toml", "ortho_config/yaml"]
 [dev-dependencies]
 tempfile = "3.20.0"
 serial_test = "3.2.0"
+rstest = "0.25.0"
 
 [lints.clippy]
 # make every pedantic lint emit a warning

--- a/README.md
+++ b/README.md
@@ -1,8 +1,13 @@
 # View Komments (vk)
 
-`vk` stands for **View Komments** because `vc` was already taken back in the 1970s and no one argues with a greybeard. This command line tool fetches unresolved GitHub code review comments for a pull request and displays them with colourful terminal markdown using [Termimad](https://crates.io/crates/termimad).
+`vk` stands for **View Komments** because `vc` was already taken back in the
+1970s and no one argues with a greybeard. This command line tool fetches
+unresolved GitHub code review comments for a pull request and displays them with
+colourful terminal markdown using
+[Termimad](https://crates.io/crates/termimad).
 
-This tool is intended for use by AI coding agents such as Aider, OpenAI Codex or Claude Code (without implying association with any of these companies).
+This tool is intended for use by AI coding agents such as Aider, OpenAI Codex or
+Claude Code (without implying association with any of these companies).
 
 ## Usage
 
@@ -16,19 +21,20 @@ sets the default repository when passing only a pull request number.
 
 The CLI provides two subcommands:
 
-* `pr` - show unresolved pull request comments (existing behaviour)
+* `pr` - show unresolved pull request comments. A summary of files and comment
+  counts is printed first.
 * `issue` - read a GitHub issue (**to do**)
 
-If you pass just a pull request number, `vk` tries to work out which
-repository you meant. It first examines `.git/FETCH_HEAD` for a GitHub remote
-URL and, if found, extracts the `owner/repo` from it. As the Codex agent does not put the
+If you pass just a pull request number, `vk` tries to work out which repository
+you meant. It first examines `.git/FETCH_HEAD` for a GitHub remote URL and, if
+found, extracts the `owner/repo` from it. As the Codex agent does not put the
 upstream URL in `.git/config`, we must obtain this from `FETCH_HEAD` for now.
 Failing that, it falls back to the configured repository (`--repo` or
 `VK_REPO`). Set this value to `owner/repo` with or without a `.git` suffix. If
 neither source is available, `vk` will refuse to run with only a number.
 
-`vk` uses the GitHub GraphQL API. Set `GITHUB_TOKEN` to authenticate. If it's not
-set you'll get a warning and anonymous requests may be rate limited.
+`vk` uses the GitHub GraphQL API. Set `GITHUB_TOKEN` to authenticate. If it's
+not set you'll get a warning and anonymous requests may be rate limited.
 
 The token only needs read access. Select the `public_repo` scope (or `repo` for
 private repositories). See [docs/GITHUB_TOKEN.md](docs/GITHUB_TOKEN.md) for a
@@ -36,8 +42,8 @@ detailed guide to creating one.
 
 ## Example
 
-```
-$ vk pr https://github.com/leynos/mxd/pull/31
+```bash
+vk pr https://github.com/leynos/mxd/pull/31
 ```
 
 ## Troubleshooting
@@ -56,4 +62,5 @@ cargo install --path .
 
 ## License
 
-This project is licensed under the ISC License. See [LICENSE](LICENSE) for details.
+This project is licensed under the ISC License. See
+[LICENSE](LICENSE) for details.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # View Komments (vk)
 
 `vk` stands for **View Komments** because `vc` was already taken back in the
-1970s and no one argues with a greybeard. This command line tool fetches
+1970s, and no one argues with a greybeard. This command line tool fetches
 unresolved GitHub code review comments for a pull request and displays them with
 colourful terminal markdown using
 [Termimad](https://crates.io/crates/termimad).
@@ -21,9 +21,9 @@ sets the default repository when passing only a pull request number.
 
 The CLI provides two subcommands:
 
-* `pr` - show unresolved pull request comments. A summary of files and comment
+* `pr` — show unresolved pull request comments. A summary of files and comment
   counts is printed first.
-* `issue` - read a GitHub issue (**to do**)
+* `issue` — read a GitHub issue (**to do**)
 
 If you pass just a pull request number, `vk` tries to work out which repository
 you meant. It first examines `.git/FETCH_HEAD` for a GitHub remote URL and, if
@@ -34,7 +34,7 @@ Failing that, it falls back to the configured repository (`--repo` or
 neither source is available, `vk` will refuse to run with only a number.
 
 `vk` uses the GitHub GraphQL API. Set `GITHUB_TOKEN` to authenticate. If it's
-not set you'll get a warning and anonymous requests may be rate limited.
+not set, you'll get a warning and anonymous requests may be rate limited.
 
 The token only needs read access. Select the `public_repo` scope (or `repo` for
 private repositories). See [docs/GITHUB_TOKEN.md](docs/GITHUB_TOKEN.md) for a
@@ -62,5 +62,5 @@ cargo install --path .
 
 ## License
 
-This project is licensed under the ISC License. See
+This project is licensed under the ISC Licence. See
 [LICENSE](LICENSE) for details.


### PR DESCRIPTION
## Summary
- print a summary of commented files before listing comments
- update README to mention the summary and fix markdown lint issues
- test the new summary helper

## Testing
- `cargo fmt --all`
- `cargo clippy -- -D warnings`
- `RUSTFLAGS="-D warnings" cargo test`
- `markdownlint README.md docs/GITHUB_TOKEN.md`
- `nixie README.md docs/GITHUB_TOKEN.md`

------
https://chatgpt.com/codex/tasks/task_e_687cbce2aff88322aad72786f7eb1047

## Summary by Sourcery

Add file comment summary to the `vk pr` output, update documentation to reflect this addition, and include tests for the summary helper.

New Features:
- Print a summary of commented files with counts before listing comments in `vk pr`

Enhancements:
- Update README to mention the new summary feature and fix markdown lint issues

Tests:
- Add unit test for the summary_files helper function