### PR TITLE
Add review banner output for pr command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -171,6 +186,21 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chrono"
+version = "0.4.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "serde",
+ "wasm-bindgen",
+ "windows-link",
+]
 
 [[package]]
 name = "clap"
@@ -798,6 +828,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.63"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c919e5debc312ad217002b8048a17b7d83f80703865bbfcfebb0458b0b27d8"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "icu_collections"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1088,6 +1142,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4a28e057d01f97e61255210fcff094d74ed0466038633e95017f5beb68e4399"
 dependencies = [
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -2157,6 +2220,7 @@ name = "vk"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "chrono",
  "clap",
  "diffy",
  "figment",
@@ -2309,6 +2373,65 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-core"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
+name = "windows-result"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ thiserror = "1.0.57"
 url = "2.5.0"
 regex = "1.10.3"
 diffy = "0.4.2"
+chrono = { version = "0.4", features = ["serde", "clock"] }
 anyhow = "1.0"
 ortho_config = { git = "https://github.com/leynos/ortho-config", tag = "v0.2.0", default-features = false }
 figment = { version = "0.10", default-features = false, features = ["env", "toml"], optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ thiserror = "1.0.57"
 url = "2.5.0"
 regex = "1.10.3"
 diffy = "0.4.2"
-chrono = { version = ">=0.4, <0.5", features = ["serde", "clock"] }
+chrono = { version = ">=0.4.20, <0.5", features = ["serde", "clock"] }
 anyhow = "1.0"
 ortho_config = { git = "https://github.com/leynos/ortho-config", tag = "v0.2.0", default-features = false }
 figment = { version = "0.10", default-features = false, features = ["env", "toml"], optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ thiserror = "1.0.57"
 url = "2.5.0"
 regex = "1.10.3"
 diffy = "0.4.2"
-chrono = { version = "0.4", features = ["serde", "clock"] }
+chrono = { version = ">=0.4, <0.5", features = ["serde", "clock"] }
 anyhow = "1.0"
 ortho_config = { git = "https://github.com/leynos/ortho-config", tag = "v0.2.0", default-features = false }
 figment = { version = "0.10", default-features = false, features = ["env", "toml"], optional = true }

--- a/docs/vk-design.md
+++ b/docs/vk-design.md
@@ -28,8 +28,9 @@ The code centres on three printing helpers:
 2. `write_comment` includes the diff for the first comment in a thread.
 3. `write_thread` iterates over a thread and prints each comment body in turn.
 
-`run_pr` fetches all unresolved threads and calls `print_thread`. Errors from
-`print_thread` are surfaced via logging.
+`run_pr` fetches the latest review banner from each reviewer and all unresolved
+threads. The reviews are printed after the summary and before individual
+threads. Errors from `print_thread` are surfaced via logging.
 
 ### CLI arguments
 

--- a/src/reviews.rs
+++ b/src/reviews.rs
@@ -1,0 +1,132 @@
+//! Helpers for fetching and displaying pull request reviews.
+
+use chrono::{DateTime, Utc};
+use serde::Deserialize;
+use serde_json::json;
+use termimad::MadSkin;
+
+use crate::{GraphQLClient, PageInfo, RepoInfo, User, VkError};
+use std::collections::HashMap;
+
+#[derive(Debug, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct PullRequestReview {
+    pub body: String,
+    pub submitted_at: DateTime<Utc>,
+    pub state: String,
+    pub author: Option<User>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ReviewData {
+    repository: RepositoryReviews,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct RepositoryReviews {
+    #[serde(rename = "pullRequest")]
+    pull_request: ReviewConnection,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ReviewConnection {
+    nodes: Vec<PullRequestReview>,
+    page_info: PageInfo,
+}
+
+const REVIEWS_QUERY: &str = r"
+    query($owner: String!, $name: String!, $number: Int!, $cursor: String) {
+      repository(owner: $owner, name: $name) {
+        pullRequest(number: $number) {
+          reviews(first: 100, after: $cursor) {
+            nodes {
+              body
+              state
+              submittedAt
+              author { login }
+            }
+            pageInfo { hasNextPage endCursor }
+          }
+        }
+      }
+    }
+";
+
+pub async fn fetch_review_page(
+    client: &GraphQLClient,
+    repo: &RepoInfo,
+    number: u64,
+    cursor: Option<String>,
+) -> Result<(Vec<PullRequestReview>, PageInfo), VkError> {
+    let data: ReviewData = client
+        .run_query(
+            REVIEWS_QUERY,
+            json!({
+                "owner": repo.owner.as_str(),
+                "name": repo.name.as_str(),
+                "number": number,
+                "cursor": cursor,
+            }),
+        )
+        .await?;
+    let conn = data.repository.pull_request;
+    Ok((conn.nodes, conn.page_info))
+}
+
+pub async fn fetch_reviews(
+    client: &GraphQLClient,
+    repo: &RepoInfo,
+    number: u64,
+) -> Result<Vec<PullRequestReview>, VkError> {
+    crate::paginate(|c| fetch_review_page(client, repo, number, c)).await
+}
+
+pub fn latest_reviews(reviews: Vec<PullRequestReview>) -> Vec<PullRequestReview> {
+    let mut latest: HashMap<String, PullRequestReview> = HashMap::new();
+    for r in reviews {
+        let key = r
+            .author
+            .as_ref()
+            .map(|u| u.login.clone())
+            .unwrap_or_default();
+        match latest.entry(key) {
+            std::collections::hash_map::Entry::Vacant(e) => {
+                e.insert(r);
+            }
+            std::collections::hash_map::Entry::Occupied(mut e) => {
+                if r.submitted_at > e.get().submitted_at {
+                    e.insert(r);
+                }
+            }
+        }
+    }
+    latest.into_values().collect()
+}
+
+pub fn write_review<W: std::io::Write>(
+    mut out: W,
+    skin: &MadSkin,
+    review: &PullRequestReview,
+) -> anyhow::Result<()> {
+    let author = review
+        .author
+        .as_ref()
+        .map_or("(unknown)", |u| u.login.as_str());
+    writeln!(out, "\u{1f4dd}  \x1b[1m{author}\x1b[0m {}:", review.state)?;
+    if let Err(e) = skin.write_text_on(&mut out, &review.body) {
+        eprintln!("error writing review body: {e}");
+    }
+    writeln!(out)?;
+    Ok(())
+}
+
+pub fn print_reviews(skin: &MadSkin, reviews: &[PullRequestReview]) {
+    for r in reviews {
+        if let Err(e) = write_review(std::io::stdout().lock(), skin, r) {
+            eprintln!("error printing review: {e}");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- fetch pull request reviews via GraphQL
- print the most recent review banner from each reviewer
- document new behaviour in `vk-design.md`

## Testing
- `cargo clippy -- -D warnings`
- `RUSTFLAGS="-D warnings" cargo test`
- `markdownlint docs/vk-design.md`
- `nixie docs/vk-design.md` *(fails: too many arguments)*

------
https://chatgpt.com/codex/tasks/task_e_688291e48c9c8322ba9c5d6466702bee

## Summary by Sourcery

Add support for fetching pull request reviews and printing each reviewer’s latest review banner in the pr command

New Features:
- Fetch pull request reviews via GraphQL with pagination
- Compute and display the latest review banner from each reviewer in the pr command output

Documentation:
- Document the new review banner output behavior in vk-design.md