### PR TITLE
Extract client creation logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -568,6 +568,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_filter"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c863f0904021b108aa8b2f55046443e6b1ebde8fd4a15c399893aae4fa069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "jiff",
+ "log",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1125,6 +1148,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
+name = "jiff"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be1f93b8b1eb69c77f24bbb0afdf66f54b632ee39af40ca21c4365a1d7347e49"
+dependencies = [
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03343451ff899767262ec32146f6d559dd759fdadf42ff0e227c7c48f72594b4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1603,6 +1650,21 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "portable-atomic"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "potential_utf"
@@ -2705,9 +2767,11 @@ dependencies = [
  "chrono",
  "clap",
  "diffy",
+ "env_logger",
  "figment",
  "figment-json5",
  "html5ever",
+ "log",
  "markup5ever_rcdom",
  "ortho_config",
  "predicates",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,8 @@ serde_json = "1.0.113"
 tokio = { version = "1.36.0", features = ["rt-multi-thread", "macros"] }
 termimad = "0.33.0"
 thiserror = "1.0.57"
+log = "0.4"
+env_logger = "0.11"
 url = "2.5.0"
 regex = "1.10.3"
 diffy = "0.4.2"


### PR DESCRIPTION
## Summary
- factor out helper to build GraphQLClient with optional transcript
- reuse helper in `run_pr` and `run_issue`

## Testing
- `make fmt`
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6886aa696d388322b24bf19e5083ed58

## Summary by Sourcery

Extract GraphQLClient creation logic into a shared helper and update run_pr and run_issue to use it for streamlined client initialization with transcript fallback

Enhancements:
- Add create_client helper to centralize GraphQLClient instantiation with optional transcript and fallback on failure
- Refactor run_pr and run_issue to use create_client instead of duplicating client setup logic