### PR TITLE
Improve diff formatting

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -513,6 +513,15 @@ fn format_comment_diff(comment: &ReviewComment) -> Result<String, std::fmt::Erro
         parsed
     }
 
+    fn num_disp(num: i32) -> String {
+        let mut s = num.to_string();
+        if s.len() > 4 {
+            let len = s.len();
+            s = s[len - 4..].to_string();
+        }
+        format!("{s:>4}")
+    }
+
     let mut lines_iter = comment.diff_hunk.lines();
     let Some(header) = lines_iter.next() else {
         return Ok(String::new());
@@ -552,9 +561,19 @@ fn format_comment_diff(comment: &ReviewComment) -> Result<String, std::fmt::Erro
 
     let mut out = String::new();
     for (o, n, text) in &lines[start..end] {
-        let old_disp = o.map_or(String::from("    "), |n| format!("{n:>4}"));
-        let new_disp = n.map_or(String::from("    "), |n| format!("{n:>4}"));
-        writeln!(&mut out, "{old_disp} {new_disp} {text}")?;
+        let num = if let Some(num) = n {
+            *num
+        } else if let Some(num) = o {
+            *num
+        } else {
+            0
+        };
+        let disp = if n.is_none() && o.is_none() {
+            "    ".to_string()
+        } else {
+            num_disp(num)
+        };
+        writeln!(&mut out, "{disp}|{text}")?;
     }
     Ok(out)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -561,18 +561,12 @@ fn format_comment_diff(comment: &ReviewComment) -> Result<String, std::fmt::Erro
 
     let mut out = String::new();
     for (o, n, text) in &lines[start..end] {
-        let num = if let Some(num) = n {
-            *num
-        } else if let Some(num) = o {
-            *num
-        } else {
-            0
-        };
-        let disp = if n.is_none() && o.is_none() {
-            "    ".to_string()
-        } else {
-            num_disp(num)
-        };
+        // Prefer the new line number, fall back to old, or blanks if neither
+        let disp = n
+            .or(*o)
+            .map(num_disp)
+            .unwrap_or_else(|| "    ".to_string());
+
         writeln!(&mut out, "{disp}|{text}")?;
     }
     Ok(out)

--- a/src/main.rs
+++ b/src/main.rs
@@ -312,6 +312,9 @@ struct CommentNode {
 
 const GITHUB_GRAPHQL_URL: &str = "https://api.github.com/graphql";
 
+/// Width of the line number gutter in diff output
+const GUTTER_WIDTH: usize = 5;
+
 const THREADS_QUERY: &str = r"
     query($owner: String!, $name: String!, $number: Int!, $cursor: String) {
       repository(owner: $owner, name: $name) {
@@ -515,11 +518,11 @@ fn format_comment_diff(comment: &ReviewComment) -> Result<String, std::fmt::Erro
 
     fn num_disp(num: i32) -> String {
         let mut s = num.to_string();
-        if s.len() > 4 {
+        if s.len() > GUTTER_WIDTH {
             let len = s.len();
-            s = s[len - 4..].to_string();
+            s = s[len - GUTTER_WIDTH..].to_string();
         }
-        format!("{s:>4}")
+        format!("{s:>GUTTER_WIDTH$}")
     }
 
     let mut lines_iter = comment.diff_hunk.lines();
@@ -562,10 +565,7 @@ fn format_comment_diff(comment: &ReviewComment) -> Result<String, std::fmt::Erro
     let mut out = String::new();
     for (o, n, text) in &lines[start..end] {
         // Prefer the new line number, fall back to old, or blanks if neither
-        let disp = n
-            .or(*o)
-            .map(num_disp)
-            .unwrap_or_else(|| "    ".to_string());
+        let disp = n.or(*o).map_or_else(|| " ".repeat(GUTTER_WIDTH), num_disp);
 
         writeln!(&mut out, "{disp}|{text}")?;
     }


### PR DESCRIPTION
## Summary
- adjust comment diff lines to show a single line number
- crop line numbers at four digits and add a `|` separator

## Testing
- `cargo clippy -- -D warnings`
- `RUSTFLAGS="-D warnings" cargo test`
- `markdownlint README.md docs/GITHUB_TOKEN.md`
- `nixie README.md docs/GITHUB_TOKEN.md`


------
https://chatgpt.com/codex/tasks/task_e_687d675f5e788322821797f295f90031

## Summary by Sourcery

Enhancements:
- Simplify comment diff output to display a single right-aligned line number (truncated to last four digits) followed by '|' and the line content