### PR TITLE
Document review thread model with class diagram

### DIFF
--- a/docs/vk-design.md
+++ b/docs/vk-design.md
@@ -80,6 +80,49 @@ sequenceDiagram
     MadSkin->>Main: print c.url
 ```
 
+## Class Diagram
+
+The diagram below outlines the relationships between review threads, comments,
+and related page information as modelled in the GraphQL schema.
+
+```mermaid
+classDiagram
+    class ReviewThread {
+        +String id
+        +bool is_resolved
+        +CommentConnection comments
+    }
+    class CommentConnection {
+        +Vec~ReviewComment~ nodes
+        +PageInfo page_info
+    }
+    class ReviewComment {
+        +String body
+        +String diff_hunk
+        +Option<i32> original_position
+        +Option<i32> position
+        +String path
+        +String url
+        +Option<User> author
+    }
+    class PageInfo {
+        +bool has_next_page
+        +Option<String> end_cursor
+    }
+    class User {
+        +String login
+    }
+    ReviewThread --> CommentConnection : comments
+    CommentConnection --> ReviewComment : nodes
+    ReviewComment --> User : author
+    ReviewThread --> PageInfo : page_info
+    CommentConnection --> PageInfo : page_info
+
+    class review_threads {
+        +fetch_review_threads(client, repo, number)
+    }
+```
+
 ## GraphQL Error Handling
 
 The diagram below illustrates how deserialisation errors surface the JSON path

--- a/docs/vk-design.md
+++ b/docs/vk-design.md
@@ -112,13 +112,13 @@ classDiagram
     class User {
         +String! login
     }
-    ReviewThread --> CommentConnection : comments
-    CommentConnection --> ReviewComment : nodes
-    ReviewComment --> User : author
-    CommentConnection --> PageInfo : pageInfo
+    ReviewThread "1" --> "1" CommentConnection : comments
+    CommentConnection "1" --> "0..*" ReviewComment : nodes
+    ReviewComment "0..1" --> "1" User : author
+    CommentConnection "1" --> "1" PageInfo : pageInfo
 
-    class ReviewThreadsService {
-        +fetchReviewThreads(client: GraphQLClient, repo: String, number: Int)
+    class ReviewThreadsService <<service>> {
+        +fetchReviewThreads(client: GraphQLClient, repo: String, number: Int): [ReviewThread!]!
     }
 ```
 

--- a/docs/vk-design.md
+++ b/docs/vk-design.md
@@ -88,38 +88,37 @@ and related page information as modelled in the GraphQL schema.
 ```mermaid
 classDiagram
     class ReviewThread {
-        +String id
-        +bool is_resolved
-        +CommentConnection comments
+        +ID! id
+        +Boolean! isResolved
+        +CommentConnection! comments
     }
     class CommentConnection {
-        +Vec~ReviewComment~ nodes
-        +PageInfo page_info
+        +[ReviewComment!]! nodes
+        +PageInfo! pageInfo
     }
     class ReviewComment {
-        +String body
-        +String diff_hunk
-        +Option<i32> original_position
-        +Option<i32> position
-        +String path
-        +String url
-        +Option<User> author
+        +String! body
+        +String! diffHunk
+        +Int originalPosition
+        +Int position
+        +String! path
+        +String! url
+        +User author
     }
     class PageInfo {
-        +bool has_next_page
-        +Option<String> end_cursor
+        +Boolean! hasNextPage
+        +String endCursor
     }
     class User {
-        +String login
+        +String! login
     }
     ReviewThread --> CommentConnection : comments
     CommentConnection --> ReviewComment : nodes
     ReviewComment --> User : author
-    ReviewThread --> PageInfo : page_info
-    CommentConnection --> PageInfo : page_info
+    CommentConnection --> PageInfo : pageInfo
 
-    class review_threads {
-        +fetch_review_threads(client, repo, number)
+    class ReviewThreadsService {
+        +fetchReviewThreads(client: GraphQLClient, repo: String, number: Int)
     }
 ```
 

--- a/docs/vk-design.md
+++ b/docs/vk-design.md
@@ -114,7 +114,7 @@ classDiagram
     }
     ReviewThread "1" --> "1" CommentConnection : comments
     CommentConnection "1" --> "0..*" ReviewComment : nodes
-    ReviewComment "0..1" --> "1" User : author
+    ReviewComment "0..*" --> "0..1" User : author
     CommentConnection "1" --> "1" PageInfo : pageInfo
 
     class ReviewThreadsService <<service>> {


### PR DESCRIPTION
## Summary
- document relationships between review threads and comments with a class diagram

## Testing
- `make fmt`
- `make lint`
- `make test`
- `make markdownlint`
- `make nixie` *(fails: libatk-1.0.so.0: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68951f89bc0c8322b9f65ed8b53a1a29

## Summary by Sourcery

Documentation:
- Add Mermaid class diagram illustrating ReviewThread, CommentConnection, ReviewComment, PageInfo, User, and their associations in the GraphQL schema