### PR TITLE
Add overview of E2E tests

### DIFF
--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -1,3 +1,9 @@
+//! End-to-end tests validate the `vk` binary using its public interface.
+//! Each test spawns a [`third-wheel`](https://crates.io/crates/third-wheel)
+//! Man-in-the-Middle proxy that intercepts outbound GitHub requests. This
+//! proxy serves canned responses from `tests/fixtures` so the suite runs in a
+//! fully hermetic and deterministic manner.
+
 use assert_cmd::Command;
 use predicates::str::contains;
 use serde_json::Value;


### PR DESCRIPTION
## Summary
- document that `tests/e2e.rs` hosts end-to-end tests
- explain how the MITM proxy controls GitHub requests

## Testing
- `make fmt`
- `make markdownlint`


------
https://chatgpt.com/codex/tasks/task_e_6888f74b1c688322915cbd542d3534e2

## Summary by Sourcery

Document the structure and purpose of the end-to-end tests in tests/e2e.rs and explain how the MITM proxy intercepts GitHub requests

Documentation:
- Add overview of tests/e2e.rs file to describe end-to-end test flow
- Explain how the MITM proxy controls and mocks GitHub API requests

Tests:
- Enhance the E2E test file with descriptive comments