### PR TITLE
Refactor GraphQL client into api module

### DIFF
--- a/docs/vk-design.md
+++ b/docs/vk-design.md
@@ -45,6 +45,10 @@ focused on orchestrating API calls and printing results. The public
 `GlobalArgs`, `PrArgs`, and `IssueArgs` structures are fully documented so
 their purpose and merge semantics are clear to downstream users.
 
+Networking logic resides in [src/api/mod.rs](../src/api/mod.rs). It exposes the
+`GraphQLClient` alongside the `run_query` helper and pagination utilities used
+throughout the application.
+
 ## Utility
 
 Splitting the printing logic into reusable `write_*` functions enables testing

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,9 +5,11 @@
 //! multiple comments on the same diff, the diff is shown only once.
 //! After all comments are printed, the tool displays an `end of code review`
 //! banner so calling processes know the output has finished.
+mod api;
 mod cli_args;
 mod html;
 mod reviews;
+use crate::api::GraphQLClient;
 use crate::cli_args::{GlobalArgs, IssueArgs, PrArgs};
 use crate::html::collapse_details;
 use crate::reviews::{fetch_reviews, latest_reviews, print_reviews};
@@ -16,8 +18,7 @@ use figment::error::{Error as FigmentError, Kind as FigmentKind};
 use log::{error, warn};
 use ortho_config::{OrthoConfig, OrthoError, load_and_merge_subcommand_for};
 use regex::Regex;
-use reqwest::header::{ACCEPT, AUTHORIZATION, HeaderMap, USER_AGENT};
-use serde::{Deserialize, Serialize, de::DeserializeOwned};
+use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::sync::LazyLock;
 use std::{env, fs, path::Path};
@@ -111,142 +112,6 @@ static HUNK_RE: LazyLock<Regex> = LazyLock::new(|| {
     )
     .expect("valid regex")
 });
