### PR TITLE
Specify caret version for rand

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ tokio = { version = "1.36.0", features = ["rt-multi-thread", "macros"] }
 termimad = "0.33.0"
 thiserror = "1.0.57"
 log = "0.4"
-rand = "0.8.5"
+rand = "^0.8.5"
 env_logger = "0.11"
 url = "2.5.0"
 regex = "1.10.3"


### PR DESCRIPTION
## Summary
- use an explicit caret version for `rand`

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689e0d7432c883229f597d0aadd99f60