### PR TITLE
Box large VkError variants

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -137,8 +137,7 @@ impl GraphQLClient {
         T: DeserializeOwned,
     {
         let payload = json!({ "query": query, "variables": &variables });
-        let ctx = serde_json::to_string(&payload).unwrap_or_default();
-        let ctx_box = ctx.clone().boxed();
+        let ctx_box = serde_json::to_string(&payload).unwrap_or_default().boxed();
         let response = self
             .client
             .post(&self.endpoint)

--- a/src/boxed.rs
+++ b/src/boxed.rs
@@ -1,0 +1,34 @@
+//! Helpers for boxing common values.
+//!
+//! These utilities reduce repetition when converting strings into `Box<str>`,
+//! keeping the `VkError` enum compact without verbose calls to
+//! `into_boxed_str`.
+
+use std::borrow::Cow;
+
+/// Convert string-like values into `Box<str>`.
+pub trait BoxedStr {
+    /// Consume `self` and return an owned boxed string.
+    fn boxed(self) -> Box<str>;
+}
+
+impl BoxedStr for String {
+    fn boxed(self) -> Box<str> {
+        self.into_boxed_str()
+    }
+}
+
+impl BoxedStr for &str {
+    fn boxed(self) -> Box<str> {
+        self.into()
+    }
+}
+
+impl BoxedStr for Cow<'_, str> {
+    fn boxed(self) -> Box<str> {
+        match self {
+            Cow::Borrowed(s) => s.into(),
+            Cow::Owned(s) => s.into_boxed_str(),
+        }
+    }
+}

--- a/src/boxed.rs
+++ b/src/boxed.rs
@@ -1,14 +1,13 @@
-//! Helpers for boxing common values.
+//! String boxing utilities to keep error enums compact.
 //!
-//! These utilities reduce repetition when converting strings into `Box<str>`,
-//! keeping the `VkError` enum compact without verbose calls to
-//! `into_boxed_str`.
+//! These helpers reduce repetition when converting strings into `Box<str>`,
+//! letting code call `.boxed()` without verbose `into_boxed_str` calls.
 
 use std::borrow::Cow;
 
-/// Convert string-like values into `Box<str>`.
+/// Extension trait to convert string-like types into `Box<str>` without clutter.
 pub trait BoxedStr {
-    /// Consume `self` and return an owned boxed string.
+    /// Box this value as `Box<str>` without intermediate `String` allocation.
     fn boxed(self) -> Box<str>;
 }
 
@@ -30,5 +29,47 @@ impl BoxedStr for Cow<'_, str> {
             Cow::Borrowed(s) => s.into(),
             Cow::Owned(s) => s.into_boxed_str(),
         }
