### PR TITLE
Check release tag against Cargo.toml version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,13 +13,24 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Setup Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
       - name: Verify tag matches Cargo.toml
         run: |
           set -euo pipefail
           tag="${GITHUB_REF_NAME#v}"
-          cargo_version="$(python3 -c "import tomllib; print(tomllib.load(open('Cargo.toml', 'rb'))['package']['version'])" 2>/dev/null || echo "")"
+          toml_path="${CARGO_TOML_PATH:-Cargo.toml}"
+          cargo_version="$(
+            CARGO_TOML_PATH="$toml_path" \
+            python3 - <<'PYCODE' || echo ""
+import os, tomllib
+print(tomllib.load(open(os.environ['CARGO_TOML_PATH'],'rb'))['package']['version'])
+PYCODE
+          )"
           if [ -z "${cargo_version:-}" ]; then
-            echo "::error title=Cargo.toml parse failure::Could not find package.version in Cargo.toml"
+            echo "::error title=Cargo.toml parse failure::Could not read package.version from ${toml_path}. Ensure Python ≥3.11 (tomllib available) and that the manifest contains [package]."
             exit 1
           fi
           if [ "$tag" != "$cargo_version" ]; then


### PR DESCRIPTION
## Summary
- fail release if tag and Cargo.toml version mismatch

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a378f136e88322b0a490bc42f54ff5

## Summary by Sourcery

CI:
- Add a release workflow step that parses the Git tag and Cargo.toml version and fails the workflow on mismatch