### PR TITLE
Refactor main module into smaller components

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,41 @@
+//! Configuration loading helpers.
+//!
+//! Provides a wrapper around `ortho_config` that tolerates missing `reference`
+//! fields by falling back to command-line values.
+
+use figment::error::{Error as FigmentError, Kind as FigmentKind};
+use ortho_config::{OrthoConfig, OrthoError, load_and_merge_subcommand_for};
+
+fn missing_reference(err: &FigmentError) -> bool {
+    err.clone()
+        .into_iter()
+        .any(|e| matches!(e.kind, FigmentKind::MissingField(ref f) if f == "reference"))
+}
+
+/// Load configuration for a set of CLI arguments, falling back when `reference`
+/// is omitted.
+///
+/// # Errors
+///
+/// Returns an [`OrthoError`] if configuration gathering fails for reasons other
+/// than a missing reference field.
+#[expect(
+    clippy::result_large_err,
+    reason = "configuration loading errors can be verbose"
+)]
+pub fn load_with_reference_fallback<T>(cli_args: T) -> Result<T, OrthoError>
+where
+    T: OrthoConfig + serde::Serialize + Default + clap::CommandFactory + Clone,
+{
+    match load_and_merge_subcommand_for::<T>(&cli_args) {
+        Ok(v) => Ok(v),
+        Err(OrthoError::Gathering(e)) => {
+            if missing_reference(&e) {
+                Ok(cli_args)
+            } else {
+                Err(OrthoError::Gathering(e))
+            }
+        }
+        Err(e) => Err(e),
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,7 +7,8 @@ use figment::error::{Error as FigmentError, Kind as FigmentKind};
 use ortho_config::{OrthoConfig, OrthoError, load_and_merge_subcommand_for};
 
 fn missing_reference(err: &FigmentError) -> bool {
-    // FigmentError yields its causes only by value; clone to inspect without ownership.
+    // FigmentError implements `IntoIterator` only for owned values; clone so the
+    // borrowed error isn't moved when checking its causes.
     err.clone()
         .into_iter()
         .any(|e| matches!(e.kind, FigmentKind::MissingField(ref f) if f == "reference"))

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,7 +7,7 @@ use figment::error::{Error as FigmentError, Kind as FigmentKind};
 use ortho_config::{OrthoConfig, OrthoError, load_and_merge_subcommand_for};
 
 fn missing_reference(err: &FigmentError) -> bool {
-    // FigmentError implements IntoIterator only for owned values, so clone.
+    // FigmentError yields its causes only by value; clone to inspect without ownership.
     err.clone()
         .into_iter()
         .any(|e| matches!(e.kind, FigmentKind::MissingField(ref f) if f == "reference"))

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,6 +7,7 @@ use figment::error::{Error as FigmentError, Kind as FigmentKind};
 use ortho_config::{OrthoConfig, OrthoError, load_and_merge_subcommand_for};
 
 fn missing_reference(err: &FigmentError) -> bool {
+    // FigmentError implements IntoIterator only for owned values, so clone.
     err.clone()
         .into_iter()
         .any(|e| matches!(e.kind, FigmentKind::MissingField(ref f) if f == "reference"))

--- a/src/issues.rs
+++ b/src/issues.rs
@@ -1,0 +1,50 @@
+//! Helpers for fetching issues from the GitHub API.
+//!
+//! Currently only retrieval of a single issue by number is supported.
+
+use serde::Deserialize;
+use serde_json::json;
+
+use crate::graphql_queries::ISSUE_QUERY;
+use crate::ref_parser::RepoInfo;
+use crate::{GraphQLClient, VkError};
+
+#[derive(Deserialize)]
+struct IssueData {
+    repository: IssueRepository,
+}
+
+#[derive(Deserialize)]
+struct IssueRepository {
+    issue: Issue,
+}
+
+/// Minimal issue representation returned by the GitHub API.
+#[derive(Deserialize)]
+pub struct Issue {
+    pub title: String,
+    pub body: String,
+}
+
+/// Fetch a single issue by repository and number.
+///
+/// # Errors
+///
+/// Returns an error if the API request fails or the response is malformed.
+pub async fn fetch_issue(
+    client: &GraphQLClient,
+    repo: &RepoInfo,
+    number: u64,
+) -> Result<Issue, VkError> {
+    let data: IssueData = client
+        .run_query(
+            ISSUE_QUERY,
+            json!({
+                "owner": repo.owner.as_str(),
+                "name": repo.name.as_str(),
+                "number": number
+            }),
+        )
+        .await?;
+    Ok(data.repository.issue)
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@
 //! line tool, which fetches unresolved review comments from GitHub's GraphQL
 //! API. The core functionality is delegated to specialised modules:
 //! `review_threads` for fetching review data, `issues` for issue retrieval,
-//! `summary` for comment summarisation, and `config` for configuration
+//! `summary` for summarising comments, and `config` for configuration
 //! management. When a thread has multiple comments on the same diff, the diff
 //! is shown only once. After all comments are printed, the tool displays an
 //! `end of code review` banner so calling processes know the output has

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,14 @@
 //! Entry point for the `vk` command line tool.
 //!
-//! `vk` fetches unresolved review comments from GitHub's GraphQL API,
-//! summarising them by file before printing each thread. When a thread has
-//! multiple comments on the same diff, the diff is shown only once.
-//! After all comments are printed, the tool displays an `end of code review`
-//! banner so calling processes know the output has finished.
+//! This module provides the main entry point and orchestrates the `vk` command
+//! line tool, which fetches unresolved review comments from GitHub's GraphQL
+//! API. The core functionality is delegated to specialised modules:
+//! `review_threads` for fetching review data, `issues` for issue retrieval,
+//! `summary` for comment summarisation, and `config` for configuration
+//! management. When a thread has multiple comments on the same diff, the diff
+//! is shown only once. After all comments are printed, the tool displays an
+//! `end of code review` banner so calling processes know the output has
+//! finished.
 
 pub mod api;
 mod cli_args;

--- a/src/review_threads.rs
+++ b/src/review_threads.rs
@@ -1,0 +1,256 @@
+//! Helpers for fetching pull request review threads from the GitHub API.
+//!
+//! The module defines GraphQL response structures and helpers to retrieve all
+//! unresolved review threads along with their comments.
+
+use serde::Deserialize;
+use serde_json::json;
+
+use crate::graphql_queries::{COMMENT_QUERY, THREADS_QUERY};
+use crate::ref_parser::RepoInfo;
+use crate::{GraphQLClient, VkError, paginate};
+
+#[derive(Debug, Deserialize, Default)]
+struct ThreadData {
+    repository: Repository,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct Repository {
+    #[serde(rename = "pullRequest")]
+    pull_request: PullRequest,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct PullRequest {
+    #[serde(rename = "reviewThreads")]
+    review_threads: ReviewThreadConnection,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct CommentNodeWrapper {
+    node: Option<CommentNode>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct CommentNode {
+    comments: CommentConnection,
+}
+
+/// Connection wrapper around [`ReviewThread`] nodes.
+#[derive(Debug, Deserialize, Default)]
+struct ReviewThreadConnection {
+    nodes: Vec<ReviewThread>,
+    #[serde(rename = "pageInfo")]
+    page_info: PageInfo,
+}
+
+/// Details of a single review thread.
+#[derive(Debug, Deserialize, Default)]
+pub struct ReviewThread {
+    pub id: String,
+    #[serde(rename = "isResolved")]
+    #[allow(
+        dead_code,
+        reason = "GraphQL query requires this field but it is unused"
+    )]
+    pub is_resolved: bool,
+    pub comments: CommentConnection,
+}
+
+/// Collection of comments within a review thread.
+#[derive(Debug, Deserialize, Default)]
+pub struct CommentConnection {
+    pub nodes: Vec<ReviewComment>,
+    #[serde(rename = "pageInfo")]
+    pub page_info: PageInfo,
+}
+
+/// A single review comment.
+#[derive(Debug, Deserialize, Default)]
+pub struct ReviewComment {
+    pub body: String,
+    #[serde(rename = "diffHunk")]
+    pub diff_hunk: String,
+    #[serde(rename = "originalPosition")]
+    pub original_position: Option<i32>,
+    pub position: Option<i32>,
+    #[allow(dead_code, reason = "stored for completeness; not displayed yet")]
+    pub path: String,
+    pub url: String,
+    pub author: Option<User>,
+}
+
+/// Pagination information returned by GitHub's GraphQL API.
+#[derive(Debug, Deserialize, Default, Clone)]
+pub struct PageInfo {
+    #[serde(rename = "hasNextPage")]
+    pub has_next_page: bool,
+    #[serde(rename = "endCursor")]
+    pub end_cursor: Option<String>,
+}
+
+/// Minimal user representation for authorship information.
+#[derive(Debug, Deserialize, Default, Clone)]
+pub struct User {
+    pub login: String,
+}
+
+async fn fetch_comment_page(
+    client: &GraphQLClient,
+    id: &str,
+    cursor: Option<String>,
+) -> Result<(Vec<ReviewComment>, PageInfo), VkError> {
+    let wrapper: CommentNodeWrapper = client
+        .run_query(COMMENT_QUERY, json!({ "id": id, "cursor": cursor.clone() }))
+        .await?;
+    let conn = wrapper
+        .node
+        .ok_or_else(|| {
+            VkError::BadResponse(format!(
+                "Missing comment node in response (id: {}, cursor: {})",
+                id,
+                cursor.as_deref().unwrap_or("None")
+            ))
+        })?
+        .comments;
+    Ok((conn.nodes, conn.page_info))
+}
+
+async fn fetch_thread_page(
+    client: &GraphQLClient,
+    repo: &RepoInfo,
+    number: u64,
+    cursor: Option<String>,
+) -> Result<(Vec<ReviewThread>, PageInfo), VkError> {
+    let data: ThreadData = client
+        .run_query(
+            THREADS_QUERY,
+            json!({
+                "owner": repo.owner.as_str(),
+                "name": repo.name.as_str(),
+                "number": number,
+                "cursor": cursor,
+            }),
+        )
+        .await?;
+    let conn = data.repository.pull_request.review_threads;
+    Ok((conn.nodes, conn.page_info))
+}
+
+/// Fetch all unresolved review threads for a pull request.
+///
+/// # Errors
+///
+/// Returns an error if any API request fails or the response is malformed.
+pub async fn fetch_review_threads(
+    client: &GraphQLClient,
+    repo: &RepoInfo,
+    number: u64,
+) -> Result<Vec<ReviewThread>, VkError> {
+    let mut threads = paginate(|cursor| fetch_thread_page(client, repo, number, cursor)).await?;
+    threads.retain(|t| !t.is_resolved);
+
+    for thread in &mut threads {
+        let initial = std::mem::replace(
+            &mut thread.comments,
+            CommentConnection {
+                nodes: Vec::new(),
+                page_info: PageInfo {
+                    has_next_page: false,
+                    end_cursor: None,
+                },
+            },
+        );
+        let mut comments = initial.nodes;
+        if initial.page_info.has_next_page {
+            let more = paginate(|c| fetch_comment_page(client, &thread.id, c)).await?;
+            comments.extend(more);
+        }
+        thread.comments = CommentConnection {
+            nodes: comments,
+            page_info: PageInfo {
+                has_next_page: false,
+                end_cursor: None,
+            },
+        };
+    }
+    Ok(threads)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::GraphQLClient;
+    use crate::ref_parser::RepoInfo;
+
+    #[tokio::test]
+    async fn run_query_missing_nodes_reports_path() {
+        use third_wheel::hyper::{
+            Body, Request, Response, Server, StatusCode,
+            service::{make_service_fn, service_fn},
+        };
+
+        let body = serde_json::json!({
+            "data": {
+                "repository": {
+                    "pullRequest": {
+                        "reviewThreads": {
+                            "pageInfo": { "hasNextPage": false, "endCursor": null }
+                        }
+                    }
+                }
+            }
+        })
+        .to_string();
+
+        let make_svc = make_service_fn(move |_conn| {
+            let body = body.clone();
+            async move {
+                Ok::<_, std::convert::Infallible>(service_fn(move |_req: Request<Body>| {
+                    let body = body.clone();
+                    async move {
+                        Ok::<_, std::convert::Infallible>(
+                            Response::builder()
+                                .status(StatusCode::OK)
+                                .header("Content-Type", "application/json")
+                                .body(Body::from(body.clone()))
+                                .expect("failed to build HTTP response"),
+                        )
+                    }
+                }))
+            }
+        });
+
+        let server = Server::bind(
+            &"127.0.0.1:0"
+                .parse()
+                .expect("failed to parse server address"),
+        )
+        .serve(make_svc);
+        let addr = server.local_addr();
+        let join = tokio::spawn(server);
+
+        let client = GraphQLClient::with_endpoint("token", &format!("http://{addr}"), None)
+            .expect("failed to create GraphQL client");
+
+        let repo = RepoInfo {
+            owner: "o".into(),
+            name: "r".into(),
+        };
+        let result = fetch_review_threads(&client, &repo, 1).await;
+        let err = result.expect_err("expected error");
+        let err_msg = format!("{err}");
+        assert!(
+            err_msg.contains("repository.pullRequest.reviewThreads"),
+            "Error should contain full JSON path",
+        );
+        assert!(
+            err_msg.contains("snippet:"),
+            "Error should contain JSON snippet",
+        );
+
+        join.abort();
+        let _ = join.await;
+    }
+}

--- a/src/summary.rs
+++ b/src/summary.rs
@@ -30,7 +30,11 @@ pub fn summarize_files(threads: &[ReviewThread]) -> Vec<(String, usize)> {
             *counts.entry(c.path.clone()).or_default() += 1;
         }
     }
-    counts.into_iter().collect()
+    let mut v: Vec<_> = counts.into_iter().collect();
+    // Sort by descending count to surface files with the most discussion.
+    // Break ties alphabetically for stable output.
+    v.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+    v
 }
 
 /// Write a preformatted summary to any writer.

--- a/src/summary.rs
+++ b/src/summary.rs
@@ -1,0 +1,149 @@
+//! Utilities for generating and printing review summaries.
+//!
+//! Functions in this module collate review comments by file path and render a
+//! human-readable summary to any writer or directly to stdout.
+
+use std::collections::BTreeMap;
+
+use crate::review_threads::ReviewThread;
+
+/// Produce a count of comments per file path.
+///
+/// # Examples
+///
+/// ```
+/// use vk::review_threads::{CommentConnection, ReviewComment, ReviewThread};
+/// use vk::summary::summarize_files;
+///
+/// let thread = ReviewThread {
+///     comments: CommentConnection { nodes: vec![ReviewComment { path: "a.rs".into(), ..Default::default() }], ..Default::default() },
+///     ..Default::default()
+/// };
+/// let summary = summarize_files(&[thread]);
+/// assert_eq!(summary, vec![("a.rs".into(), 1)]);
+/// ```
+#[must_use]
+pub fn summarize_files(threads: &[ReviewThread]) -> Vec<(String, usize)> {
+    let mut counts: BTreeMap<String, usize> = BTreeMap::new();
+    for t in threads {
+        for c in &t.comments.nodes {
+            *counts.entry(c.path.clone()).or_default() += 1;
+        }
+    }
+    counts.into_iter().collect()
+}
+
+/// Write a preformatted summary to any writer.
+///
+/// # Errors
+///
+/// Returns an error if writing to the provided output fails.
+///
+/// # Examples
+///
+/// ```
+/// use vk::summary::{summarize_files, write_summary};
+/// use vk::review_threads::{CommentConnection, ReviewComment, ReviewThread};
+///
+/// let thread = ReviewThread {
+///     comments: CommentConnection { nodes: vec![ReviewComment { path: "a.rs".into(), ..Default::default() }], ..Default::default() },
+///     ..Default::default()
+/// };
+/// let summary = summarize_files(&[thread]);
+/// let mut out = Vec::new();
+/// write_summary(&mut out, &summary).unwrap();
+/// assert!(String::from_utf8(out).unwrap().contains("a.rs: 1 comment"));
+/// ```
+pub fn write_summary<W: std::io::Write>(
+    mut out: W,
+    summary: &[(String, usize)],
+) -> std::io::Result<()> {
+    if summary.is_empty() {
+        return Ok(());
+    }
+    writeln!(out, "Summary:")?;
+    for (path, count) in summary {
+        let label = if *count == 1 { "comment" } else { "comments" };
+        writeln!(out, "{path}: {count} {label}")?;
+    }
+    writeln!(out)?;
+    Ok(())
+}
+
+/// Print the summary directly to stdout.
+pub fn print_summary(summary: &[(String, usize)]) {
+    let _ = write_summary(std::io::stdout().lock(), summary);
+}
+
+/// Print a closing banner once all review threads have been displayed.
+pub fn print_end_banner() {
+    println!("========== end of code review ==========");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::review_threads::{CommentConnection, ReviewComment, ReviewThread};
+
+    #[fixture]
+    fn review_comment(#[default("test.rs")] path: &str) -> ReviewComment {
+        ReviewComment {
+            path: path.into(),
+            ..Default::default()
+        }
+    }
+
+    use rstest::*;
+
+    #[rstest]
+    #[case(vec![], vec![])]
+    #[case(
+        vec![ReviewThread {
+            comments: CommentConnection {
+                nodes: vec![review_comment("a.rs"), review_comment("b.rs")],
+                ..Default::default()
+            },
+            ..Default::default()
+        }],
+        vec![("a.rs".into(), 1), ("b.rs".into(), 1)]
+    )]
+    #[case(
+        vec![ReviewThread {
+            comments: CommentConnection {
+                nodes: vec![
+                    review_comment("a.rs"),
+                    review_comment("b.rs"),
+                    review_comment("a.rs"),
+                ],
+                ..Default::default()
+            },
+            ..Default::default()
+        }],
+        vec![("a.rs".into(), 2), ("b.rs".into(), 1)]
+    )]
+    fn summarize_files_counts_comments(
+        #[case] input: Vec<ReviewThread>,
+        #[case] expected: Vec<(String, usize)>,
+    ) {
+        let result = summarize_files(&input);
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn write_summary_outputs_text() {
+        let summary = vec![("foo.rs".into(), 1)];
+        let mut buf = Vec::new();
+        write_summary(&mut buf, &summary).expect("write summary");
+        let out = String::from_utf8(buf).expect("utf8");
+        assert!(out.contains("Summary:"));
+        assert!(out.contains("foo.rs: 1 comment"));
+    }
+
+    #[test]
+    fn write_summary_handles_empty() {
+        let summary = Vec::<(String, usize)>::new();
+        let mut buf = Vec::new();
+        write_summary(&mut buf, &summary).expect("write summary");
+        assert!(buf.is_empty());
+    }
+}

--- a/src/summary.rs
+++ b/src/summary.rs
@@ -72,7 +72,9 @@ pub fn write_summary<W: std::io::Write>(
 
 /// Print the summary directly to stdout.
 pub fn print_summary(summary: &[(String, usize)]) {
-    let _ = write_summary(std::io::stdout().lock(), summary);
+    if let Err(e) = write_summary(std::io::stdout().lock(), summary) {
+        eprintln!("Failed to write summary: {e}");
+    }
 }
 
 /// Print a closing banner once all review threads have been displayed.

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -1,0 +1,19 @@
+//! Common utilities for manipulating environment variables in tests.
+
+/// Set an environment variable.
+///
+/// # Safety
+///
+/// Tests run serially so modifying process-wide state is safe here.
+pub fn set_var<K: AsRef<std::ffi::OsStr>, V: AsRef<std::ffi::OsStr>>(key: K, value: V) {
+    unsafe { std::env::set_var(key, value) }
+}
+
+/// Remove an environment variable.
+///
+/// # Safety
+///
+/// Tests run serially so modifying process-wide state is safe here.
+pub fn remove_var<K: AsRef<std::ffi::OsStr>>(key: K) {
+    unsafe { std::env::remove_var(key) }
+}

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -1,19 +1,29 @@
 //! Common utilities for manipulating environment variables in tests.
 
-/// Set an environment variable.
+/// Set an environment variable for testing.
 ///
-/// # Safety
+/// Environment manipulation is process-wide and therefore not thread-safe.
+/// Callers must ensure tests using these helpers run serially, for example by
+/// applying `#[serial]` from the `serial_test` crate to the test itself.
 ///
-/// Tests run serially so modifying process-wide state is safe here.
+/// # Examples
+///
+/// ```ignore
+/// use vk::test_utils::{set_var, remove_var};
+///
+/// set_var("MY_VAR", "1");
+/// assert_eq!(std::env::var("MY_VAR"), Ok("1".into()));
+/// remove_var("MY_VAR");
+/// ```
 pub fn set_var<K: AsRef<std::ffi::OsStr>, V: AsRef<std::ffi::OsStr>>(key: K, value: V) {
-    unsafe { std::env::set_var(key, value) }
+    // SAFETY: Tests using this helper run serially.
+    unsafe { std::env::set_var(key, value) };
 }
 
-/// Remove an environment variable.
+/// Remove an environment variable set during testing.
 ///
-/// # Safety
-///
-/// Tests run serially so modifying process-wide state is safe here.
+/// Callers must ensure tests using these helpers run serially.
 pub fn remove_var<K: AsRef<std::ffi::OsStr>>(key: K) {
-    unsafe { std::env::remove_var(key) }
+    // SAFETY: Tests using this helper run serially.
+    unsafe { std::env::remove_var(key) };
 }


### PR DESCRIPTION
## Summary
- extract review thread fetching into dedicated module
- move summary generation and banner printing into reusable helpers
- isolate configuration loading logic and test utilities

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68950702af188322b313af31cf67f3ad

## Summary by Sourcery

Modularize the main module by extracting core functionalities into dedicated components

Enhancements:
- Split main.rs functionality into new modules: review_threads for GraphQL review thread fetching, summary for review summary generation, issues for issue retrieval, config for configuration loading with reference fallback, and test_utils for shared test helpers

Tests:
- Update existing tests to use the centralized test_utils module for environment variable management