### PR TITLE
Update and rename coverage.yml to ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,13 +17,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Setup Rust
-        uses: leynos/shared-actions/.github/actions/setup-rust@e48ed26d7f53f12f56eb7bcfdfdfe4d97065ea4c
+        uses: leynos/shared-actions/.github/actions/setup-rust@c6559452842af6a83b83429129dccaf910e34562
       - name: Format
         run: make check-fmt
       - name: Lint
         run: make lint
       - name: Test and Measure Coverage
-        uses: leynos/shared-actions/.github/actions/generate-coverage@e48ed26d7f53f12f56eb7bcfdfdfe4d97065ea4c
+        uses: leynos/shared-actions/.github/actions/generate-coverage@c6559452842af6a83b83429129dccaf910e34562
         with:
           output-path: lcov.info
           format: lcov
@@ -31,7 +31,7 @@ jobs:
         env:
           CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN }}
         if: ${{ env.CS_ACCESS_TOKEN }}
-        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@e48ed26d7f53f12f56eb7bcfdfdfe4d97065ea4c
+        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@c6559452842af6a83b83429129dccaf910e34562
         with:
           format: lcov
           access-token: ${{ env.CS_ACCESS_TOKEN }}


### PR DESCRIPTION
## Summary by Sourcery

Rename and enhance the CI workflow to run on both push and pull requests, tighten job permissions, introduce a build profile, and update shared-actions references to the latest commits.

CI:
- Rename workflow file to ci.yml and trigger it on push and pull_request events on main branch
- Restrict permissions to contents: read and add BUILD_PROFILE=debug for the build-test job
- Update setup-rust, generate-coverage, and upload-codescene actions to their latest commit hashes
- Rename coverage step to "Test and Measure Coverage" and move CS_ACCESS_TOKEN environment variable into the upload step