### PR TITLE
Fix GraphQL decode failure

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -153,7 +153,7 @@ impl GraphQLClient {
     {
         let payload = json!({ "query": query, "variables": &variables });
         let ctx = serde_json::to_string(&payload).unwrap_or_default();
-        let resp: GraphQlResponse<T> = self
+        let resp: GraphQlResponse<serde_json::Value> = self
             .client
             .post(&self.endpoint)
             .headers(self.headers.clone())
@@ -167,14 +167,16 @@ impl GraphQLClient {
             .json()
             .await
             .map_err(|e| VkError::RequestContext {
-                context: ctx,
+                context: ctx.clone(),
                 source: e,
             })?;
 
         if let Some(errs) = resp.errors {
             return Err(handle_graphql_errors(errs));
         }
-        resp.data.ok_or(VkError::BadResponse)
+
+        let value = resp.data.ok_or(VkError::BadResponse)?;
+        serde_json::from_value(value).map_err(|_| VkError::BadResponse)
     }
 }
 


### PR DESCRIPTION
## Summary
- handle errors from GitHub GraphQL API before attempting to decode

## Testing
- `make fmt`
- `make lint`
- `make test`
- `make markdownlint`
- `make nixie` *(fails: too many arguments)*

------
https://chatgpt.com/codex/tasks/task_e_688624cb2988832297046de8f7b8405e