### PR TITLE
Introduce printer module

### DIFF
--- a/src/html.rs
+++ b/src/html.rs
@@ -65,9 +65,11 @@ fn write_collapsed_summary(node: &Handle, out: &mut String) {
 
 fn find_summary_text(node: &Handle) -> Option<String> {
     for child in node.children.borrow().iter() {
-        if let NodeData::Element { name, .. } = &child.data
-            && name.local.eq_str_ignore_ascii_case("summary")
-        {
+        if matches!(
+            &child.data,
+            NodeData::Element { name, .. }
+                if name.local.eq_str_ignore_ascii_case("summary")
+        ) {
             return Some(collect_text(child));
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -563,7 +563,11 @@ async fn run_pr(args: PrArgs, global: &GlobalArgs) -> Result<(), VkError> {
 
     let skin = MadSkin::default();
     let latest = latest_reviews(reviews);
-    print_reviews(&skin, &latest);
+    let stdout = std::io::stdout();
+    let mut handle = stdout.lock();
+    if let Err(e) = print_reviews(&mut handle, &skin, &latest) {
+        error!("error printing review: {e}");
+    }
 
     for t in threads {
         if let Err(e) = print_thread(&skin, &t) {

--- a/src/printer/mod.rs
+++ b/src/printer/mod.rs
@@ -15,8 +15,11 @@ fn write_author_line<W: std::io::Write>(
     login: Option<&str>,
     suffix: &str,
 ) -> std::io::Result<()> {
-    let login = login.unwrap_or("(unknown)");
-    writeln!(out, "{icon}  \x1b[1m{login}\x1b[0m{suffix}")
+    writeln!(
+        out,
+        "{icon}  \x1b[1m{}\x1b[0m{suffix}",
+        login.unwrap_or("(unknown)")
+    )
 }
 
 /// Format the body of a single review comment.

--- a/src/printer/mod.rs
+++ b/src/printer/mod.rs
@@ -1,0 +1,154 @@
+//! Helpers for printing review comments and threads.
+//!
+//! These functions format comments with syntax highlighting using
+//! `termimad`. They are separated from the rest of the application so
+//! behaviour can be unit tested without capturing stdout.
+use termimad::MadSkin;
+
+use crate::html::collapse_details;
+use crate::reviews::PullRequestReview;
+use crate::{ReviewComment, ReviewThread};
+
+/// Format the body of a single review comment.
+///
+/// The author's login appears in bold followed by the rendered markdown
+/// from the comment body.
+///
+/// # Examples
+///
+/// ```ignore
+/// use vk::printer::write_comment_body;
+/// use vk::ReviewComment;
+/// use termimad::MadSkin;
+/// let skin = MadSkin::default();
+/// let comment = ReviewComment { body: "hello".into(), ..Default::default() };
+/// let mut buf = Vec::new();
+/// write_comment_body(&mut buf, &skin, &comment).unwrap();
+/// ```
+pub fn write_comment_body<W: std::io::Write>(
+    mut out: W,
+    skin: &MadSkin,
+    comment: &ReviewComment,
+) -> anyhow::Result<()> {
+    let author = comment.author.as_ref().map_or("", |u| u.login.as_str());
+    writeln!(out, "\u{1f4ac}  \x1b[1m{author}\x1b[0m wrote:")?;
+    let body = collapse_details(&comment.body);
+    let _ = skin.write_text_on(&mut out, &body);
+    writeln!(out)?;
+    Ok(())
+}
+
+/// Write a single comment including its diff hunk.
+///
+/// The diff is emitted first, followed by the comment body formatted
+/// using [`write_comment_body`].
+///
+/// # Examples
+///
+/// ```ignore
+/// use vk::printer::write_comment;
+/// use vk::ReviewComment;
+/// use termimad::MadSkin;
+/// let comment = ReviewComment { diff_hunk: "@@ -1 +1 @@\n-old\n+new".into(), ..Default::default() };
+/// let mut buf = Vec::new();
+/// write_comment(&mut buf, &MadSkin::default(), &comment).unwrap();
+/// ```
+pub fn write_comment<W: std::io::Write>(
+    mut out: W,
+    skin: &MadSkin,
+    comment: &ReviewComment,
+) -> anyhow::Result<()> {
+    let diff = crate::format_comment_diff(comment)?;
+    write!(out, "{diff}")?;
+    write_comment_body(&mut out, skin, comment)?;
+    Ok(())
+}
+
+/// Write all comments in a thread, showing the diff only once.
+///
+/// The first comment is printed via [`write_comment`]. Subsequent
+/// comments omit the diff and are formatted with [`write_comment_body`].
+///
+/// # Examples
+///
+/// ```ignore
+/// use vk::printer::write_thread;
+/// use vk::{ReviewComment, ReviewThread, CommentConnection};
+/// use termimad::MadSkin;
+/// let diff = "@@ -1 +1 @@\n-old\n+new\n";
+/// let c1 = ReviewComment { diff_hunk: diff.into(), ..Default::default() };
+/// let c2 = ReviewComment { diff_hunk: diff.into(), ..Default::default() };
+/// let thread = ReviewThread { comments: CommentConnection { nodes: vec![c1,c2], ..Default::default() }, ..Default::default() };
+/// let mut buf = Vec::new();
+/// write_thread(&mut buf, &MadSkin::default(), &thread).unwrap();
+/// ```
+pub fn write_thread<W: std::io::Write>(
+    mut out: W,
+    skin: &MadSkin,
+    thread: &ReviewThread,
+) -> anyhow::Result<()> {
+    let mut iter = thread.comments.nodes.iter();
+    if let Some(first) = iter.next() {
+        write_comment(&mut out, skin, first)?;
+        writeln!(out, "{}", first.url)?;
+        for c in iter {
+            write_comment_body(&mut out, skin, c)?;
+            writeln!(out, "{}", c.url)?;
+        }
+    }
+    Ok(())
+}
+
+/// Print the body of a review comment to stdout with the given skin.
+///
+/// Each review is printed with the reviewer's login followed by the
+/// formatted comment text.
+///
+/// # Examples
+///
+/// ```ignore
+/// use vk::printer::print_reviews;
+/// use vk::reviews::PullRequestReview;
+/// use chrono::Utc;
+/// use termimad::MadSkin;
+/// let review = PullRequestReview { body: "Looks good".into(), submitted_at: Utc::now(), state: "APPROVED".into(), author: None };
+/// print_reviews(&MadSkin::default(), &[review]);
+/// ```
+pub fn print_reviews(skin: &MadSkin, reviews: &[PullRequestReview]) {
+    for r in reviews {
+        if let Err(e) = write_review(std::io::stdout().lock(), skin, r) {
+            eprintln!("error printing review: {e}");
+        }
+    }
+}
+
+/// Format a single review banner to the provided writer.
+///
+/// # Examples
+///
+/// ```ignore
+/// use vk::printer::write_review;
+/// use vk::reviews::PullRequestReview;
+/// use chrono::Utc;
+/// use termimad::MadSkin;
+/// let review = PullRequestReview { body: "Nice".into(), submitted_at: Utc::now(), state: "APPROVED".into(), author: None };
+/// let mut buf = Vec::new();
+/// write_review(&mut buf, &MadSkin::default(), &review).unwrap();
+/// ```
+pub fn write_review<W: std::io::Write>(
+    mut out: W,
+    skin: &MadSkin,
+    review: &PullRequestReview,
+) -> anyhow::Result<()> {
+    let author = review
+        .author
+        .as_ref()
+        .map_or("(unknown)", |u| u.login.as_str());
+    writeln!(out, "\u{1f4dd}  \x1b[1m{author}\x1b[0m {}:", review.state)?;
+    let body = collapse_details(&review.body);
+    if let Err(e) = skin.write_text_on(&mut out, &body) {
+        eprintln!("error writing review body: {e}");
+    }
+    writeln!(out)?;
+    Ok(())
+}

--- a/src/reviews.rs
+++ b/src/reviews.rs
@@ -1,14 +1,11 @@
-//! Functions for retrieving pull-request reviews and presenting them in the terminal.
+//! Functions for retrieving pull-request reviews through the GitHub API.
 //!
-//! The module defines GraphQL query structures, pagination helpers, and output
-//! formatting so callers can fetch review threads through the GitHub API, then
-//! display only the latest review from each author using `termimad`.
+//! The module defines GraphQL query structures and pagination helpers so callers
+//! can fetch review threads and collate the latest review from each author.
 
-use crate::html::collapse_details;
 use chrono::{DateTime, Utc};
 use serde::Deserialize;
 use serde_json::json;
-use termimad::MadSkin;
 
 use crate::api::{self, GraphQLClient};
 use crate::{PageInfo, RepoInfo, User, VkError};
@@ -116,30 +113,4 @@ pub fn latest_reviews(reviews: Vec<PullRequestReview>) -> Vec<PullRequestReview>
         }
     }
     latest.into_values().collect()
-}
-
-pub fn write_review<W: std::io::Write>(
-    mut out: W,
-    skin: &MadSkin,
-    review: &PullRequestReview,
-) -> anyhow::Result<()> {
-    let author = review
-        .author
-        .as_ref()
-        .map_or("(unknown)", |u| u.login.as_str());
-    writeln!(out, "\u{1f4dd}  \x1b[1m{author}\x1b[0m {}:", review.state)?;
-    let body = collapse_details(&review.body);
-    if let Err(e) = skin.write_text_on(&mut out, &body) {
-        eprintln!("error writing review body: {e}");
-    }
-    writeln!(out)?;
-    Ok(())
-}
-
-pub fn print_reviews(skin: &MadSkin, reviews: &[PullRequestReview]) {
-    for r in reviews {
-        if let Err(e) = write_review(std::io::stdout().lock(), skin, r) {
-            eprintln!("error printing review: {e}");
-        }
-    }
 }


### PR DESCRIPTION
## Summary
- move printing helpers into `printer` module
- document printer functions with examples
- restrict `reviews` module to fetching helpers only

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_688be428f84c8322986c38c04790b8b4

## Summary by Sourcery

Extract printing logic into a dedicated `printer` module, relocate all comment/thread/review printing functions there, remove them from `main.rs` and `reviews.rs`, and update imports and tests to use the new module.

Enhancements:
- Add `printer` module to house functions for formatting and printing review comments, review threads, and reviews with termimad syntax highlighting.
- Document all printer functions with usage examples and module-level documentation.

Chores:
- Remove obsolete printing helpers from `main.rs` and `reviews.rs` to restrict the reviews module to fetching logic.
- Update imports and tests to reference printing functions from the new `printer` module.