### PR TITLE
Add end-of-review banner

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,8 +9,8 @@
 - **Clarity over cleverness.** Be concise, but favour explicit over terse or
   obscure idioms. Prefer code that's easy to follow.
 - **Use functions and composition.** Avoid repetition by extracting reusable
-  logic. Prefer generators or comprehensions, and declarative code to imperative
-  repetition when readable.
+  logic. Prefer generators or comprehensions, and declarative code to
+  imperative repetition when readable.
 - **Small, meaningful functions.** Functions must be small, clear in purpose,
   single responsibility, and obey command/query segregation.
 - **Clear commit messages.** Commit messages should be descriptive, explaining
@@ -25,12 +25,14 @@
   ("-ize" / "-yse" / "-our") spelling and grammar, with the exception of
   references to external APIs.
 - **Illustrate with clear examples.** Function documentation must include clear
-  examples demonstrating the usage and outcome of the function. Test documentation
-  should omit examples where the example serves only to reiterate the test logic.
-- **Keep file size managable.** No single code file may be longer than 400 lines.
+  examples demonstrating the usage and outcome of the function. Test
+  documentation should omit examples where the example serves only to reiterate
+  the test logic.
+- **Keep file size managable.** No single code file may be longer than 400
+  lines.
   Long switch statements or dispatch tables should be broken up by feature and
-  constituents colocated with targets. Large blocks of test data should be moved
-  to external data files.
+  constituents colocated with targets. Large blocks of test data should be
+  moved to external data files.
 
 ## Documentation Maintenance
 
@@ -42,8 +44,8 @@
   relevant file(s) in the `docs/` directory to reflect the latest state.
   **Ensure the documentation remains accurate and current.**
 - Documentation must use en-GB-oxendict ("-ize" / "-yse" / "-our") spelling
-  and grammar. (EXCEPTION: the naming of the "LICENSE" file, which
-  is to be left unchanged for community consistency.)
+  and grammar. (EXCEPTION: the naming of the "LICENSE" file, which is to be
+  left unchanged for community consistency.)
 
 ## Change Quality & Committing
 
@@ -153,19 +155,19 @@ project:
   specified in `Cargo.toml` must use SemVer-compatible caret requirements
   (e.g., `some-crate = "1.2.3"`). This is Cargo's default and allows for safe,
   non-breaking updates to minor and patch versions while preventing breaking
-  changes from new major versions. This approach is critical for ensuring
-  build stability and reproducibility.
+  changes from new major versions. This approach is critical for ensuring build
+  stability and reproducibility.
 - **Prohibit unstable version specifiers.** The use of wildcard (`*`) or
-  open-ended inequality (`>=`) version requirements is strictly forbidden
-  as they introduce unacceptable risk and unpredictability. Tilde requirements
+  open-ended inequality (`>=`) version requirements is strictly forbidden as
+  they introduce unacceptable risk and unpredictability. Tilde requirements
   (`~`) should only be used where a dependency must be locked to patch-level
   updates for a specific, documented reason.
 
 ### Error Handling
 
 - **Prefer semantic error enums**. Derive `std::error::Error` (via the
-  `thiserror` crate) for any condition the caller might inspect, retry, or
-  map to an HTTP status.
+  `thiserror` crate) for any condition the caller might inspect, retry, or map
+  to an HTTP status.
 - **Use an *opaque* error only at the app boundary**. Use `eyre::Report` for
   human-readable logs; these should not be exposed in public APIs.
 - **Never export the opaque type from a library**. Convert to domain enums at

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,10 +29,9 @@
   documentation should omit examples where the example serves only to reiterate
   the test logic.
 - **Keep file size managable.** No single code file may be longer than 400
-  lines.
-  Long switch statements or dispatch tables should be broken up by feature and
-  constituents colocated with targets. Large blocks of test data should be
-  moved to external data files.
+  lines. Long switch statements or dispatch tables should be broken up by
+  feature and constituents colocated with targets. Large blocks of test data
+  should be moved to external data files.
 
 ## Documentation Maintenance
 
@@ -157,7 +156,7 @@ project:
   non-breaking updates to minor and patch versions while preventing breaking
   changes from new major versions. This approach is critical for ensuring build
   stability and reproducibility.
-- **Prohibit unstable version specifiers.** The use of wildcard (`*`) or
+- **Prohibit unstable version specifiers.** The use of wildcard (`*`), or
   open-ended inequality (`>=`) version requirements is strictly forbidden as
   they introduce unacceptable risk and unpredictability. Tilde requirements
   (`~`) should only be used where a dependency must be locked to patch-level

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -157,7 +157,7 @@ project:
   changes from new major versions. This approach is critical for ensuring build
   stability and reproducibility.
 - **Prohibit unstable version specifiers.** The use of wildcard (`*`), or
-  open-ended inequality (`>=`) version requirements are strictly forbidden as
+  open-ended inequality (`>=`) version requirements are strictly forbidden, as
   they introduce unacceptable risk and unpredictability. Tilde requirements
   (`~`) should only be used where a dependency must be locked to patch-level
   updates for a specific, documented reason.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,7 @@
   examples demonstrating the usage and outcome of the function. Test
   documentation should omit examples where the example serves only to reiterate
   the test logic.
-- **Keep file size managable.** No single code file may be longer than 400
+- **Keep file size manageable.** No single code file may be longer than 400
   lines. Long switch statements or dispatch tables should be broken up by
   feature and constituents colocated with targets. Large blocks of test data
   should be moved to external data files.
@@ -157,7 +157,7 @@ project:
   changes from new major versions. This approach is critical for ensuring build
   stability and reproducibility.
 - **Prohibit unstable version specifiers.** The use of wildcard (`*`), or
