### PR TITLE
Retry GraphQL queries with backoff

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1750,6 +1750,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "precomputed-hash"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1837,6 +1846,18 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
  "rand_core",
 ]
 
@@ -1845,6 +1866,9 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.16",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -2857,6 +2881,7 @@ dependencies = [
  "markup5ever_rcdom",
  "ortho_config",
  "predicates",
+ "rand",
  "regex",
  "reqwest",
  "rstest",
@@ -3321,6 +3346,26 @@ dependencies = [
  "quote",
  "syn",
  "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ tokio = { version = "1.36.0", features = ["rt-multi-thread", "macros"] }
 termimad = "0.33.0"
 thiserror = "1.0.57"
 log = "0.4"
+rand = "0.8"
 env_logger = "0.11"
 url = "2.5.0"
 regex = "1.10.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ tokio = { version = "1.36.0", features = ["rt-multi-thread", "macros"] }
 termimad = "0.33.0"
 thiserror = "1.0.57"
 log = "0.4"
-rand = "0.8"
+rand = "0.8.5"
 env_logger = "0.11"
 url = "2.5.0"
 regex = "1.10.3"

--- a/docs/vk-design.md
+++ b/docs/vk-design.md
@@ -131,9 +131,9 @@ classDiagram
 
 GraphQL requests are retried when a network error occurs or the response lacks
 data. Retry behaviour is configurable through `RetryConfig`, covering the
-number of attempts, base delay, and jitter fraction. By default the client
+number of attempts, base delay, and jitter fraction. By default, the client
 attempts a query up to five times, waiting `200ms * 2^attempt` plus up to the
-same backoff again of random jitter, scaling jitter with the backoff so
+same backoff again of random jitter, scaling jitter with the backoff, so
 concurrent callers spread out as delays grow. Because `run_query` only returns
 after a full page has been fetched, `paginate` never appends partial results,
 preserving order and avoiding duplicates.

--- a/docs/vk-design.md
+++ b/docs/vk-design.md
@@ -130,10 +130,13 @@ classDiagram
 ## GraphQL Error Handling
 
 GraphQL requests are retried when a network error occurs or the response lacks
-data. The client waits `200ms * 2^attempt` plus up to `200ms` of random jitter
-between tries, attempting each query at most five times. Because `run_query`
-only returns after a full page has been fetched, `paginate` never appends
-partial results, preserving order and avoiding duplicates.
+data. Retry behaviour is configurable through `RetryConfig`, covering the
+number of attempts, base delay, and jitter fraction. By default the client
+attempts a query up to five times, waiting `200ms * 2^attempt` plus up to the
+same backoff again of random jitter, scaling jitter with the backoff so
+concurrent callers spread out as delays grow. Because `run_query` only returns
+after a full page has been fetched, `paginate` never appends partial results,
+preserving order and avoiding duplicates.
 
 The diagram below illustrates how deserialisation errors surface the JSON path
 and a response snippet, helping developers quickly locate schema mismatches.

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -6,11 +6,13 @@
 //! a cursor-based connection.
 
 use log::warn;
+use rand::Rng;
 use reqwest::header::{ACCEPT, AUTHORIZATION, HeaderMap, USER_AGENT};
 use serde::Deserialize;
 use serde::de::DeserializeOwned;
 use serde_json::json;
 use std::env;
+use tokio::time::{Duration, sleep};
 
 use crate::VkError;
 use crate::boxed::BoxedStr;
@@ -19,6 +21,8 @@ const GITHUB_GRAPHQL_URL: &str = "https://api.github.com/graphql";
 
 const BODY_SNIPPET_LEN: usize = 500;
 const VALUE_SNIPPET_LEN: usize = 200;
+const RETRY_ATTEMPTS: u32 = 5;
+const RETRY_BASE_DELAY: Duration = Duration::from_millis(200);
 
 fn snippet(text: &str, max: usize) -> String {
     if text.chars().count() <= max {
@@ -125,12 +129,24 @@ impl GraphQLClient {
         })
     }
 
+    fn should_retry(err: &VkError) -> bool {
+        match err {
+            VkError::RequestContext { .. } | VkError::Request(_) => true,
+            VkError::BadResponse(msg) => msg.starts_with("Missing data in response"),
+            _ => false,
+        }
+    }
+
     /// Execute a GraphQL query using this client.
     ///
     /// # Errors
     ///
     /// Returns a [`VkError`] if the request fails or the response cannot be
     /// deserialised.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the retry base delay exceeds `u64` milliseconds.
     pub async fn run_query<V, T>(&self, query: &str, variables: V) -> Result<T, VkError>
     where
         V: serde::Serialize,
@@ -138,65 +154,86 @@ impl GraphQLClient {
     {
         let payload = json!({ "query": query, "variables": &variables });
         let ctx_box = serde_json::to_string(&payload).unwrap_or_default().boxed();
-        let response = self
-            .client
-            .post(&self.endpoint)
-            .headers(self.headers.clone())
-            .json(&payload)
-            .send()
-            .await
-            .map_err(|e| VkError::RequestContext {
-                context: ctx_box.clone(),
-                source: e.into(),
-            })?;
-        let body = response.text().await.map_err(|e| VkError::RequestContext {
-            context: ctx_box.clone(),
-            source: e.into(),
-        })?;
-        if let Some(t) = &self.transcript {
-            use std::io::Write as _;
-            match t.lock() {
-                Ok(mut f) => {
-                    if let Err(e) = writeln!(
-                        f,
-                        "{}",
-                        serde_json::to_string(&json!({ "request": payload, "response": body }))
-                            .unwrap_or_default()
-                    ) {
-                        warn!("failed to write transcript: {e}");
+        let mut rng = rand::thread_rng();
+        for attempt in 0..RETRY_ATTEMPTS {
+            let result = async {
+                let response = self
+                    .client
+                    .post(&self.endpoint)
+                    .headers(self.headers.clone())
+                    .json(&payload)
+                    .send()
+                    .await
+                    .map_err(|e| VkError::RequestContext {
+                        context: ctx_box.clone(),
+                        source: e.into(),
+                    })?;
+                let body = response.text().await.map_err(|e| VkError::RequestContext {
+                    context: ctx_box.clone(),
+                    source: e.into(),
+                })?;
+                if let Some(t) = &self.transcript {
+                    use std::io::Write as _;
+                    match t.lock() {
+                        Ok(mut f) => {
+                            if let Err(e) = writeln!(
+                                f,
+                                "{}",
+                                serde_json::to_string(
+                                    &json!({ "request": payload, "response": body })
+                                )
+                                .unwrap_or_default(),
+                            ) {
+                                warn!("failed to write transcript: {e}");
+                            }
+                        }
+                        Err(_) => warn!("failed to lock transcript"),
                     }
                 }
-                Err(_) => warn!("failed to lock transcript"),
+                let resp: GraphQLResponse<serde_json::Value> = serde_json::from_str(&body)
+                    .map_err(|e| {
+                        let snippet = snippet(&body, BODY_SNIPPET_LEN);
+                        VkError::BadResponseSerde(
+                            format!("{e} | response body snippet:{snippet}").boxed(),
+                        )
+                    })?;
+                let resp_debug = format!("{resp:?}");
+                if let Some(errs) = resp.errors {
+                    return Err(handle_graphql_errors(errs));
+                }
+                let value = resp.data.ok_or_else(|| {
+                    VkError::BadResponse(format!("Missing data in response: {resp_debug}").boxed())
+                })?;
+                match serde_path_to_error::deserialize::<_, T>(value.clone()) {
+                    Ok(v) => Ok(v),
+                    Err(e) => {
+                        let snippet = snippet(
+                            &serde_json::to_string_pretty(&value).unwrap_or_default(),
+                            VALUE_SNIPPET_LEN,
+                        );
+                        let path = e.path().to_string();
+                        let inner = e.into_inner();
+                        Err(VkError::BadResponseSerde(
+                            format!("{inner} at {path} | snippet: {snippet}").boxed(),
+                        ))
+                    }
+                }
+            }
+            .await;
+            match result {
+                Ok(v) => return Ok(v),
+                Err(e) if attempt + 1 < RETRY_ATTEMPTS && Self::should_retry(&e) => {
+                    let base_ms =
+                        u64::try_from(RETRY_BASE_DELAY.as_millis()).expect("delay fits in u64");
+                    let backoff = RETRY_BASE_DELAY * 2u32.pow(attempt);
+                    let jitter = Duration::from_millis(rng.gen_range(0..base_ms));
+                    warn!("retrying GraphQL query after error: {e}");
+                    sleep(backoff + jitter).await;
+                }
+                Err(e) => return Err(e),
             }
         }
-        let resp: GraphQLResponse<serde_json::Value> =
-            serde_json::from_str(&body).map_err(|e| {
-                let snippet = snippet(&body, BODY_SNIPPET_LEN);
-                VkError::BadResponseSerde(format!("{e} | response body snippet:{snippet}").boxed())
-            })?;
-
-        let resp_debug = format!("{resp:?}");
-        if let Some(errs) = resp.errors {
-            return Err(handle_graphql_errors(errs));
-        }
-
-        let value = resp.data.ok_or_else(|| {
-            VkError::BadResponse(format!("Missing data in response: {resp_debug}").boxed())
-        })?;
-        match serde_path_to_error::deserialize::<_, T>(value.clone()) {
-            Ok(v) => Ok(v),
-            Err(e) => {
-                let snippet = snippet(
-                    &serde_json::to_string_pretty(&value).unwrap_or_default(),
-                    VALUE_SNIPPET_LEN,
-                );
-                let path = e.path().to_string();
-                let inner = e.into_inner();
-                Err(VkError::BadResponseSerde(
-                    format!("{inner} at {path} | snippet: {snippet}").boxed(),
-                ))
-            }
-        }
+        unreachable!("retry loop exhausted without returning");
     }
 }
 
@@ -256,9 +293,78 @@ where
 
 #[cfg(test)]
 mod tests {
+    //! Tests for API utilities.
+
     use super::*;
     use crate::PageInfo;
-    use std::cell::RefCell;
+    use std::{
+        cell::RefCell,
+        sync::{
+            Arc,
+            atomic::{AtomicUsize, Ordering},
+        },
+    };
+    use third_wheel::hyper::{
+        Body, Request, Response, Server, StatusCode,
+        service::{make_service_fn, service_fn},
+    };
+    use tokio::task::JoinHandle;
+
+    struct TestClient {
+        client: GraphQLClient,
+        join: JoinHandle<()>,
+    }
+
+    fn start_server(responses: Vec<String>) -> TestClient {
+        let responses = Arc::new(responses);
+        let counter = Arc::new(AtomicUsize::new(0));
+        let svc = make_service_fn(move |_conn| {
+            let responses = Arc::clone(&responses);
+            let counter = Arc::clone(&counter);
+            async move {
+                Ok::<_, std::convert::Infallible>(service_fn(move |_req: Request<Body>| {
+                    let idx = counter.fetch_add(1, Ordering::SeqCst);
+                    let body = responses
+                        .get(idx)
+                        .cloned()
+                        .unwrap_or_else(|| "{}".to_string());
+                    async move {
+                        Ok::<_, std::convert::Infallible>(
+                            Response::builder()
+                                .status(StatusCode::OK)
+                                .header("Content-Type", "application/json")
+                                .body(Body::from(body))
+                                .expect("response"),
+                        )
+                    }
+                }))
+            }
+        });
+        let server = Server::bind(&"127.0.0.1:0".parse().expect("addr")).serve(svc);
+        let addr = server.local_addr();
+        let join = tokio::spawn(async move {
+            let _ = server.await;
+        });
+        let client =
+            GraphQLClient::with_endpoint("token", &format!("http://{addr}"), None).expect("client");
+        TestClient { client, join }
+    }
+
+    #[tokio::test]
+    async fn run_query_retries_missing_data() {
+        let responses = vec![
+            "{}".to_string(),
+            serde_json::json!({"data": {"x": 1}}).to_string(),
+        ];
+        let TestClient { client, join } = start_server(responses);
+        let result: serde_json::Value = client
+            .run_query("query", serde_json::json!({}))
+            .await
+            .expect("success");
+        assert_eq!(result, serde_json::json!({"x": 1}));
+        join.abort();
+        let _ = join.await;
+    }
 
     #[tokio::test]
     async fn paginate_discards_items_on_error() {

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -29,7 +29,10 @@ pub struct RetryConfig {
     pub attempts: u32,
     /// Base delay for the exponential backoff.
     pub base_delay: Duration,
-    /// Jitter fraction of the backoff interval (1/128 fixed point).
+    /// Jitter fraction of the backoff interval as a fixed-point value.
+    ///
+    /// The actual fraction is `jitter_factor / 128`; 128 means 100% jitter
+    /// (up to the full backoff duration).
     pub jitter_factor: u32,
 }
 

--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -1,0 +1,105 @@
+//! Tests for API utilities.
+
+use super::*;
+use crate::PageInfo;
+use std::{
+    cell::RefCell,
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
+};
+use third_wheel::hyper::{
+    Body, Request, Response, Server, StatusCode,
+    service::{make_service_fn, service_fn},
+};
+use tokio::{task::JoinHandle, time::Duration};
+
+struct TestClient {
+    client: GraphQLClient,
+    join: JoinHandle<()>,
+}
+
+fn start_server(responses: Vec<String>) -> TestClient {
+    let responses = Arc::new(responses);
+    let counter = Arc::new(AtomicUsize::new(0));
+    let svc = make_service_fn(move |_conn| {
+        let responses = Arc::clone(&responses);
+        let counter = Arc::clone(&counter);
+        async move {
+            Ok::<_, std::convert::Infallible>(service_fn(move |_req: Request<Body>| {
+                let idx = counter.fetch_add(1, Ordering::SeqCst);
+                let body = responses
+                    .get(idx)
+                    .cloned()
+                    .unwrap_or_else(|| "{}".to_string());
+                async move {
+                    Ok::<_, std::convert::Infallible>(
+                        Response::builder()
+                            .status(StatusCode::OK)
+                            .header("Content-Type", "application/json")
+                            .body(Body::from(body))
+                            .expect("response"),
+                    )
+                }
+            }))
+        }
+    });
+    let server = Server::bind(&"127.0.0.1:0".parse().expect("addr")).serve(svc);
+    let addr = server.local_addr();
+    let join = tokio::spawn(async move {
+        let _ = server.await;
+    });
+    let retry = RetryConfig {
+        base_delay: Duration::from_millis(1),
+        jitter_factor: 0,
+        ..RetryConfig::default()
+    };
+    let client =
+        GraphQLClient::with_endpoint_retry("token", &format!("http://{addr}"), None, retry)
+            .expect("client");
+    TestClient { client, join }
+}
+
+#[tokio::test]
+async fn run_query_retries_missing_data() {
+    let responses = vec![
+        "{}".to_string(),
+        serde_json::json!({"data": {"x": 1}}).to_string(),
+    ];
+    let TestClient { client, join } = start_server(responses);
+    let result: serde_json::Value = client
+        .run_query("query", serde_json::json!({}))
+        .await
+        .expect("success");
+    assert_eq!(result, serde_json::json!({"x": 1}));
+    join.abort();
+    let _ = join.await;
+}
+
+#[tokio::test]
+async fn paginate_discards_items_on_error() {
+    let seen = RefCell::new(Vec::new());
+
+    let result: Result<Vec<i32>, VkError> = paginate(|cursor| {
+        let seen = &seen;
+        async move {
+            if cursor.is_none() {
+                seen.borrow_mut().push(1);
+                Ok((
+                    vec![1],
+                    PageInfo {
+                        has_next_page: true,
+                        end_cursor: Some("next".to_string()),
+                    },
+                ))
+            } else {
+                Err(VkError::ApiErrors("boom".into()))
+            }
+        }
+    })
+    .await;
+
+    assert!(result.is_err());
+    assert_eq!(seen.borrow().as_slice(), &[1]);
+}

--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -45,7 +45,7 @@ fn start_server(responses: Vec<String>) -> TestClient {
             }))
         }
     });
-    let server = Server::bind(&"127.0.0.1:0".parse().expect("addr")).serve(svc);
+    let server = Server::bind(&"127.0.0.1:0".parse().expect("parse addr")).serve(svc);
     let addr = server.local_addr();
     let join = tokio::spawn(async move {
         let _ = server.await;
@@ -57,7 +57,7 @@ fn start_server(responses: Vec<String>) -> TestClient {
     };
     let client =
         GraphQLClient::with_endpoint_retry("token", &format!("http://{addr}"), None, retry)
-            .expect("client");
+            .expect("create client");
     TestClient { client, join }
 }
 

--- a/src/review_threads/tests.rs
+++ b/src/review_threads/tests.rs
@@ -1,8 +1,8 @@
 //! Tests for review thread fetching helpers.
 
 use super::*;
+use crate::api::{GraphQLClient, RetryConfig};
 use crate::ref_parser::RepoInfo;
-use crate::{GraphQLClient, api::RetryConfig};
 use rstest::{fixture, rstest};
 use tokio::{task::JoinHandle, time::Duration};
 


### PR DESCRIPTION
## Summary
- retry GraphQL requests up to five times using exponential backoff with jitter
- add rand dependency for jitter and document networking retries
- test retry behaviour on missing data responses
- verify review thread pagination retries preserve order and skip duplicates
- document retry policy and back-off jitter in design guide

## Testing
- `make fmt`
- `make lint`
- `make test`
- `make markdownlint`
- `make nixie` *(fails: Error running command bun x --bun @mermaid-js/mermaid-cli ... FileNotFound)*

------
https://chatgpt.com/codex/tasks/task_e_689dc6305d3c83228ea414a60b6abe4d

## Summary by Sourcery

Implement retry logic for GraphQL client with exponential backoff and jitter, update tests and documentation accordingly

New Features:
- Retry GraphQL run_query up to five times on network errors or missing data responses using exponential backoff with random jitter
- Preserve pagination order and avoid duplicates when retrying review thread pagination

Enhancements:
- Add should_retry filter with constants for retry attempts and base delay and integrate rand for jitter generation

Build:
- Add rand 0.8 dependency for jitter

Documentation:
- Document the retry policy and backoff jitter in the design guide

Tests:
- Add tests for retry behaviour on missing data responses
- Add tests to verify pagination retries preserve order and skip duplicates