-
-const BODY_SNIPPET_LEN: usize = 500;
-const VALUE_SNIPPET_LEN: usize = 200;
-
-fn snippet(text: &str, max: usize) -> String {
-    if text.chars().count() <= max {
-        text.to_string()
-    } else {
-        let mut out = text.chars().take(max).collect::<String>();
-        out.push_str("...");
-        out
-    }
-}
-
-#[derive(Debug, Deserialize)]
-struct GraphQlResponse<T> {
-    data: Option<T>,
-    errors: Option<Vec<GraphQlError>>,
-}
-
-#[derive(Debug, Deserialize)]
-struct GraphQlError {
-    message: String,
-}
-
-fn handle_graphql_errors(errors: Vec<GraphQlError>) -> VkError {
-    let msg = errors
-        .into_iter()
-        .map(|e| e.message)
-        .collect::<Vec<_>>()
-        .join(", ");
-    VkError::ApiErrors(msg)
-}
-
-struct GraphQLClient {
-    client: reqwest::Client,
-    headers: HeaderMap,
-    endpoint: String,
-    transcript: Option<std::sync::Mutex<std::io::BufWriter<std::fs::File>>>,
-}
-
-impl GraphQLClient {
-    fn new(token: &str, transcript: Option<std::path::PathBuf>) -> Result<Self, std::io::Error> {
-        let endpoint =
-            env::var("GITHUB_GRAPHQL_URL").unwrap_or_else(|_| GITHUB_GRAPHQL_URL.to_string());
-        Self::with_endpoint(token, &endpoint, transcript)
-    }
-
-    fn with_endpoint(
-        token: &str,
-        endpoint: &str,
-        transcript: Option<std::path::PathBuf>,
-    ) -> Result<Self, std::io::Error> {
-        let transcript = match transcript {
-            Some(p) => match std::fs::File::create(p) {
-                Ok(file) => Some(std::sync::Mutex::new(std::io::BufWriter::new(file))),
-                Err(e) => return Err(e),
-            },
-            None => None,
-        };
-        Ok(Self {
-            client: reqwest::Client::new(),
-            headers: build_headers(token),
-            endpoint: endpoint.to_string(),
-            transcript,
-        })
-    }
-
-    async fn run_query<V, T>(&self, query: &str, variables: V) -> Result<T, VkError>
-    where
-        V: serde::Serialize,
-        T: DeserializeOwned,
-    {
-        let payload = json!({ "query": query, "variables": &variables });
-        let ctx = serde_json::to_string(&payload).unwrap_or_default();
-        let response = self
-            .client
-            .post(&self.endpoint)
-            .headers(self.headers.clone())
-            .json(&payload)
-            .send()
-            .await
-            .map_err(|e| VkError::RequestContext {
-                context: ctx.clone(),
-                source: e,
-            })?;
-        let body = response.text().await.map_err(|e| VkError::RequestContext {
-            context: ctx.clone(),
-            source: e,
-        })?;
-        if let Some(t) = &self.transcript {
-            use std::io::Write as _;
-            match t.lock() {
-                Ok(mut f) => {
-                    if let Err(e) = writeln!(
-                        f,
-                        "{}",
-                        serde_json::to_string(&json!({ "request": payload, "response": body }))
-                            .unwrap_or_default()
-                    ) {
-                        warn!("failed to write transcript: {e}");
-                    }
-                }
-                Err(_) => warn!("failed to lock transcript"),
-            }
-        }
-        let resp: GraphQlResponse<serde_json::Value> =
-            serde_json::from_str(&body).map_err(|e| {
-                let snippet = snippet(&body, BODY_SNIPPET_LEN);
-                VkError::BadResponseSerde(format!("{e} | response body snippet:{snippet}"))
-            })?;
-
-        let resp_debug = format!("{resp:?}");
-        if let Some(errs) = resp.errors {
-            return Err(handle_graphql_errors(errs));
-        }
-
-        let value = resp.data.ok_or_else(|| {
-            VkError::BadResponse(format!("Missing data in response: {resp_debug}"))
-        })?;
-        match serde_path_to_error::deserialize::<_, T>(value.clone()) {
-            Ok(v) => Ok(v),
-            Err(e) => {
-                let snippet = snippet(
-                    &serde_json::to_string_pretty(&value).unwrap_or_default(),
-                    VALUE_SNIPPET_LEN,
-                );
-                let path = e.path().to_string();
-                let inner = e.into_inner();
-                Err(VkError::BadResponseSerde(format!(
-                    "{inner} at {path} | snippet: {snippet}"
-                )))
-            }
-        }
-    }
-}
 
 #[derive(Deserialize)]
 struct ThreadData {
@@ -344,8 +209,6 @@ struct CommentNode {
     comments: CommentConnection,
 }
 
-const GITHUB_GRAPHQL_URL: &str = "https://api.github.com/graphql";
-
 /// Width of the line number gutter in diff output
 const GUTTER_WIDTH: usize = 5;
 
@@ -409,32 +272,17 @@ const ISSUE_QUERY: &str = r"
     }
 ";
 
