### PR TITLE
Handle missing subcommand references

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -56,6 +56,8 @@ impl GlobalArgs {
 struct PrArgs {
     /// Pull request URL or number
     #[arg(required = true)]
+    // Clap marks the argument as required so parsing yields `Some(value)`. The
+    // `Option` allows `PrArgs::default()` and config merging to leave it unset.
     reference: Option<String>,
 }
 
@@ -72,6 +74,8 @@ impl Default for PrArgs {
 struct IssueArgs {
     /// Issue URL or number
     #[arg(required = true)]
+    // The argument is required and will parse to `Some`, but `Option` permits
+    // defaults or config merging to leave it unset.
     reference: Option<String>,
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,11 +59,13 @@ struct PrArgs {
     reference: String,
 }
 
+const UNSET_REF: &str = "<unset>";
+
 impl Default for PrArgs {
     #[allow(clippy::derivable_impls)]
     fn default() -> Self {
         Self {
-            reference: String::new(),
+            reference: UNSET_REF.to_string(),
         }
     }
 }
@@ -81,7 +83,7 @@ impl Default for IssueArgs {
     #[allow(clippy::derivable_impls)]
     fn default() -> Self {
         Self {
-            reference: String::new(),
+            reference: UNSET_REF.to_string(),
         }
     }
 }


### PR DESCRIPTION
## Summary
- avoid invalid state when `PrArgs::default()` or `IssueArgs::default()` is used

## Testing
- `cargo fmt --all`
- `cargo clippy -- -D warnings`
- `RUSTFLAGS="-D warnings" cargo test`

------
https://chatgpt.com/codex/tasks/task_e_687d037e105083229dbb84242fe453aa

## Summary by Sourcery

Enhancements:
- Introduce UNSET_REF constant and apply it as the default reference for PrArgs and IssueArgs instead of an empty string