### PR TITLE
Fix PR reviews parsing

### DIFF
--- a/src/reviews.rs
+++ b/src/reviews.rs
@@ -28,7 +28,13 @@ struct ReviewData {
 #[serde(rename_all = "camelCase")]
 struct RepositoryReviews {
     #[serde(rename = "pullRequest")]
-    pull_request: ReviewConnection,
+    pull_request: PullRequestReviews,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct PullRequestReviews {
+    reviews: ReviewConnection,
 }
 
 #[derive(Debug, Deserialize)]
@@ -73,7 +79,7 @@ pub async fn fetch_review_page(
             }),
         )
         .await?;
-    let conn = data.repository.pull_request;
+    let conn = data.repository.pull_request.reviews;
     Ok((conn.nodes, conn.page_info))
 }
 


### PR DESCRIPTION
## Summary
- handle `reviews` field returned by GitHub's API
- keep tests and formatting passing

## Testing
- `make fmt`
- `make lint`
- `make test`
- `make markdownlint`
- `make nixie` *(fails: FileNotFound: failed copying files from cache to destination for package @iconify/utils)*

------
https://chatgpt.com/codex/tasks/task_e_68896e37b4a88322b3ff90e8823ed86e

## Summary by Sourcery

Fix parsing of pull request reviews by accommodating GitHub API’s nested `reviews` field.

Bug Fixes:
- Introduce PullRequestReviews struct to wrap the nested `reviews` field in API responses
- Update RepositoryReviews and fetch_review_page to extract review connections from the nested structure