### PR TITLE
Clarify paginate error behaviour

### DIFF
--- a/src/html.rs
+++ b/src/html.rs
@@ -65,10 +65,10 @@ fn write_collapsed_summary(node: &Handle, out: &mut String) {
 
 fn find_summary_text(node: &Handle) -> Option<String> {
     for child in node.children.borrow().iter() {
-        if let NodeData::Element { name, .. } = &child.data
-            && name.local.eq_str_ignore_ascii_case("summary")
-        {
-            return Some(collect_text(child));
+        if let NodeData::Element { name, .. } = &child.data {
+            if name.local.eq_str_ignore_ascii_case("summary") {
+                return Some(collect_text(child));
+            }
         }
     }
     None

--- a/src/html.rs
+++ b/src/html.rs
@@ -64,14 +64,15 @@ fn write_collapsed_summary(node: &Handle, out: &mut String) {
 }
 
 fn find_summary_text(node: &Handle) -> Option<String> {
-    for child in node.children.borrow().iter() {
-        if let NodeData::Element { name, .. } = &child.data {
-            if name.local.eq_str_ignore_ascii_case("summary") {
-                return Some(collect_text(child));
+    node.children
+        .borrow()
+        .iter()
+        .find_map(|child| match &child.data {
+            NodeData::Element { name, .. } if name.local.eq_str_ignore_ascii_case("summary") => {
+                Some(collect_text(child))
             }
-        }
-    }
-    None
+            _ => None,
+        })
 }
 
 fn collect_text(node: &Handle) -> String {


### PR DESCRIPTION
## Summary
- clarify that `paginate` discards fetched items on error and returns only `Err`
- replace unstable `let` chain in HTML summary search

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_688f720a44648322889682480723ab6d

## Summary by Sourcery

Clarify the behavior of the `paginate` function on errors and refactor HTML summary search logic

Enhancements:
- expand `paginate` doc comments to specify that items are discarded on error and include a usage example
- refactor HTML summary search to avoid unstable `let` chains by using nested `if` statements