+    }
+}
+
+impl BoxedStr for Box<str> {
+    fn boxed(self) -> Box<str> {
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::BoxedStr;
+    use std::borrow::Cow;
+
+    #[test]
+    fn string_is_boxed() {
+        assert_eq!(&*String::from("hi").boxed(), "hi");
+    }
+
+    #[test]
+    fn str_is_boxed() {
+        assert_eq!(&*"hi".boxed(), "hi");
+    }
+
+    #[test]
+    fn cow_borrowed_is_boxed() {
+        let cow = Cow::Borrowed("hi");
+        assert_eq!(&*cow.boxed(), "hi");
+    }
+
+    #[test]
+    fn cow_owned_is_boxed() {
+        let cow: Cow<'_, str> = Cow::Owned(String::from("hi"));
+        assert_eq!(&*cow.boxed(), "hi");
+    }
+
+    #[test]
+    fn box_identity() {
+        let b: Box<str> = "hi".into();
+        let ptr = b.as_ref().as_ptr();
+        let boxed = b.boxed();
+        assert!(std::ptr::eq(ptr, boxed.as_ref().as_ptr()));
     }
 }

--- a/src/boxed.rs
+++ b/src/boxed.rs
@@ -12,18 +12,21 @@ pub trait BoxedStr {
 }
 
 impl BoxedStr for String {
+    #[inline]
     fn boxed(self) -> Box<str> {
         self.into_boxed_str()
     }
 }
 
 impl BoxedStr for &str {
+    #[inline]
     fn boxed(self) -> Box<str> {
         self.into()
     }
 }
 
 impl BoxedStr for Cow<'_, str> {
+    #[inline]
     fn boxed(self) -> Box<str> {
         match self {
             Cow::Borrowed(s) => s.into(),
@@ -33,6 +36,7 @@ impl BoxedStr for Cow<'_, str> {
 }
 
 impl BoxedStr for Box<str> {
+    #[inline]
     fn boxed(self) -> Box<str> {
         self
     }
@@ -41,28 +45,16 @@ impl BoxedStr for Box<str> {
 #[cfg(test)]
 mod tests {
     use super::BoxedStr;
+    use rstest::rstest;
     use std::borrow::Cow;
 
-    #[test]
-    fn string_is_boxed() {
-        assert_eq!(&*String::from("hi").boxed(), "hi");
-    }
-
-    #[test]
-    fn str_is_boxed() {
-        assert_eq!(&*"hi".boxed(), "hi");
-    }
-
-    #[test]
-    fn cow_borrowed_is_boxed() {
-        let cow = Cow::Borrowed("hi");
-        assert_eq!(&*cow.boxed(), "hi");
-    }
-
-    #[test]
-    fn cow_owned_is_boxed() {
-        let cow: Cow<'_, str> = Cow::Owned(String::from("hi"));
-        assert_eq!(&*cow.boxed(), "hi");
+    #[rstest]
+    #[case(String::from("hi"))]
+    #[case("hi")]
+    #[case(Cow::Borrowed("hi"))]
+    #[case(Cow::Owned(String::from("hi")))]
+    fn boxes_string_like_inputs(#[case] input: impl BoxedStr + AsRef<str>) {
+        assert_eq!(&*input.boxed(), "hi");
     }
 
     #[test]

--- a/src/boxed.rs
+++ b/src/boxed.rs
@@ -8,6 +8,16 @@ use std::borrow::Cow;
 /// Extension trait to convert string-like types into `Box<str>` without clutter.
 pub trait BoxedStr {
     /// Box this value as `Box<str>` without intermediate `String` allocation.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// use crate::boxed::BoxedStr;
+    ///
+    /// let boxed: Box<str> = String::from("hi").boxed();
+    /// assert_eq!(&*boxed, "hi");
+    /// ```
+    #[must_use]
     fn boxed(self) -> Box<str>;
 }
 
@@ -53,7 +63,7 @@ mod tests {
     #[case("hi")]
     #[case(Cow::Borrowed("hi"))]
     #[case(Cow::Owned(String::from("hi")))]
-    fn boxes_string_like_inputs(#[case] input: impl BoxedStr + AsRef<str>) {
+    fn boxes_string_like_inputs(#[case] input: impl BoxedStr) {
         assert_eq!(&*input.boxed(), "hi");
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -31,9 +31,9 @@ where
             if missing_reference(&e) {
                 Ok(cli_args)
             } else {
-                Err(Box::new(OrthoError::Gathering(e)))
+                Err(OrthoError::Gathering(e).into())
             }
         }
-        Err(e) => Err(Box::new(e)),
+        Err(e) => Err(e.into()),
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -19,13 +19,9 @@ fn missing_reference(err: &FigmentError) -> bool {
 ///
 /// # Errors
 ///
-/// Returns an [`OrthoError`] if configuration gathering fails for reasons other
-/// than a missing reference field.
-#[expect(
-    clippy::result_large_err,
-    reason = "configuration loading errors can be verbose"
-)]
-pub fn load_with_reference_fallback<T>(cli_args: T) -> Result<T, OrthoError>
+/// Returns a boxed [`OrthoError`] if configuration gathering fails for reasons
+/// other than a missing reference field.
+pub fn load_with_reference_fallback<T>(cli_args: T) -> Result<T, Box<OrthoError>>
 where
     T: OrthoConfig + serde::Serialize + Default + clap::CommandFactory + Clone,
 {
@@ -35,9 +31,9 @@ where
             if missing_reference(&e) {
                 Ok(cli_args)
             } else {
-                Err(OrthoError::Gathering(e))
+                Err(Box::new(OrthoError::Gathering(e)))
             }
         }
-        Err(e) => Err(e),
+        Err(e) => Err(Box::new(e)),
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -106,6 +106,7 @@ pub enum VkError {
     Config(#[from] Box<ortho_config::OrthoError>),
 }
 
+/// Implement `From<$source>` for `VkError` by boxing the source into `$variant`.
 macro_rules! boxed_error_from {
     ($source:ty, $variant:ident) => {
         impl From<$source> for VkError {

--- a/src/ref_parser.rs
+++ b/src/ref_parser.rs
@@ -51,7 +51,7 @@ fn parse_github_url(
     if !resource.allowed_segments().contains(segment) {
         return Some(Err(VkError::WrongResourceType {
             expected: resource.allowed_segments(),
-            found: (*segment).to_owned(),
+            found: (*segment).into(),
         }));
     }
     let number_str = parts.get(3).expect("length checked");
@@ -91,10 +91,6 @@ fn repo_from_fetch_head() -> Option<RepoInfo> {
     content.lines().find_map(parse_repo_str)
 }
 
-#[expect(
-    clippy::result_large_err,
-    reason = "VkError variants are semantically small; FIXME: consider boxing large variants"
-)]
 fn parse_reference(
     input: &str,
     default_repo: Option<&str>,
@@ -113,10 +109,6 @@ fn parse_reference(
     Err(VkError::InvalidRef)
 }
 
-#[expect(
-    clippy::result_large_err,
-    reason = "VkError variants are semantically small; FIXME: consider boxing large variants"
-)]
 pub fn parse_issue_reference(
     input: &str,
     default_repo: Option<&str>,
@@ -124,10 +116,6 @@ pub fn parse_issue_reference(
     parse_reference(input, default_repo, ResourceType::Issues)
 }
 
-#[expect(
-    clippy::result_large_err,
-    reason = "VkError variants are semantically small; FIXME: consider boxing large variants"
-)]
 pub fn parse_pr_reference(
     input: &str,
     default_repo: Option<&str>,

--- a/src/review_threads.rs
+++ b/src/review_threads.rs
@@ -6,6 +6,7 @@
 use serde::Deserialize;
 use serde_json::json;
 
+use crate::boxed::BoxedStr;
 use crate::graphql_queries::{COMMENT_QUERY, THREADS_QUERY};
 use crate::ref_parser::RepoInfo;
 use crate::{GraphQLClient, VkError, paginate};
@@ -102,7 +103,7 @@ async fn fetch_comment_page(
                     id,
                     cursor.as_deref().unwrap_or("None")
                 )
-                .into_boxed_str(),
+                .boxed(),
             )
         })?
         .comments;

--- a/src/review_threads.rs
+++ b/src/review_threads.rs
@@ -96,11 +96,14 @@ async fn fetch_comment_page(
     let conn = wrapper
         .node
         .ok_or_else(|| {
-            VkError::BadResponse(format!(
-                "Missing comment node in response (id: {}, cursor: {})",
-                id,
-                cursor.as_deref().unwrap_or("None")
-            ))
+            VkError::BadResponse(
+                format!(
+                    "Missing comment node in response (id: {}, cursor: {})",
+                    id,
+                    cursor.as_deref().unwrap_or("None")
+                )
+                .into_boxed_str(),
+            )
         })?
         .comments;
     Ok((conn.nodes, conn.page_info))


### PR DESCRIPTION
## Summary
- box large `VkError` variants and remove `result_large_err` suppressions
- return `Box<OrthoError>` from config loader to avoid large error results
- box `String` payloads when constructing `VkError` in API and parser helpers

## Testing
- `make fmt`
- `make lint`
- `make test`

closes #58

------
https://chatgpt.com/codex/tasks/task_e_689797186e688322851b9c66dc429d37

## Summary by Sourcery

Box large VkError variants and streamline error handling by boxing external errors and string payloads across the codebase, removing obsolete Clippy suppressions, and updating the configuration loader to return boxed errors.

Enhancements:
- Box reqwest::Error, std::io::Error, and ortho_config::OrthoError variants in VkError and introduce From implementations to wrap sources in Box
- Update configuration loader to return Result<T, Box<OrthoError>> and adjust error propagation accordingly
- Replace String and &str payloads with Box<str> in VkError constructors, API client, and parser modules
- Remove clippy::result_large_err suppressions and simplify function signatures now that error variants are boxed