### PR TITLE
Improve BadResponse error context

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -370,11 +370,17 @@ async fn fetch_comment_page(
     cursor: Option<String>,
 ) -> Result<(Vec<ReviewComment>, PageInfo), VkError> {
     let wrapper: CommentNodeWrapper = client
-        .run_query(COMMENT_QUERY, json!({ "id": id, "cursor": cursor }))
+        .run_query(COMMENT_QUERY, json!({ "id": id, "cursor": cursor.clone() }))
         .await?;
     let conn = wrapper
         .node
-        .ok_or_else(|| VkError::BadResponse("Missing comment node in response".into()))?
+        .ok_or_else(|| {
+            VkError::BadResponse(format!(
+                "Missing comment node in response (id: {}, cursor: {})",
+                id,
+                cursor.as_deref().unwrap_or("None")
+            ))
+        })?
         .comments;
     Ok((conn.nodes, conn.page_info))
 }


### PR DESCRIPTION
## Summary
- attach context string to `VkError::BadResponse`
- report missing GraphQL data or comment nodes
- derive `Debug` for `GraphQlResponse`

## Testing
- `cargo fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68862b79e02883228c52432e6dc03ecd

## Summary by Sourcery

Enhance BadResponse errors to include contextual debug information, improve reporting for missing GraphQL data and comment nodes, and derive Debug for GraphQlResponse

Enhancements:
- Convert VkError::BadResponse into a tuple variant carrying a context string
- Include detailed response debug output when data is missing in GraphQLClient
- Add specific error context for missing comment nodes in fetch_comment_page
- Derive Debug for GraphQlResponse to enable formatted response inspection