### PR TITLE
Handle BrokenPipe gracefully

### DIFF
--- a/src/summary.rs
+++ b/src/summary.rs
@@ -4,7 +4,7 @@
 //! human-readable summary to any writer or directly to stdout.
 
 use std::collections::BTreeMap;
-use std::io::Write;
+use std::io::{ErrorKind, Write};
 
 use crate::review_threads::ReviewThread;
 
@@ -78,6 +78,9 @@ pub fn write_summary<W: std::io::Write>(
 /// Print the summary directly to stdout.
 pub fn print_summary(summary: &[(String, usize)]) {
     if let Err(e) = write_summary(std::io::stdout().lock(), summary) {
+        if e.kind() == ErrorKind::BrokenPipe {
+            return;
+        }
         eprintln!("Failed to write summary: {e}");
     }
 }

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -14,6 +14,7 @@ use assert_cmd::prelude::*;
 use predicates::str::contains;
 use serde_json::Value;
 use std::fs;
+use std::io::{BufRead, BufReader};
 use std::process::{Command, Stdio};
 use std::time::Duration;
 mod utils;
@@ -124,13 +125,11 @@ async fn pr_exits_cleanly_on_broken_pipe() {
                 .stdout(Stdio::piped())
                 .spawn()
                 .expect("spawn vk");
-            let mut head = Command::new("head")
-                .arg("-n")
-                .arg("1")
-                .stdin(child.stdout.take().expect("take stdout"))
-                .spawn()
-                .expect("spawn head");
-            head.wait().expect("wait head");
+            let stdout = child.stdout.take().expect("take stdout");
+            let mut reader = BufReader::new(stdout);
+            let mut line = String::new();
+            let _ = reader.read_line(&mut line);
+            drop(reader);
             child.wait().expect("wait vk")
         }),
     )


### PR DESCRIPTION
## Summary
- avoid logging when review/thread output hits a BrokenPipe
- write end banner via `writeln!` and surface write errors
- add regression test ensuring `vk pr` exits cleanly when piped to a short-lived reader

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6898985477208322a5415a24d283ad2d

## Summary by Sourcery

Gracefully handle BrokenPipe errors during review output and end banner printing, surface write errors via Result, and add a regression test to ensure clean exits when piping output into a reader that closes early

Enhancements:
- Suppress logging and gracefully ignore BrokenPipe errors when printing reviews, threads, and end banner
- Update print_end_banner to return a Result and use writeln! to propagate write errors

Documentation:
- Add error documentation for print_end_banner

Tests:
- Add end-to-end test to verify vk pr exits successfully when its output is piped to a short-lived reader