### PR TITLE
Add start banner to code review output

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ sets the default repository when passing only a pull request number.
 The CLI provides two subcommands:
 
 * `pr` — show unresolved pull request comments. Output begins with a
-  `code review` banner followed by a summary of files and comment counts. When
+  `code review` banner, followed by a summary of files and comment counts. When
   finished, `vk` prints an `end of code review` banner. Pass file paths after
   the pull request to restrict output to those paths.
 * `issue` — read a GitHub issue (**to do**)

--- a/README.md
+++ b/README.md
@@ -29,11 +29,11 @@ sets the default repository when passing only a pull request number.
 
 The CLI provides two subcommands:
 
-* `pr` — show unresolved pull request comments. Output begins with a
+- `pr` — show unresolved pull request comments. Output begins with a
   `code review` banner, followed by a summary of files and comment counts. When
   finished, `vk` prints an `end of code review` banner. Pass file paths after
   the pull request to restrict output to those paths.
-* `issue` — read a GitHub issue (**to do**)
+- `issue` — read a GitHub issue (**to do**)
 
 `vk` loads default values for subcommands from configuration files and
 environment variables. When these defaults omit the required `reference` field,

--- a/README.md
+++ b/README.md
@@ -29,10 +29,11 @@ sets the default repository when passing only a pull request number.
 
 The CLI provides two subcommands:
 
-* `pr` — show unresolved pull request comments. A summary of files and comment
-  counts is printed first. When finished, `vk` prints an `end of code review`
-  banner. Pass file paths after the pull request to restrict output to those
-  paths.
+* `pr` — show unresolved pull request comments. Output begins with a `code
+  review
+  ` banner followed by a summary of files and comment counts. When finished, `vk
+  ` prints an `end of code review` banner. Pass file paths after the pull
+  request to restrict output to those paths.
 * `issue` — read a GitHub issue (**to do**)
 
 `vk` loads default values for subcommands from configuration files and

--- a/README.md
+++ b/README.md
@@ -29,10 +29,10 @@ sets the default repository when passing only a pull request number.
 
 The CLI provides two subcommands:
 
-- `pr` — show unresolved pull request comments. Output begins with a
-  `code review` banner, followed by a summary of files and comment counts. When
-  finished, `vk` prints an `end of code review` banner. Pass file paths after
-  the pull request to restrict output to those paths.
+- `pr` — show unresolved pull request comments. It begins with a `code review`
+  banner, summarises files and comment counts, then prints an
+  `end of code review` banner. Pass file paths after the pull request to
+  restrict output to those paths.
 - `issue` — read a GitHub issue (**to do**)
 
 `vk` loads default values for subcommands from configuration files and

--- a/README.md
+++ b/README.md
@@ -29,11 +29,10 @@ sets the default repository when passing only a pull request number.
 
 The CLI provides two subcommands:
 
-* `pr` — show unresolved pull request comments. Output begins with a `code
-  review
-  ` banner followed by a summary of files and comment counts. When finished, `vk
-  ` prints an `end of code review` banner. Pass file paths after the pull
-  request to restrict output to those paths.
+* `pr` — show unresolved pull request comments. Output begins with a
+  `code review` banner followed by a summary of files and comment counts. When
+  finished, `vk` prints an `end of code review` banner. Pass file paths after
+  the pull request to restrict output to those paths.
 * `issue` — read a GitHub issue (**to do**)
 
 `vk` loads default values for subcommands from configuration files and

--- a/docs/vk-design.md
+++ b/docs/vk-design.md
@@ -33,11 +33,12 @@ The code centres on three printing helpers:
 2. `write_comment` includes the diff for the first comment in a thread.
 3. `write_thread` iterates over a thread and prints each comment body in turn.
 
-`run_pr` fetches the latest review banner from each reviewer and all unresolved
+`run_pr` fetches the latest review from each reviewer and all unresolved
 threads. After printing a `code review` banner and a summary, the reviews are
-printed before individual threads. Errors from `print_thread` are surfaced via
-logging. Once all threads have been printed, a final banner reading
-`end of code review` confirms completion.
+printed before individual threads. Broken pipe errors terminate output early;
+other errors from `print_thread` and banner printing are surfaced via logging.
+Once all threads have been printed, a final banner reading `end of code review`
+confirms completion.
 
 ### CLI arguments
 
