### PR TITLE
Fix global config initialization

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -670,7 +670,7 @@ async fn run_issue(args: IssueArgs, repo: Option<&str>) -> Result<(), VkError> {
 #[allow(clippy::result_large_err)]
 async fn main() -> Result<(), VkError> {
     let cli = Cli::parse();
-    let mut global = GlobalArgs::load()?;
+    let mut global = GlobalArgs::load_from_iter(std::env::args_os().take(1))?;
     global.merge(cli.global);
     match cli.command {
         Commands::Pr(pr_cli) => {


### PR DESCRIPTION
## Summary
- load global config using `load_from_iter` with only the program name

## Testing
- `cargo fmt -- --check`
- `cargo clippy -- -D warnings`
- `RUSTFLAGS='-D warnings' cargo test`

------
https://chatgpt.com/codex/tasks/task_e_687d1796020c832298e5f89a5af62740

## Summary by Sourcery

Bug Fixes:
- Use load_from_iter with only the program name to initialize global configuration instead of load()