### PR TITLE
Add version flag to base CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,12 @@ or Claude Code (without implying association with any of these companies).
 vk pr <pull-request-url-or-number>
 ```
 
+Print the current version and exit with:
+
+```bash
+vk --version
+```
+
 `vk` now uses [OrthoConfig](https://github.com/leynos/ortho-config) v0.2.0 for
 configuration. A global `--repo` option or the `VK_REPO` environment variable
 sets the default repository when passing only a pull request number.

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,10 +54,11 @@ enum Commands {
     Issue(IssueArgs),
 }
 
-#[derive(Parser)]
+#[derive(Debug, Parser)]
 #[command(
     name = "vk",
     about = "View Komments - show unresolved PR comments",
+    version,
     subcommand_required = true,
     arg_required_else_help = true
 )]
@@ -306,6 +307,13 @@ mod tests {
             Commands::Issue(args) => assert_eq!(args.reference.as_deref(), Some("123")),
             Commands::Pr(_) => panic!("wrong variant"),
         }
+    }
+
+    #[test]
+    fn version_flag_displays_version() {
+        let err = Cli::try_parse_from(["vk", "--version"]).expect_err("display version");
+        assert_eq!(err.kind(), clap::error::ErrorKind::DisplayVersion);
+        assert!(err.to_string().contains(env!("CARGO_PKG_VERSION")));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- expose Clap's built-in version flag on the root command
- document the new `vk --version` usage

## Testing
- `make fmt`
- `make lint`
- `make test`
- `make markdownlint`
- `make nixie` *(fails: libXdamage.so.1 missing)*

------
https://chatgpt.com/codex/tasks/task_e_689a8b3c65ec83229982ff6cb6d710d6