-pub(crate) async fn paginate<T, F, Fut>(mut fetch: F) -> Result<Vec<T>, VkError>
-where
-    F: FnMut(Option<String>) -> Fut,
-    Fut: std::future::Future<Output = Result<(Vec<T>, PageInfo), VkError>>,
-{
-    let mut items = Vec::new();
-    let mut cursor = None;
-    loop {
-        let (mut page, info) = fetch(cursor.clone()).await?;
-        items.append(&mut page);
-        if !info.has_next_page {
-            break;
-        }
-        cursor = info.end_cursor;
-    }
-    Ok(items)
-}
-
 async fn fetch_comment_page(
     client: &GraphQLClient,
     id: &str,
     cursor: Option<String>,
 ) -> Result<(Vec<ReviewComment>, PageInfo), VkError> {
-    let wrapper: CommentNodeWrapper = client
-        .run_query(COMMENT_QUERY, json!({ "id": id, "cursor": cursor.clone() }))
-        .await?;
+    let wrapper: CommentNodeWrapper = api::run_query(
+        client,
+        COMMENT_QUERY,
+        json!({ "id": id, "cursor": cursor.clone() }),
+    )
+    .await?;
     let conn = wrapper
         .node
         .ok_or_else(|| {
@@ -453,16 +301,16 @@ async fn fetch_issue(
     repo: &RepoInfo,
     number: u64,
 ) -> Result<Issue, VkError> {
-    let data: IssueData = client
-        .run_query(
-            ISSUE_QUERY,
-            json!({
-                "owner": repo.owner.as_str(),
-                "name": repo.name.as_str(),
-                "number": number
-            }),
-        )
-        .await?;
+    let data: IssueData = api::run_query(
+        client,
+        ISSUE_QUERY,
+        json!({
+            "owner": repo.owner.as_str(),
+            "name": repo.name.as_str(),
+            "number": number
+        }),
+    )
+    .await?;
     Ok(data.repository.issue)
 }
 
@@ -472,17 +320,17 @@ async fn fetch_thread_page(
     number: u64,
     cursor: Option<String>,
 ) -> Result<(Vec<ReviewThread>, PageInfo), VkError> {
-    let data: ThreadData = client
-        .run_query(
-            THREADS_QUERY,
-            json!({
-                "owner": repo.owner.as_str(),
-                "name": repo.name.as_str(),
-                "number": number,
-                "cursor": cursor,
-            }),
-        )
-        .await?;
+    let data: ThreadData = api::run_query(
+        client,
+        THREADS_QUERY,
+        json!({
+            "owner": repo.owner.as_str(),
+            "name": repo.name.as_str(),
+            "number": number,
+            "cursor": cursor,
+        }),
+    )
+    .await?;
     let conn = data.repository.pull_request.review_threads;
     Ok((conn.nodes, conn.page_info))
 }
@@ -492,7 +340,8 @@ async fn fetch_review_threads(
     repo: &RepoInfo,
     number: u64,
 ) -> Result<Vec<ReviewThread>, VkError> {
-    let mut threads = paginate(|cursor| fetch_thread_page(client, repo, number, cursor)).await?;
+    let mut threads =
+        api::paginate(|cursor| fetch_thread_page(client, repo, number, cursor)).await?;
     threads.retain(|t| !t.is_resolved);
 
     for thread in &mut threads {
@@ -508,7 +357,7 @@ async fn fetch_review_threads(
         );
         let mut comments = initial.nodes;
         if initial.page_info.has_next_page {
-            let more = paginate(|c| fetch_comment_page(client, &thread.id, c)).await?;
+            let more = api::paginate(|c| fetch_comment_page(client, &thread.id, c)).await?;
             comments.extend(more);
         }
         thread.comments = CommentConnection {
@@ -727,24 +576,6 @@ fn print_summary(summary: &[(String, usize)]) {
 /// Print a closing banner once all review threads have been displayed.
 fn print_end_banner() {
     println!("========== end of code review ==========");
-}
-
-fn build_headers(token: &str) -> HeaderMap {
-    let mut headers = HeaderMap::new();
-    headers.insert(USER_AGENT, "vk".parse().expect("static string"));
-    headers.insert(
-        ACCEPT,
-        "application/vnd.github+json"
-            .parse()
-            .expect("static string"),
-    );
-    if !token.is_empty() {
-        headers.insert(
-            AUTHORIZATION,
-            format!("Bearer {token}").parse().expect("valid header"),
-        );
-    }
-    headers
 }
 
 /// Create a [`GraphQLClient`], falling back to no transcript on failure.


### PR DESCRIPTION
## Summary
- move GraphQL client and helpers to `api` module
- update callers to use `api::run_query` and `api::paginate`
- document new module in design docs

## Testing
- `make fmt`
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_688bb35e83848322ae8f2490bcc6cfb2

## Summary by Sourcery

Extract GraphQL client and pagination logic into a dedicated `api` module and update callers accordingly

Enhancements:
- Move GraphQL client implementation, error handling, and pagination helpers into `src/api/mod.rs`
- Replace inline `run_query` and `paginate` implementations with `api::run_query` and `api::paginate` across the codebase
- Remove deprecated GraphQL client and helper code from `main.rs` and `reviews.rs`

Documentation:
- Document the new `api` module in the design documentation (`vk-design.md`)