-  open-ended inequality (`>=`) version requirements is strictly forbidden as
+  open-ended inequality (`>=`) version requirements are strictly forbidden as
   they introduce unacceptable risk and unpredictability. Tilde requirements
   (`~`) should only be used where a dependency must be locked to patch-level
   updates for a specific, documented reason.

--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
 
 `vk` stands for **View Komments** because `vc` was already taken back in the
 1970s, and no one argues with a greybeard. This command line tool fetches
-unresolved GitHub code review comments for a pull request and displays them with
-colourful terminal markdown using
+unresolved GitHub code review comments for a pull request and displays them
+with colourful terminal markdown using
 [Termimad](https://crates.io/crates/termimad).
 
-This tool is intended for use by AI coding agents such as Aider, OpenAI Codex or
-Claude Code (without implying association with any of these companies).
+This tool is intended for use by AI coding agents such as Aider, OpenAI Codex
+or Claude Code (without implying association with any of these companies).
 
 ## Usage
 
@@ -22,13 +22,14 @@ sets the default repository when passing only a pull request number.
 The CLI provides two subcommands:
 
 * `pr` — show unresolved pull request comments. A summary of files and comment
-  counts is printed first.
+  counts is printed first. When finished, `vk` prints an `end of code review`
+  banner.
 * `issue` — read a GitHub issue (**to do**)
 
 `vk` loads default values for subcommands from configuration files and
-environment variables. When these defaults omit the required `reference`
-field, the tool continues with the value provided on the CLI instead of
-exiting with an error.
+environment variables. When these defaults omit the required `reference` field,
+the tool continues with the value provided on the CLI instead of exiting with
+an error.
 
 If you pass just a pull request number, `vk` tries to work out which repository
 you meant. It first examines `.git/FETCH_HEAD` for a GitHub remote URL and, if
@@ -67,5 +68,5 @@ cargo install --path .
 
 ## License
 
-This project is licensed under the ISC Licence. See
-[LICENSE](LICENSE) for details.
+This project is licensed under the ISC Licence. See [LICENSE](LICENSE) for
+details.

--- a/docs/GITHUB_TOKEN.md
+++ b/docs/GITHUB_TOKEN.md
@@ -4,8 +4,7 @@ vk authenticates to the GitHub GraphQL API using a personal access token (PAT).
 Follow these steps to create one:
 
 1. Visit <https://github.com/settings/tokens> and choose **Generate new token**.
-   GitHub may prompt you to pick a classic or fine‑grained token – either
-   works.
+   GitHub may prompt you to pick a classic or fine‑grained token – either works.
 2. Give the token a note and set an expiration.
 3. Under **Select scopes**, enable `public_repo`. If you need to access private
    repositories, select the broader `repo` scope instead.

--- a/docs/vk-design.md
+++ b/docs/vk-design.md
@@ -19,6 +19,7 @@ even when multiple comments reference the same code.
   reducing clutter when multiple remarks target the same line.
 - **Error visibility**: Failures encountered while printing a thread are logged
   to stderr instead of being silently discarded.
+- **Completion notice**: A final banner marks the *end of code review*.
 
 ## Architecture
 
@@ -31,7 +32,9 @@ The code centres on three printing helpers:
 
 `run_pr` fetches the latest review banner from each reviewer and all unresolved
 threads. The reviews are printed after the summary and before individual
-threads. Errors from `print_thread` are surfaced via logging.
+threads. Errors from `print_thread` are surfaced via logging. Once all threads
+have been printed, a final banner reading `end of code review` confirms
+completion.
 
 ### CLI arguments
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -635,6 +635,11 @@ fn print_summary(summary: &[(String, usize)]) {
     let _ = write_summary(std::io::stdout().lock(), summary);
 }
 
+/// Print a closing banner once all review threads have been displayed.
+fn print_end_banner() {
+    println!("========== end of code review ==========");
+}
+
 fn build_headers(token: &str) -> HeaderMap {
     let mut headers = HeaderMap::new();
     headers.insert(USER_AGENT, "vk".parse().expect("static string"));
@@ -688,6 +693,7 @@ async fn run_pr(args: PrArgs, repo: Option<&str>) -> Result<(), VkError> {
             eprintln!("error printing thread: {e}");
         }
     }
+    print_end_banner();
     Ok(())
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,10 @@
-//! CLI tool for inspecting GitHub pull requests and issues.
+//! Entry point for the `vk` command line tool.
 //!
 //! `vk` fetches unresolved review comments from GitHub's GraphQL API,
-//! summarizes them by file, and prints each thread. When a thread has
-//! multiple comments on the same diff, the diff is displayed only once.
+//! summarizing them by file before printing each thread. When a thread has
+//! multiple comments on the same diff, the diff is shown only once.
+//! After all comments are printed, the tool displays an `end of code review`
+//! banner so calling processes know the output has finished.
 mod cli_args;
 mod reviews;
 use crate::cli_args::{GlobalArgs, IssueArgs, PrArgs};


### PR DESCRIPTION
## Summary
- display final banner after printing PR review threads
- document the new banner in vk-design
- mention banner in README usage section

## Testing
- `make lint`
- `make test`
- `make markdownlint`
- `make nixie` *(fails: too many arguments)*

------
https://chatgpt.com/codex/tasks/task_e_6884fbe49d848322ad47a6ca1d22b533

## Summary by Sourcery

Add a final completion banner to the CLI’s PR review output and update documentation to describe it

New Features:
- Print a closing banner ‘end of code review’ after displaying all PR review threads

Enhancements:
- Reflow README text for consistent line wrapping

Documentation:
- Document the end-of-review banner in vk-design and mention it in the README usage section