### PR TITLE
Document paginate error handling

### DIFF
--- a/docs/vk-design.md
+++ b/docs/vk-design.md
@@ -45,10 +45,10 @@ focused on orchestrating API calls and printing results. The public
 `GlobalArgs`, `PrArgs`, and `IssueArgs` structures are fully documented so
 their purpose and merge semantics are clear to downstream users.
 
-Networking logic resides in [src/api/mod.rs](../src/api/mod.rs) and is re-
-exported at the crate root. The module exposes the `GraphQLClient` with a
-`run_query` method, along with the `paginate` helper used throughout the
-application.
+Networking logic resides in [src/api/mod.rs](../src/api/mod.rs). It exposes the
+`GraphQLClient` alongside the `run_query` helper and pagination utilities used
+throughout the application. The `paginate` helper loops until `PageInfo`
+indicates completion, discarding any items fetched before an error occurs.
 
 ## Utility
 

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -202,7 +202,8 @@ impl GraphQLClient {
 /// Retrieve all pages from a cursor-based connection.
 ///
 /// The `fetch` closure is called repeatedly with the current cursor until the
-/// [`PageInfo`] object indicates no further pages remain.
+/// [`PageInfo`] object indicates no further pages remain. Items fetched before
+/// an error occurs are discarded.
 ///
 /// # Errors
 ///


### PR DESCRIPTION
## Summary
- clarify that `paginate` discards items if a fetch fails
- note this behaviour in the design docs

closes #50


------
https://chatgpt.com/codex/tasks/task_e_688be49466d88322a0149563be69ac95

## Summary by Sourcery

Clarify in documentation and code comments that the paginate helper discards any items fetched before an error occurs

Enhancements:
- Update paginate function doc comment to mention discarding items on fetch errors

Documentation:
- Add note in design docs that paginate drops items when a fetch fails