### PR TITLE
Replace coverage workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches: [main]
 
-env:
+variables:
   # This SHA pins shared composite actions to a specific commit for
   # reproducibility. Update it manually when bumping shared-actions to
   # guarantee consistent workflow behaviour.
@@ -19,12 +19,13 @@ jobs:
       CODESCENE_CLI_SHA256: ${{ vars.CODESCENE_CLI_SHA256 }}
     steps:
       - uses: actions/checkout@v4
-      - uses: leynos/shared-actions/.github/actions/setup-rust@${{ vars.SHARED_ACTIONS_SHA }}
+      - name: Setup Rust
+        uses: leynos/shared-actions/.github/actions/setup-rust@${{ vars.SHARED_ACTIONS_SHA }}
       - name: Format
         run: make check-fmt
       - name: Lint
         run: make lint
-      - id: generate-coverage
+      - name: Generate coverage
         uses: leynos/shared-actions/.github/actions/generate-coverage@${{ vars.SHARED_ACTIONS_SHA }}
         with:
           output-path: lcov.info

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -14,19 +14,19 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Setup Rust
-        uses: leynos/shared-actions/.github/actions/setup-rust@e48ed26d7f53f12f56eb7bcfdfdfe4d97065ea4c
+        uses: leynos/shared-actions/.github/actions/setup-rust@c6559452842af6a83b83429129dccaf910e34562
       - name: Format
         run: make check-fmt
       - name: Lint
         run: make lint
       - name: Generate coverage
-        uses: leynos/shared-actions/.github/actions/generate-coverage@e48ed26d7f53f12f56eb7bcfdfdfe4d97065ea4c
+        uses: leynos/shared-actions/.github/actions/generate-coverage@c6559452842af6a83b83429129dccaf910e34562
         with:
           output-path: lcov.info
           format: lcov
       - name: Upload coverage data to CodeScene
         if: ${{ env.CS_ACCESS_TOKEN != '' }}
-        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@e48ed26d7f53f12f56eb7bcfdfdfe4d97065ea4c
+        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@c6559452842af6a83b83429129dccaf910e34562
         with:
           format: lcov
           access-token: ${{ env.CS_ACCESS_TOKEN }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -4,12 +4,6 @@ on:
   pull_request:
     branches: [main]
 
-variables:
-  # This SHA pins shared composite actions to a specific commit for
-  # reproducibility. Update it manually when bumping shared-actions to
-  # guarantee consistent workflow behaviour.
-  SHARED_ACTIONS_SHA: e48ed26d7f53f12f56eb7bcfdfdfe4d97065ea4c
-
 jobs:
   build-test:
     runs-on: ubuntu-latest
@@ -20,19 +14,19 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Setup Rust
-        uses: leynos/shared-actions/.github/actions/setup-rust@${{ vars.SHARED_ACTIONS_SHA }}
+        uses: leynos/shared-actions/.github/actions/setup-rust@e48ed26d7f53f12f56eb7bcfdfdfe4d97065ea4c
       - name: Format
         run: make check-fmt
       - name: Lint
         run: make lint
       - name: Generate coverage
-        uses: leynos/shared-actions/.github/actions/generate-coverage@${{ vars.SHARED_ACTIONS_SHA }}
+        uses: leynos/shared-actions/.github/actions/generate-coverage@e48ed26d7f53f12f56eb7bcfdfdfe4d97065ea4c
         with:
           output-path: lcov.info
           format: lcov
       - name: Upload coverage data to CodeScene
         if: ${{ env.CS_ACCESS_TOKEN != '' }}
-        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@v1.2.1
+        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@e48ed26d7f53f12f56eb7bcfdfdfe4d97065ea4c
         with:
           format: lcov
           access-token: ${{ env.CS_ACCESS_TOKEN }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -16,13 +16,13 @@ jobs:
       CODESCENE_CLI_SHA256: ${{ vars.CODESCENE_CLI_SHA256 }}
     steps:
       - uses: actions/checkout@v4
-      - uses: leynos/shared-actions/.github/actions/setup-rust@${{ env.SHARED_ACTIONS_SHA }}
+      - uses: ${{ format('leynos/shared-actions/.github/actions/setup-rust@{0}', env.SHARED_ACTIONS_SHA) }}
       - name: Format
         run: make check-fmt
       - name: Lint
         run: make lint
       - id: generate-coverage
-        uses: leynos/shared-actions/.github/actions/generate-coverage@${{ env.SHARED_ACTIONS_SHA }}
+        uses: ${{ format('leynos/shared-actions/.github/actions/generate-coverage@{0}', env.SHARED_ACTIONS_SHA) }}
         with:
           output-path: lcov.info
           format: lcov

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,33 +1,37 @@
-name: Coverage
+name: CI
 
 on:
   pull_request:
     branches: [main]
 
+env:
+  SHARED_ACTIONS_SHA: e48ed26d7f53f12f56eb7bcfdfdfe4d97065ea4c
+
 jobs:
-  coverage:
+  build-test:
     runs-on: ubuntu-latest
     env:
       CARGO_TERM_COLOR: always
-
+      CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN }}
+      CODESCENE_CLI_SHA256: ${{ vars.CODESCENE_CLI_SHA256 }}
     steps:
       - uses: actions/checkout@v4
