### PR TITLE
Handle missing reference defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,11 @@ The CLI provides two subcommands:
   counts is printed first.
 * `issue` — read a GitHub issue (**to do**)
 
+`vk` loads default values for subcommands from configuration files and
+environment variables. When these defaults omit the required `reference`
+field, the tool continues with the value provided on the CLI instead of
+exiting with an error.
+
 If you pass just a pull request number, `vk` tries to work out which repository
 you meant. It first examines `.git/FETCH_HEAD` for a GitHub remote URL and, if
 found, extracts the `owner/repo` from it. As the Codex agent does not put the


### PR DESCRIPTION
## Summary
- use match to handle configuration errors when merging subcommands
- fall back to CLI args when defaults omit `reference`
- document the behaviour in the usage section

## Testing
- `cargo clippy -- -D warnings`
- `RUSTFLAGS="-D warnings" cargo test`
- `markdownlint README.md docs/GITHUB_TOKEN.md`
- `nixie README.md docs/GITHUB_TOKEN.md`


------
https://chatgpt.com/codex/tasks/task_e_687d264352ac832294130c99d1b5acff

## Summary by Sourcery

Use match to catch missing reference defaults during subcommand configuration merging and fall back to CLI-provided values instead of erroring out, and document this behavior in the README.

Enhancements:
- Catch OrthoError::Gathering errors with MissingField("reference") when merging subcommand defaults and use the original CLI args as fallback
- Update README to explain that missing 'reference' in defaults is handled by falling back to CLI input