@@ -121,7 +122,7 @@ classDiagram
     ReviewComment "0..*" --> "0..1" User : author
     CommentConnection "1" --> "1" PageInfo : pageInfo
 
-    class ReviewThreadsService <<service>> {
+    class ReviewThreadsService {
         +fetchReviewThreads(client: GraphQLClient, repo: String, number: Int): [ReviewThread!]!
     }
 ```

--- a/docs/vk-design.md
+++ b/docs/vk-design.md
@@ -21,7 +21,8 @@ even when multiple comments reference the same code.
   reducing clutter when multiple remarks target the same line.
 - **Error visibility**: Failures encountered while printing a thread are logged
   to stderr instead of being silently discarded.
-- **Completion notice**: A final banner marks the *end of code review*.
+- **Banners**: Output opens with a `code review` banner and ends with an
+  `end of code review` banner, framing the printed threads.
 
 ## Architecture
 
@@ -33,10 +34,10 @@ The code centres on three printing helpers:
 3. `write_thread` iterates over a thread and prints each comment body in turn.
 
 `run_pr` fetches the latest review banner from each reviewer and all unresolved
-threads. The reviews are printed after the summary and before individual
-threads. Errors from `print_thread` are surfaced via logging. Once all threads
-have been printed, a final banner reading `end of code review` confirms
-completion.
+threads. After printing a `code review` banner and a summary, the reviews are
+printed before individual threads. Errors from `print_thread` are surfaced via
+logging. Once all threads have been printed, a final banner reading
+`end of code review` confirms completion.
 
 ### CLI arguments
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,7 +33,9 @@ pub use review_threads::{
     CommentConnection, PageInfo, ReviewComment, ReviewThread, User, fetch_review_threads,
     filter_threads_by_files,
 };
-pub use summary::{print_end_banner, print_summary, summarize_files, write_summary};
+pub use summary::{
+    print_end_banner, print_start_banner, print_summary, summarize_files, write_summary,
+};
 
 use crate::cli_args::{GlobalArgs, IssueArgs, PrArgs};
 use crate::printer::{print_reviews, write_thread};
@@ -179,6 +181,12 @@ async fn run_pr(args: PrArgs, global: &GlobalArgs) -> Result<(), VkError> {
         fetch_review_threads(&client, &repo, number).await?,
         &args.files,
     );
+    if let Err(e) = print_start_banner() {
+        if is_broken_pipe_io(&e) {
+            return Ok(());
+        }
+        error!("error printing start banner: {e}");
+    }
     // Avoid fetching reviews when there are no unresolved threads.
     if threads.is_empty() {
         if args.files.is_empty() {

--- a/src/summary.rs
+++ b/src/summary.rs
@@ -250,7 +250,7 @@ mod tests {
     }
 
     #[test]
-    fn write_start_banner_outputs_text() {
+    fn write_start_banner_outputs_exact_text() {
         let mut buf = Vec::new();
         write_start_banner(&mut buf).expect("write start banner");
         assert_eq!(

--- a/src/summary.rs
+++ b/src/summary.rs
@@ -85,6 +85,26 @@ pub fn print_summary(summary: &[(String, usize)]) {
     }
 }
 
+/// Print a banner marking the start of code review output.
+///
+/// # Errors
+///
+/// Returns an error if writing to stdout fails.
+///
+/// # Examples
+///
+/// ```
+/// use vk::summary::print_start_banner;
+/// print_start_banner().unwrap();
+/// ```
+pub fn print_start_banner() -> std::io::Result<()> {
+    writeln!(
+        std::io::stdout().lock(),
+        "========== code review =========="
+    )?;
+    Ok(())
+}
+
 /// Print a closing banner once all review threads have been displayed.
 ///
 /// # Errors

--- a/src/summary.rs
+++ b/src/summary.rs
@@ -1,12 +1,18 @@
-//! Utilities for generating and printing review summaries.
+//! Utilities for generating and printing review summaries and banners.
 //!
 //! Functions in this module collate review comments by file path and render a
-//! human-readable summary to any writer or directly to stdout.
+//! human-readable summary to any writer or directly to stdout. Banner helpers
+//! frame output with start and end markers.
 
 use std::collections::BTreeMap;
 use std::io::{ErrorKind, Write};
 
 use crate::review_threads::ReviewThread;
+
+/// Banner printed at the start of a code review.
+pub const START_BANNER: &str = "========== code review ==========";
+/// Banner printed at the end of a code review.
+pub const END_BANNER: &str = "========== end of code review ==========";
 
 /// Produce a count of comments per file path.
 ///
@@ -56,8 +62,8 @@ pub fn summarize_files(threads: &[ReviewThread]) -> Vec<(String, usize)> {
 /// };
 /// let summary = summarize_files(&[thread]);
 /// let mut out = Vec::new();
-/// write_summary(&mut out, &summary).unwrap();
-/// assert!(String::from_utf8(out).unwrap().contains("a.rs: 1 comment"));
+/// write_summary(&mut out, &summary).expect("write summary");
+/// assert!(String::from_utf8(out).expect("utf8").contains("a.rs: 1 comment"));
 /// ```
 pub fn write_summary<W: std::io::Write>(
     mut out: W,
@@ -100,10 +106,10 @@ fn write_banner<W: Write>(mut out: W, text: &str) -> std::io::Result<()> {
 /// ```
 /// use vk::summary::write_start_banner;
 /// let mut out = Vec::new();
-/// write_start_banner(&mut out).unwrap();
+/// write_start_banner(&mut out).expect("write start banner");
 /// ```
 pub fn write_start_banner<W: Write>(out: W) -> std::io::Result<()> {
-    write_banner(out, "========== code review ==========")
+    write_banner(out, START_BANNER)
 }
 
 /// Print a banner marking the start of code review output.
@@ -116,7 +122,7 @@ pub fn write_start_banner<W: Write>(out: W) -> std::io::Result<()> {
 ///
 /// ```
 /// use vk::summary::print_start_banner;
-/// print_start_banner().unwrap();
+/// print_start_banner().expect("print start banner");
 /// ```
 pub fn print_start_banner() -> std::io::Result<()> {
     write_start_banner(std::io::stdout().lock())
@@ -134,10 +140,10 @@ pub fn print_start_banner() -> std::io::Result<()> {
 /// ```
 /// use vk::summary::write_end_banner;
 /// let mut out = Vec::new();
-/// write_end_banner(&mut out).unwrap();
+/// write_end_banner(&mut out).expect("write end banner");
 /// ```
 pub fn write_end_banner<W: Write>(out: W) -> std::io::Result<()> {
-    write_banner(out, "========== end of code review ==========")
+    write_banner(out, END_BANNER)
 }
 
 /// Print a closing banner once all review threads have been displayed.
@@ -150,7 +156,7 @@ pub fn write_end_banner<W: Write>(out: W) -> std::io::Result<()> {
 ///
 /// ```
 /// use vk::summary::print_end_banner;
-/// print_end_banner().unwrap();
+/// print_end_banner().expect("print end banner");
 /// ```
 pub fn print_end_banner() -> std::io::Result<()> {
     write_end_banner(std::io::stdout().lock())
@@ -240,6 +246,26 @@ mod tests {
 
         let mut writer = ErrorWriter;
         let err = write_start_banner(&mut writer).expect_err("expect error");
+        assert_eq!(err.to_string(), "Simulated stdout write error");
+    }
+
+    #[test]
+    fn write_end_banner_propagates_io_errors() {
+        use std::io::{self, Write};
+
+        struct ErrorWriter;
+        impl Write for ErrorWriter {
+            fn write(&mut self, _buf: &[u8]) -> io::Result<usize> {
+                Err(io::Error::other("Simulated stdout write error"))
+            }
+
+            fn flush(&mut self) -> io::Result<()> {
+                Ok(())
+            }
+        }
+
+        let mut writer = ErrorWriter;
+        let err = write_end_banner(&mut writer).expect_err("expect error");
         assert_eq!(err.to_string(), "Simulated stdout write error");
     }
 }

--- a/src/summary.rs
+++ b/src/summary.rs
@@ -250,6 +250,16 @@ mod tests {
     }
 
     #[test]
+    fn write_start_banner_outputs_text() {
+        let mut buf = Vec::new();
+        write_start_banner(&mut buf).expect("write start banner");
+        assert_eq!(
+            String::from_utf8(buf).expect("utf8"),
+            format!("{START_BANNER}\n"),
+        );
+    }
+
+    #[test]
     fn write_end_banner_propagates_io_errors() {
         use std::io::{self, Write};
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -11,6 +11,8 @@ use rstest::rstest;
 use serde_json::json;
 use std::process::Command;
 
+use predicates::prelude::*;
+
 mod utils;
 use utils::start_mitm;
 
@@ -69,6 +71,64 @@ async fn pr_empty_state(
         }
 
         cmd.assert().success().stdout(output);
+    })
+    .await
+    .expect("spawn blocking");
+
+    shutdown.shutdown().await;
+}
+
+#[tokio::test]
+async fn pr_outputs_banner_when_threads_present() {
+    let (addr, handler, shutdown) = start_mitm().await.expect("start server");
+    let threads_body = json!({
+        "data": {"repository": {"pullRequest": {"reviewThreads": {
+            "nodes": [{
+                "id": "t1",
+                "isResolved": false,
+                "comments": {
+                    "nodes": [{
+                        "body": "Looks good",
+                        "diffHunk": "@@ -1 +1 @@\n-old\n+new\n",
+                        "originalPosition": null,
+                        "position": null,
+                        "path": "file.rs",
+                        "url": "http://example.com",
+                        "author": {"login": "alice"}
+                    }],
+                    "pageInfo": {"hasNextPage": false, "endCursor": null}
+                }
+            }],
+            "pageInfo": {"hasNextPage": false, "endCursor": null}
+        }}}}
+    })
+    .to_string();
+    let reviews_body = json!({
+        "data": {"repository": {"pullRequest": {"reviews": {
+            "nodes": [],
+            "pageInfo": {"hasNextPage": false, "endCursor": null}
+        }}}}
+    })
+    .to_string();
+    let mut responses = vec![threads_body, reviews_body].into_iter();
+    *handler.lock().expect("lock handler") = Box::new(move |_req| {
+        let body = responses.next().expect("response");
+        Response::builder()
+            .status(StatusCode::OK)
+            .header("Content-Type", "application/json")
+            .body(Full::from(body))
+            .expect("build response")
+    });
+
+    tokio::task::spawn_blocking(move || {
+        let mut cmd = Command::cargo_bin("vk").expect("binary");
+        cmd.env("GITHUB_GRAPHQL_URL", format!("http://{addr}"))
+            .env("GITHUB_TOKEN", "dummy")
+            .args(["pr", "https://github.com/leynos/shared-actions/pull/42"]);
+        cmd.assert().success().stdout(
+            predicate::str::starts_with("========== code review ==========\n")
+                .and(predicate::str::contains("Looks good")),
+        );
     })
     .await
     .expect("spawn blocking");

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -42,11 +42,11 @@ fn create_empty_review_handler()
 #[rstest]
 #[case(
     Vec::new(),
-    "No unresolved comments.\n========== end of code review ==========\n"
+    "========== code review ==========\nNo unresolved comments.\n========== end of code review ==========\n"
 )]
 #[case(
     vec!["no_such_file.rs"],
-    "No unresolved comments for the specified files.\n========== end of code review ==========\n",
+    "========== code review ==========\nNo unresolved comments for the specified files.\n========== end of code review ==========\n",
 )]
 #[tokio::test]
 async fn pr_empty_state(


### PR DESCRIPTION
## Summary
- print an opening `code review` banner before summaries and threads
- document the new start banner behaviour
- expect the start banner in CLI tests

## Testing
- `make fmt`
- `make lint`
- `make test`
- `./target/debug/vk pr https://github.com/leynos/wildside/pull/3 > /tmp/pr_output2.txt && head -n 20 /tmp/pr_output2.txt`

------
https://chatgpt.com/codex/tasks/task_e_689dc44978308322beed3756bf6baa4a

## Summary by Sourcery

Add a start banner to code review output and integrate it into the CLI flow

New Features:
- Add print_start_banner function and invoke it at the start of the `pr` command to output a `code review` banner

Enhancements:
- Handle errors when printing the start banner by ignoring broken pipe errors
- Frame review output with opening and closing banners

Documentation:
- Document opening and closing banners in design docs and README

Tests:
- Update CLI tests to expect the start banner before summaries