### PR TITLE
Refine GraphQL client API

### DIFF
--- a/docs/vk-design.md
+++ b/docs/vk-design.md
@@ -45,9 +45,10 @@ focused on orchestrating API calls and printing results. The public
 `GlobalArgs`, `PrArgs`, and `IssueArgs` structures are fully documented so
 their purpose and merge semantics are clear to downstream users.
 
-Networking logic resides in [src/api/mod.rs](../src/api/mod.rs). It exposes the
-`GraphQLClient` alongside the `run_query` helper and pagination utilities used
-throughout the application.
+Networking logic resides in [src/api/mod.rs](../src/api/mod.rs) and is re-
+exported at the crate root. The module exposes the `GraphQLClient` with a
+`run_query` method, along with the `paginate` helper used throughout the
+application.
 
 ## Utility
 

--- a/src/reviews.rs
+++ b/src/reviews.rs
@@ -10,8 +10,7 @@ use serde::Deserialize;
 use serde_json::json;
 use termimad::MadSkin;
 
-use crate::api::{self, GraphQLClient};
-use crate::{PageInfo, RepoInfo, User, VkError};
+use crate::{GraphQLClient, PageInfo, RepoInfo, User, VkError, paginate};
 use std::collections::HashMap;
 
 #[derive(Debug, Deserialize, Clone)]
@@ -73,17 +72,17 @@ pub async fn fetch_review_page(
     number: u64,
     cursor: Option<String>,
 ) -> Result<(Vec<PullRequestReview>, PageInfo), VkError> {
-    let data: ReviewData = api::run_query(
-        client,
-        REVIEWS_QUERY,
-        json!({
-            "owner": repo.owner.as_str(),
-            "name": repo.name.as_str(),
-            "number": number,
-            "cursor": cursor,
-        }),
-    )
-    .await?;
+    let data: ReviewData = client
+        .run_query(
+            REVIEWS_QUERY,
+            json!({
+                "owner": repo.owner.as_str(),
+                "name": repo.name.as_str(),
+                "number": number,
+                "cursor": cursor,
+            }),
+        )
+        .await?;
     let conn = data.repository.pull_request.reviews;
     Ok((conn.nodes, conn.page_info))
 }
@@ -93,7 +92,7 @@ pub async fn fetch_reviews(
     repo: &RepoInfo,
     number: u64,
 ) -> Result<Vec<PullRequestReview>, VkError> {
-    api::paginate(|c| fetch_review_page(client, repo, number, c)).await
+    paginate(|c| fetch_review_page(client, repo, number, c)).await
 }
 
 pub fn latest_reviews(reviews: Vec<PullRequestReview>) -> Vec<PullRequestReview> {


### PR DESCRIPTION
## Summary
- expose `GraphQLClient` publicly and re-export it at the crate root
- rename `GraphQlResponse` to `GraphQLResponse`
- provide public `run_query` method and use it from callers
- export pagination helper at crate root
- document the crate root re-exports

Closes #49


------
https://chatgpt.com/codex/tasks/task_e_688be4826d5483228cf042eece1ed9e4

## Summary by Sourcery

Refine the GraphQL client API by exposing core types and helpers at the crate root, renaming response types, and converting the standalone query helper into a method.

New Features:
- Expose GraphQLClient and run_query at the crate root
- Export paginate helper and PageInfo type publicly

Enhancements:
- Rename GraphQlResponse to GraphQLResponse and update call sites to use client.run_query
- Make VkError enum and PageInfo struct publicly accessible

Documentation:
- Document crate root re-exports of GraphQLClient, run_query, and pagination utilities