### PR TITLE
Show comment label in summary

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -606,7 +606,7 @@ fn write_summary<W: std::io::Write>(
     }
     writeln!(out, "Summary:")?;
     for (path, count) in summary {
-        writeln!(out, "{path}: {count}")?;
+        writeln!(out, "{path}: {count} comments")?;
     }
     writeln!(out)?;
     Ok(())
@@ -1108,8 +1108,8 @@ mod tests {
         write_summary(&mut buf, &summary).unwrap();
         let out = String::from_utf8(buf).unwrap();
         assert!(out.contains("Summary:"));
-        assert!(out.contains("a.rs: 2"));
-        assert!(out.contains("b.rs: 1"));
+        assert!(out.contains("a.rs: 2 comments"));
+        assert!(out.contains("b.rs: 1 comments"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add the word `comments` when printing the summary
- update tests for the new text

## Testing
- `cargo clippy -- -D warnings`
- `RUSTFLAGS="-D warnings" cargo test`
- `markdownlint README.md docs/GITHUB_TOKEN.md`
- `nixie README.md docs/GITHUB_TOKEN.md`

------
https://chatgpt.com/codex/tasks/task_e_687d8395805c8322a47801fb47370add