### PR TITLE
Clarify file-filtered empty state message

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -161,11 +161,16 @@ async fn run_pr(args: PrArgs, global: &GlobalArgs) -> Result<(), VkError> {
         fetch_review_threads(&client, &repo, number).await?,
         &args.files,
     );
-    let reviews = fetch_reviews(&client, &repo, number).await?;
+    // Avoid fetching reviews when there are no unresolved threads.
     if threads.is_empty() {
-        println!("No unresolved comments.");
+        if args.files.is_empty() {
+            println!("No unresolved comments.");
+        } else {
+            println!("No unresolved comments for the specified files.");
+        }
         return Ok(());
     }
+    let reviews = fetch_reviews(&client, &repo, number).await?;
 
     let summary = summarize_files(&threads);
     print_summary(&summary);

--- a/src/main.rs
+++ b/src/main.rs
@@ -168,6 +168,13 @@ async fn run_pr(args: PrArgs, global: &GlobalArgs) -> Result<(), VkError> {
         } else {
             println!("No unresolved comments for the specified files.");
         }
+        // Preserve the end-of-review banner for consumers that parse it.
+        if let Err(e) = print_end_banner() {
+            if is_broken_pipe_io(&e) {
+                return Ok(());
+            }
+            error!("error printing end banner: {e}");
+        }
         return Ok(());
     }
     let reviews = fetch_reviews(&client, &repo, number).await?;

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,0 +1,97 @@
+//! CLI integration tests for empty-state messages.
+//!
+//! These tests verify that the `vk pr` command reports a clear message when no
+//! review comments remain, both with and without file filters.
+
+use assert_cmd::prelude::*;
+use http_body_util::Full;
+use hyper::{Response, StatusCode};
+use serde_json::json;
+use std::process::Command;
+
+mod utils;
+use utils::start_mitm;
+
+#[tokio::test]
+async fn pr_empty_state_global() {
+    let (addr, handler, shutdown) = start_mitm().await.expect("start server");
+    *handler.lock().expect("lock handler") = Box::new(move |_req| {
+        let body = json!({
+            "data": {
+                "repository": {
+                    "pullRequest": {
+                        "reviewThreads": {
+                            "nodes": [],
+                            "pageInfo": { "hasNextPage": false, "endCursor": null }
+                        }
+                    }
+                }
+            }
+        })
+        .to_string();
+        Response::builder()
+            .status(StatusCode::OK)
+            .header("Content-Type", "application/json")
+            .body(Full::from(body))
+            .expect("build response")
+    });
+
+    tokio::task::spawn_blocking(move || {
+        Command::cargo_bin("vk")
+            .expect("binary")
+            .env("GITHUB_GRAPHQL_URL", format!("http://{addr}"))
+            .env("GITHUB_TOKEN", "dummy")
+            .args(["pr", "https://github.com/leynos/shared-actions/pull/42"])
+            .assert()
+            .success()
+            .stdout("No unresolved comments.\n========== end of code review ==========\n");
+    })
+    .await
+    .expect("spawn blocking");
+    shutdown.shutdown().await;
+}
+
+#[tokio::test]
+async fn pr_empty_state_filtered() {
+    let (addr, handler, shutdown) = start_mitm().await.expect("start server");
+    *handler.lock().expect("lock handler") = Box::new(move |_req| {
+        let body = json!({
+            "data": {
+                "repository": {
+                    "pullRequest": {
+                        "reviewThreads": {
+                            "nodes": [],
+                            "pageInfo": { "hasNextPage": false, "endCursor": null }
+                        }
+                    }
+                }
+            }
+        })
+        .to_string();
+        Response::builder()
+            .status(StatusCode::OK)
+            .header("Content-Type", "application/json")
+            .body(Full::from(body))
+            .expect("build response")
+    });
+
+    tokio::task::spawn_blocking(move || {
+        Command::cargo_bin("vk")
+            .expect("binary")
+            .env("GITHUB_GRAPHQL_URL", format!("http://{addr}"))
+            .env("GITHUB_TOKEN", "dummy")
+            .args([
+                "pr",
+                "https://github.com/leynos/shared-actions/pull/42",
+                "no_such_file.rs",
+            ])
+            .assert()
+            .success()
+            .stdout(
+                "No unresolved comments for the specified files.\n========== end of code review ==========\n",
+            );
+    })
+    .await
+    .expect("spawn blocking");
+    shutdown.shutdown().await;
+}


### PR DESCRIPTION
## Summary
- Exit early when no threads remain after file filtering
- Distinguish between global and per-file empty states

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689cceb8ec508322aafe3814033e05ab

## Summary by Sourcery

Distinguish between global and file-specific empty states for unresolved comments and avoid unnecessary review fetching

Enhancements:
- Exit early without fetching reviews when no unresolved threads remain
- Print a specific empty state message when file filters are applied vs globally