-
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: leynos/shared-actions/.github/actions/setup-rust@${{ env.SHARED_ACTIONS_SHA }}
+      - name: Format
+        run: make check-fmt
+      - name: Lint
+        run: make lint
+      - id: generate-coverage
+        uses: leynos/shared-actions/.github/actions/generate-coverage@${{ env.SHARED_ACTIONS_SHA }}
         with:
-          components: llvm-tools-preview
-
-      - uses: taiki-e/install-action@cargo-llvm-cov@v2
-
-      - name: Generate coverage
-        run: |
-          cargo llvm-cov --workspace --all-features \
-                         --lcov --output-path lcov.info \
-                         --codecov --output-path codecov.json
-
-      - uses: codecov/codecov-action@v4
+          output-path: lcov.info
+          format: lcov
+      - name: Upload coverage data to CodeScene
+        env:
+          CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN }}
+        if: ${{ env.CS_ACCESS_TOKEN != '' }}
+        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@v1.2.1
         with:
-          files: lcov.info,codecov.json
-          fail_ci_if_error: true
-          flags: unittests
-          verbose: true
+          format: lcov
+          access-token: ${{ env.CS_ACCESS_TOKEN }}
+          installer-checksum: ${{ vars.CODESCENE_CLI_SHA256 }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
 
 env:
+  # This SHA pins shared composite actions to a specific commit for
+  # reproducibility. Update it manually when bumping shared-actions to
+  # guarantee consistent workflow behaviour.
   SHARED_ACTIONS_SHA: e48ed26d7f53f12f56eb7bcfdfdfe4d97065ea4c
 
 jobs:
@@ -16,19 +19,17 @@ jobs:
       CODESCENE_CLI_SHA256: ${{ vars.CODESCENE_CLI_SHA256 }}
     steps:
       - uses: actions/checkout@v4
-      - uses: ${{ format('leynos/shared-actions/.github/actions/setup-rust@{0}', env.SHARED_ACTIONS_SHA) }}
+      - uses: leynos/shared-actions/.github/actions/setup-rust@${{ vars.SHARED_ACTIONS_SHA }}
       - name: Format
         run: make check-fmt
       - name: Lint
         run: make lint
       - id: generate-coverage
-        uses: ${{ format('leynos/shared-actions/.github/actions/generate-coverage@{0}', env.SHARED_ACTIONS_SHA) }}
+        uses: leynos/shared-actions/.github/actions/generate-coverage@${{ vars.SHARED_ACTIONS_SHA }}
         with:
           output-path: lcov.info
           format: lcov
       - name: Upload coverage data to CodeScene
-        env:
-          CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN }}
         if: ${{ env.CS_ACCESS_TOKEN != '' }}
         uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@v1.2.1
         with:


### PR DESCRIPTION
## Summary
- replace the old coverage workflow with a CI workflow
- share the commit SHA for shared-actions across job steps

## Testing
- `make fmt`
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6889bdec1c5483229fbb10ec650ebcf9

## Summary by Sourcery

Overhaul the GitHub Actions workflow into a unified CI job that runs Rust setup, formatting, linting, coverage generation, and conditional CodeScene upload using pinned shared actions.

Enhancements:
- Rename the workflow from Coverage to CI and the job from coverage to build-test
- Add a variables section to pin shared composite actions to a specific commit SHA
- Replace manual Rust toolchain and coverage commands with shared-actions steps
- Add Format and Lint steps using make targets
- Introduce a conditional CodeScene coverage upload step that uses an access token