### PR TITLE
Refactor GraphQL pagination helpers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -140,6 +140,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
+name = "backon"
+version = "1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "592277618714fbcecda9a02ba7a8781f319d26532a88553bbacc77ba5d2b3a8d"
+dependencies = [
+ "fastrand",
+ "gloo-timers",
+ "tokio",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -828,6 +839,18 @@ name = "glob"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
+
+[[package]]
+name = "gloo-timers"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "h2"
@@ -1750,15 +1773,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
-name = "ppv-lite86"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
-dependencies = [
- "zerocopy",
-]
-
-[[package]]
 name = "precomputed-hash"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1846,18 +1860,6 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
- "libc",
- "rand_chacha",
- "rand_core",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
  "rand_core",
 ]
 
@@ -1866,9 +1868,6 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom 0.2.16",
-]
 
 [[package]]
 name = "redox_syscall"
@@ -2866,6 +2865,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
+ "backon",
  "bytes 1.10.1",
  "chrono",
  "clap",
@@ -2881,7 +2881,6 @@ dependencies = [
  "markup5ever_rcdom",
  "ortho_config",
  "predicates",
- "rand",
  "regex",
  "reqwest",
  "rstest",
@@ -3346,26 +3345,6 @@ dependencies = [
  "quote",
  "syn",
  "synstructure",
-]
-
-[[package]]
-name = "zerocopy"
-version = "0.8.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
-dependencies = [
- "zerocopy-derive",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.8.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ env_logger = "0.11"
 url = "2.5.0"
 regex = "1.10.3"
 diffy = "0.4.2"
-chrono = { version = ">=0.4.20, <0.5", features = ["serde", "clock"] }
+chrono = { version = "0.4.41", features = ["serde", "clock"] }
 anyhow = "1.0"
 backon = "1.5.2"
 html5ever = "0.35.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,13 +14,13 @@ tokio = { version = "1.36.0", features = ["rt-multi-thread", "macros"] }
 termimad = "0.33.0"
 thiserror = "1.0.57"
 log = "0.4"
-rand = "0.8.5"
 env_logger = "0.11"
 url = "2.5.0"
 regex = "1.10.3"
 diffy = "0.4.2"
 chrono = { version = ">=0.4.20, <0.5", features = ["serde", "clock"] }
 anyhow = "1.0"
+backon = "1.5.2"
 html5ever = "0.35.0"
 markup5ever_rcdom = "0.35.0+unofficial"
 ortho_config = { git = "https://github.com/leynos/ortho-config", tag = "v0.2.0", default-features = false }

--- a/docs/vk-design.md
+++ b/docs/vk-design.md
@@ -52,10 +52,10 @@ accepts an optional list of file paths that limits output to matching comments.
 
 Networking logic resides in [src/api/mod.rs](../src/api/mod.rs). It exposes the
 `GraphQLClient` alongside the `run_query` helper and pagination utilities used
-throughout the application. `run_query` retries transient request failures up
-to five times with exponential backoff and random jitter. The `paginate` helper
-loops until `PageInfo` indicates completion, discarding any items fetched
-before an error occurs.
+throughout the application. `run_query` retries transient request failures with
+`backon`'s jittered exponential backoff, attempting each query up to five
+times. The `paginate` helper loops until `PageInfo` indicates completion,
+discarding any items fetched before an error occurs.
 
 ## Utility
 
@@ -133,12 +133,12 @@ classDiagram
 
 GraphQL requests are retried when a network error occurs or the response lacks
 data. Retry behaviour is configurable through `RetryConfig`, covering the
-number of attempts, base delay, and jitter fraction. By default, the client
-attempts a query up to five times, waiting `200ms * 2^attempt` plus up to the
-same backoff again of random jitter, scaling jitter with the backoff, so
-concurrent callers spread out as delays grow. Because `run_query` only returns
-after a full page has been fetched, `paginate` never appends partial results,
-preserving order and avoiding duplicates.
+number of attempts and the base delay for the exponential backoff. By default,
+the client tries a query up to five times, waiting `200ms * 2^attempt` with
+full jitter supplied by `backon` so concurrent callers spread out as delays
+grow. Because `run_query` only returns after a full page has been fetched,
+`paginate` never appends partial results, preserving order and avoiding
+duplicates.
 
 The diagram below illustrates how deserialisation errors surface the JSON path
 and a response snippet, helping developers quickly locate schema mismatches.

--- a/docs/vk-design.md
+++ b/docs/vk-design.md
@@ -51,13 +51,14 @@ their purpose and merge semantics are clear to downstream users. `PrArgs`
 accepts an optional list of file paths that limits output to matching comments.
 
 Networking logic resides in [src/api/mod.rs](../src/api/mod.rs). It exposes the
-`GraphQLClient` alongside the `run_query` helper and pagination utilities used
-throughout the application. The client employs lightweight `Token`, `Endpoint`,
-`Query`, and `Cursor` types to avoid parameter mix-ups. `run_query` retries
-transient request failures with `backon`'s jittered exponential backoff,
-attempting each query up to five times. The `paginate` helper loops until
-`PageInfo` indicates completion, discarding any items fetched before an error
-occurs.
+`GraphQLClient` alongside `run_query`, `fetch_page`, and `paginate_all` helpers
+used throughout the application. The client employs lightweight `Token`,
+`Endpoint`, `Query`, and `Cursor` types to avoid parameter mix-ups. `run_query`
+retries transient request failures with `backon`'s jittered exponential
+backoff, attempting each query up to five times. `fetch_page` merges an
+optional cursor into a variables map and rejects non-object input upfront. The
+`paginate` helper loops until `PageInfo` indicates completion, discarding any
+items fetched before an error occurs.
 
 ## Utility
 

--- a/docs/vk-design.md
+++ b/docs/vk-design.md
@@ -52,10 +52,12 @@ accepts an optional list of file paths that limits output to matching comments.
 
 Networking logic resides in [src/api/mod.rs](../src/api/mod.rs). It exposes the
 `GraphQLClient` alongside the `run_query` helper and pagination utilities used
-throughout the application. `run_query` retries transient request failures with
-`backon`'s jittered exponential backoff, attempting each query up to five
-times. The `paginate` helper loops until `PageInfo` indicates completion,
-discarding any items fetched before an error occurs.
+throughout the application. The client employs lightweight `Token`, `Endpoint`,
+`Query`, and `Cursor` types to avoid parameter mix-ups. `run_query` retries
+transient request failures with `backon`'s jittered exponential backoff,
+attempting each query up to five times. The `paginate` helper loops until
+`PageInfo` indicates completion, discarding any items fetched before an error
+occurs.
 
 ## Utility
 

--- a/docs/vk-design.md
+++ b/docs/vk-design.md
@@ -57,8 +57,8 @@ used throughout the application. The client employs lightweight `Token`,
 retries transient request failures with `backon`'s jittered exponential
 backoff, attempting each query up to five times. `fetch_page` merges an
 optional cursor into a variables map and rejects non-object input upfront. The
-`paginate` helper loops until `PageInfo` indicates completion, discarding any
-items fetched before an error occurs.
+`paginate_all` helper loops until `PageInfo` indicates completion, discarding
+any items fetched before an error occurs.
 
 ## Utility
 
@@ -140,7 +140,7 @@ number of attempts and the base delay for the exponential backoff. By default,
 the client tries a query up to five times, waiting `200ms * 2^attempt` with
 full jitter supplied by `backon` so concurrent callers spread out as delays
 grow. Because `run_query` only returns after a full page has been fetched,
-`paginate` never appends partial results, preserving order and avoiding
+`paginate_all` never appends partial results, preserving order and avoiding
 duplicates.
 
 The diagram below illustrates how deserialisation errors surface the JSON path

--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -54,9 +54,13 @@ fn start_server(responses: Vec<String>) -> TestClient {
         base_delay: Duration::from_millis(1),
         ..RetryConfig::default()
     };
-    let client =
-        GraphQLClient::with_endpoint_retry("token", &format!("http://{addr}"), None, retry)
-            .expect("create client");
+    let client = GraphQLClient::with_endpoint_retry(
+        "token",
+        format!("http://{addr}"),
+        None,
+        retry,
+    )
+    .expect("create client");
     TestClient { client, join }
 }
 
@@ -107,10 +111,10 @@ async fn fetch_page_injects_cursor() {
         let _ = server.await;
     });
     let client =
-        GraphQLClient::with_endpoint("token", &format!("http://{addr}"), None).expect("client");
+        GraphQLClient::with_endpoint("token", format!("http://{addr}"), None).expect("client");
 
     let _: serde_json::Value = client
-        .fetch_page("query", Some("abc".to_string()), serde_json::Map::new())
+        .fetch_page("query", Some("abc".into()), serde_json::Map::new())
         .await
         .expect("fetch");
 

--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -52,7 +52,6 @@ fn start_server(responses: Vec<String>) -> TestClient {
     });
     let retry = RetryConfig {
         base_delay: Duration::from_millis(1),
-        jitter_factor: 0,
         ..RetryConfig::default()
     };
     let client =

--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -2,6 +2,8 @@
 
 use super::*;
 use crate::PageInfo;
+use rstest::{fixture, rstest};
+use serde_json::{Map, Value, json};
 use std::{
     cell::RefCell,
     sync::{
@@ -59,6 +61,52 @@ fn start_server(responses: Vec<String>) -> TestClient {
     TestClient { client, join }
 }
 
+#[fixture]
+fn mock_server_with_capture() -> (GraphQLClient, Arc<Mutex<String>>, JoinHandle<()>) {
+    use third_wheel::hyper::body::to_bytes;
+
+    let captured = Arc::new(Mutex::new(String::new()));
+    let cap_clone = Arc::clone(&captured);
+    let svc = make_service_fn(move |_conn| {
+        let cap_inner = Arc::clone(&cap_clone);
+        async move {
+            Ok::<_, std::convert::Infallible>(service_fn(move |req: Request<Body>| {
+                let cap = Arc::clone(&cap_inner);
+                async move {
+                    let bytes = to_bytes(req.into_body()).await.expect("body");
+                    *cap.lock().expect("lock") = String::from_utf8(bytes.to_vec()).expect("utf8");
+                    Ok::<_, std::convert::Infallible>(
+                        Response::builder()
+                            .status(StatusCode::OK)
+                            .header("Content-Type", "application/json")
+                            .body(Body::from("{\"data\":{}}"))
+                            .expect("response"),
+                    )
+                }
+            }))
+        }
+    });
+    let server = Server::bind(&"127.0.0.1:0".parse().expect("addr")).serve(svc);
+    let addr = server.local_addr();
+    let join = tokio::spawn(async move {
+        let _ = server.await;
+    });
+    let client =
+        GraphQLClient::with_endpoint("token", format!("http://{addr}"), None).expect("client");
+
+    (client, captured, join)
+}
+
+fn assert_cursor_in_request(captured: &Arc<Mutex<String>>, expected: &str) {
+    let body = captured.lock().expect("lock").to_string();
+    let v: Value = serde_json::from_str(&body).expect("json body");
+    let cur = v
+        .get("variables")
+        .and_then(|vars| vars.get("cursor"))
+        .and_then(Value::as_str);
+    assert_eq!(cur, Some(expected));
+}
+
 #[tokio::test]
 async fn run_query_retries_missing_data() {
     let responses = vec![
@@ -76,59 +124,10 @@ async fn run_query_retries_missing_data() {
 }
 
 #[tokio::test]
-async fn fetch_page_injects_cursor() {
-    use third_wheel::hyper::body::to_bytes;
-
-    let captured = Arc::new(Mutex::new(String::new()));
-    let cap_clone = Arc::clone(&captured);
-    let svc = make_service_fn(move |_conn| {
-        let cap_inner = Arc::clone(&cap_clone);
-        async move {
-            Ok::<_, std::convert::Infallible>(service_fn(move |req: Request<Body>| {
-                let cap = Arc::clone(&cap_inner);
-                async move {
-                    let bytes = to_bytes(req.into_body()).await.expect("body");
-                    *cap.lock().expect("lock") = String::from_utf8(bytes.to_vec()).expect("utf8");
-                    Ok::<_, std::convert::Infallible>(
-                        Response::builder()
-                            .status(StatusCode::OK)
-                            .header("Content-Type", "application/json")
-                            .body(Body::from("{\"data\":{}}"))
-                            .expect("response"),
-                    )
-                }
-            }))
-        }
-    });
-    let server = Server::bind(&"127.0.0.1:0".parse().expect("addr")).serve(svc);
-    let addr = server.local_addr();
-    let join = tokio::spawn(async move {
-        let _ = server.await;
-    });
-    let client =
-        GraphQLClient::with_endpoint("token", format!("http://{addr}"), None).expect("client");
-
-    let _: serde_json::Value = client
-        .fetch_page("query", Some("abc".into()), serde_json::Map::new())
-        .await
-        .expect("fetch");
-
-    join.abort();
-    let _ = join.await;
-    let body = captured.lock().expect("lock").to_string();
-    let v: serde_json::Value = serde_json::from_str(&body).expect("json body");
-    let cur = v
-        .get("variables")
-        .and_then(|vars| vars.get("cursor"))
-        .and_then(|c| c.as_str());
-    assert_eq!(cur, Some("abc"));
-}
-
-#[tokio::test]
 async fn fetch_page_rejects_non_object_variables() {
     let client = GraphQLClient::with_endpoint("token", "http://127.0.0.1:9", None).expect("client");
     let err = client
-        .fetch_page::<serde_json::Value, _>("query", None, serde_json::json!(null))
+        .fetch_page::<Value, _>("query", None, serde_json::json!(null))
         .await
         .expect_err("error");
     match err {
@@ -139,57 +138,28 @@ async fn fetch_page_rejects_non_object_variables() {
     }
 }
 
-#[tokio::test]
-async fn fetch_page_overwrites_existing_cursor() {
-    use serde_json::json;
-    use third_wheel::hyper::body::to_bytes;
-
-    let captured = Arc::new(Mutex::new(String::new()));
-    let cap_clone = Arc::clone(&captured);
-    let svc = make_service_fn(move |_conn| {
-        let cap_inner = Arc::clone(&cap_clone);
-        async move {
-            Ok::<_, std::convert::Infallible>(service_fn(move |req: Request<Body>| {
-                let cap = Arc::clone(&cap_inner);
-                async move {
-                    let bytes = to_bytes(req.into_body()).await.expect("body");
-                    *cap.lock().expect("lock") = String::from_utf8(bytes.to_vec()).expect("utf8");
-                    Ok::<_, std::convert::Infallible>(
-                        Response::builder()
-                            .status(StatusCode::OK)
-                            .header("Content-Type", "application/json")
-                            .body(Body::from("{\"data\":{}}"))
-                            .expect("response"),
-                    )
-                }
-            }))
-        }
-    });
-    let server = Server::bind(&"127.0.0.1:0".parse().expect("addr")).serve(svc);
-    let addr = server.local_addr();
-    let join = tokio::spawn(async move {
-        let _ = server.await;
-    });
-    let client =
-        GraphQLClient::with_endpoint("token", format!("http://{addr}"), None).expect("client");
-
-    let mut vars = serde_json::Map::new();
+#[rstest]
+#[case(Map::new(), "abc", "abc")]
+#[case({
+    let mut vars = Map::new();
     vars.insert("cursor".into(), json!("stale"));
-    let _: serde_json::Value = client
-        .fetch_page("query", Some("fresh".into()), vars)
+    vars
+}, "fresh", "fresh")]
+#[tokio::test]
+async fn fetch_page_cursor_handling(
+    mock_server_with_capture: (GraphQLClient, Arc<Mutex<String>>, JoinHandle<()>),
+    #[case] variables: Map<String, Value>,
+    #[case] cursor: &str,
+    #[case] expected: &str,
+) {
+    let (client, captured, join) = mock_server_with_capture;
+    let _: Value = client
+        .fetch_page("query", Some(cursor.into()), variables)
         .await
         .expect("fetch");
-
     join.abort();
     let _ = join.await;
-    let body = captured.lock().expect("lock").to_string();
-    let v: serde_json::Value = serde_json::from_str(&body).expect("json body");
-    let cur = v
-        .get("variables")
-        .and_then(|vars| vars.get("cursor"))
-        .and_then(|c| c.as_str());
-    assert_eq!(cur, Some("fresh"));
-    assert!(!body.contains("\"cursor\":\"stale\""));
+    assert_cursor_in_request(&captured, expected);
 }
 
 #[tokio::test]

--- a/src/issues.rs
+++ b/src/issues.rs
@@ -5,6 +5,7 @@
 use serde::Deserialize;
 use serde_json::json;
 
+use crate::api::fetch_page;
 use crate::graphql_queries::ISSUE_QUERY;
 use crate::ref_parser::RepoInfo;
 use crate::{GraphQLClient, VkError};
@@ -36,15 +37,16 @@ pub async fn fetch_issue(
     repo: &RepoInfo,
     number: u64,
 ) -> Result<Issue, VkError> {
-    let data: IssueData = client
-        .run_query(
-            ISSUE_QUERY,
-            json!({
-                "owner": repo.owner.as_str(),
-                "name": repo.name.as_str(),
-                "number": number
-            }),
-        )
-        .await?;
+    let data: IssueData = fetch_page(
+        client,
+        ISSUE_QUERY,
+        None,
+        json!({
+            "owner": repo.owner.as_str(),
+            "name": repo.name.as_str(),
+            "number": number,
+        }),
+    )
+    .await?;
     Ok(data.repository.issue)
 }

--- a/src/issues.rs
+++ b/src/issues.rs
@@ -36,8 +36,8 @@ pub async fn fetch_issue(
     number: u64,
 ) -> Result<Issue, VkError> {
     let mut vars = Map::new();
-    vars.insert("owner".into(), json!(repo.owner.as_str()));
-    vars.insert("name".into(), json!(repo.name.as_str()));
+    vars.insert("owner".into(), json!(repo.owner.clone()));
+    vars.insert("name".into(), json!(repo.name.clone()));
     vars.insert("number".into(), json!(number));
     let data: IssueData = client.fetch_page(ISSUE_QUERY, None, vars).await?;
     Ok(data.repository.issue)

--- a/src/issues.rs
+++ b/src/issues.rs
@@ -2,13 +2,11 @@
 //!
 //! Currently only retrieval of a single issue by number is supported.
 
-use serde::Deserialize;
-use serde_json::json;
-
-use crate::api::fetch_page;
 use crate::graphql_queries::ISSUE_QUERY;
 use crate::ref_parser::RepoInfo;
 use crate::{GraphQLClient, VkError};
+use serde::Deserialize;
+use serde_json::{Map, json};
 
 #[derive(Deserialize)]
 struct IssueData {
@@ -37,16 +35,10 @@ pub async fn fetch_issue(
     repo: &RepoInfo,
     number: u64,
 ) -> Result<Issue, VkError> {
-    let data: IssueData = fetch_page(
-        client,
-        ISSUE_QUERY,
-        None,
-        json!({
-            "owner": repo.owner.as_str(),
-            "name": repo.name.as_str(),
-            "number": number,
-        }),
-    )
-    .await?;
+    let mut vars = Map::new();
+    vars.insert("owner".into(), json!(repo.owner.as_str()));
+    vars.insert("name".into(), json!(repo.name.as_str()));
+    vars.insert("number".into(), json!(number));
+    let data: IssueData = client.fetch_page(ISSUE_QUERY, None, vars).await?;
     Ok(data.repository.issue)
 }

--- a/src/review_threads.rs
+++ b/src/review_threads.rs
@@ -115,9 +115,7 @@ pub async fn fetch_review_threads(
     for thread in &mut threads {
         let initial = std::mem::take(&mut thread.comments);
         let mut comments = initial.nodes;
-        if initial.page_info.has_next_page
-            && let Some(cursor) = initial.page_info.end_cursor
-        {
+        if initial.page_info.has_next_page && let Some(cursor) = initial.page_info.end_cursor {
             let thread_id = thread.id.clone();
             let mut vars = Map::new();
             vars.insert("id".into(), json!(thread_id.clone()));

--- a/src/review_threads.rs
+++ b/src/review_threads.rs
@@ -6,14 +6,13 @@
 //! utilities for filtering threads by file path.
 
 use serde::Deserialize;
-use serde_json::json;
+use serde_json::{Map, json};
 use std::collections::HashSet;
 
-use crate::api::fetch_page;
 use crate::boxed::BoxedStr;
 use crate::graphql_queries::{COMMENT_QUERY, THREADS_QUERY};
 use crate::ref_parser::RepoInfo;
-use crate::{GraphQLClient, VkError, paginate};
+use crate::{GraphQLClient, VkError};
 
 #[derive(Debug, Deserialize, Default)]
 struct ThreadData {
@@ -90,55 +89,6 @@ pub struct User {
     pub login: String,
 }
 
-async fn fetch_comment_page(
-    client: &GraphQLClient,
-    id: &str,
-    cursor: Option<String>,
-) -> Result<(Vec<ReviewComment>, PageInfo), VkError> {
-    let wrapper: NodeWrapper<CommentNode> = fetch_page(
-        client,
-        COMMENT_QUERY,
-        cursor.clone(),
-        json!({ "id": id }),
-    )
-    .await?;
-    let conn = wrapper
-        .node
-        .ok_or_else(|| {
-            VkError::BadResponse(
-                format!(
-                    "Missing comment node in response (id: {}, cursor: {})",
-                    id,
-                    cursor.as_deref().unwrap_or("None")
-                )
-                .boxed(),
-            )
-        })?
-        .comments;
-    Ok((conn.nodes, conn.page_info))
-}
-
-async fn fetch_thread_page(
-    client: &GraphQLClient,
-    repo: &RepoInfo,
-    number: u64,
-    cursor: Option<String>,
-) -> Result<(Vec<ReviewThread>, PageInfo), VkError> {
-    let data: ThreadData = fetch_page(
-        client,
-        THREADS_QUERY,
-        cursor,
-        json!({
-            "owner": repo.owner.as_str(),
-            "name": repo.name.as_str(),
-            "number": number,
-        }),
-    )
-    .await?;
-    let conn = data.repository.pull_request.review_threads;
-    Ok((conn.nodes, conn.page_info))
-}
-
 /// Fetch all unresolved review threads for a pull request.
 ///
 /// # Errors
@@ -150,38 +100,47 @@ pub async fn fetch_review_threads(
     number: u64,
 ) -> Result<Vec<ReviewThread>, VkError> {
     // GitHub's API lacks filtering for unresolved threads, so filter client-side.
-    let mut threads = paginate(|cursor| fetch_thread_page(client, repo, number, cursor)).await?;
+    let mut vars = Map::new();
+    vars.insert("owner".into(), json!(repo.owner.as_str()));
+    vars.insert("name".into(), json!(repo.name.as_str()));
+    vars.insert("number".into(), json!(number));
+    let mut threads = client
+        .paginate_all(THREADS_QUERY, vars, None, |data: ThreadData| {
+            let conn = data.repository.pull_request.review_threads;
+            Ok((conn.nodes, conn.page_info))
+        })
+        .await?;
     threads.retain(|t| !t.is_resolved);
 
     for thread in &mut threads {
-        let initial = std::mem::replace(
-            &mut thread.comments,
-            CommentConnection {
-                nodes: Vec::new(),
-                page_info: PageInfo {
-                    has_next_page: false,
-                    end_cursor: None,
-                },
-            },
-        );
+        let initial = std::mem::take(&mut thread.comments);
         let mut comments = initial.nodes;
-        let mut cursor = initial.page_info.end_cursor;
-        while let Some(c) = cursor.take() {
-            let (more, info) = fetch_comment_page(client, &thread.id, Some(c)).await?;
-            comments.extend(more);
-            cursor = match (info.has_next_page, info.end_cursor) {
-                (true, Some(next)) => Some(next),
-                (true, None) => {
-                    return Err(VkError::BadResponse(
-                        format!(
-                            "hasNextPage=true but endCursor missing for thread {}",
-                            thread.id
-                        )
-                        .boxed(),
-                    ));
-                }
-                (false, _) => None,
-            };
+        if let Some(cursor) = initial.page_info.end_cursor {
+            let mut vars = Map::new();
+            vars.insert("id".into(), json!(thread.id.clone()));
+            let thread_id = thread.id.clone();
+            let mut more = client
+                .paginate_all(
+                    COMMENT_QUERY,
+                    vars,
+                    Some(cursor),
+                    move |wrapper: NodeWrapper<CommentNode>| {
+                        let conn = wrapper
+                            .node
+                            .ok_or_else(|| {
+                                VkError::BadResponse(
+                                    format!(
+                                        "Missing comment node in response for thread {thread_id}"
+                                    )
+                                    .boxed(),
+                                )
+                            })?
+                            .comments;
+                        Ok((conn.nodes, conn.page_info))
+                    },
+                )
+                .await?;
+            comments.append(&mut more);
         }
         thread.comments = CommentConnection {
             nodes: comments,

--- a/src/review_threads.rs
+++ b/src/review_threads.rs
@@ -120,7 +120,7 @@ pub async fn fetch_review_threads(
         {
             let thread_id = thread.id.clone();
             let mut vars = Map::new();
-            vars.insert("id".into(), json!(thread_id.clone()));
+            vars.insert("id".into(), json!(&thread_id));
             let mut more = client
                 .paginate_all(
                     COMMENT_QUERY,

--- a/src/review_threads.rs
+++ b/src/review_threads.rs
@@ -115,7 +115,9 @@ pub async fn fetch_review_threads(
     for thread in &mut threads {
         let initial = std::mem::take(&mut thread.comments);
         let mut comments = initial.nodes;
-        if initial.page_info.has_next_page && let Some(cursor) = initial.page_info.end_cursor {
+        if initial.page_info.has_next_page
+            && let Some(cursor) = initial.page_info.end_cursor
+        {
             let thread_id = thread.id.clone();
             let mut vars = Map::new();
             vars.insert("id".into(), json!(thread_id.clone()));

--- a/src/review_threads.rs
+++ b/src/review_threads.rs
@@ -123,7 +123,7 @@ pub async fn fetch_review_threads(
                 .paginate_all(
                     COMMENT_QUERY,
                     vars,
-                    Some(cursor),
+                    Some(cursor.into()),
                     move |wrapper: NodeWrapper<CommentNode>| {
                         let conn = wrapper
                             .node

--- a/src/review_threads/tests.rs
+++ b/src/review_threads/tests.rs
@@ -60,9 +60,13 @@ fn start_server(responses: Vec<String>) -> TestClient {
         base_delay: Duration::from_millis(1),
         ..RetryConfig::default()
     };
-    let client =
-        GraphQLClient::with_endpoint_retry("token", &format!("http://{addr}"), None, retry)
-            .expect("create client");
+    let client = GraphQLClient::with_endpoint_retry(
+        "token",
+        format!("http://{addr}"),
+        None,
+        retry,
+    )
+    .expect("create client");
     TestClient {
         client,
         join,

--- a/src/review_threads/tests.rs
+++ b/src/review_threads/tests.rs
@@ -58,7 +58,6 @@ fn start_server(responses: Vec<String>) -> TestClient {
     });
     let retry = RetryConfig {
         base_delay: Duration::from_millis(1),
-        jitter_factor: 0,
         ..RetryConfig::default()
     };
     let client =

--- a/src/review_threads/tests.rs
+++ b/src/review_threads/tests.rs
@@ -60,13 +60,8 @@ fn start_server(responses: Vec<String>) -> TestClient {
         base_delay: Duration::from_millis(1),
         ..RetryConfig::default()
     };
-    let client = GraphQLClient::with_endpoint_retry(
-        "token",
-        format!("http://{addr}"),
-        None,
-        retry,
-    )
-    .expect("create client");
+    let client = GraphQLClient::with_endpoint_retry("token", format!("http://{addr}"), None, retry)
+        .expect("create client");
     TestClient {
         client,
         join,

--- a/src/reviews.rs
+++ b/src/reviews.rs
@@ -5,10 +5,9 @@
 
 use chrono::{DateTime, Utc};
 use serde::Deserialize;
-use serde_json::json;
+use serde_json::{Map, json};
 
-use crate::api::fetch_page;
-use crate::{GraphQLClient, PageInfo, User, VkError, paginate, ref_parser::RepoInfo};
+use crate::{GraphQLClient, PageInfo, User, VkError, ref_parser::RepoInfo};
 use std::collections::HashMap;
 
 #[derive(Debug, Deserialize, Clone)]
@@ -64,33 +63,21 @@ const REVIEWS_QUERY: &str = r"
     }
 ";
 
-pub async fn fetch_review_page(
-    client: &GraphQLClient,
-    repo: &RepoInfo,
-    number: u64,
-    cursor: Option<String>,
-) -> Result<(Vec<PullRequestReview>, PageInfo), VkError> {
-    let data: ReviewData = fetch_page(
-        client,
-        REVIEWS_QUERY,
-        cursor,
-        json!({
-            "owner": repo.owner.as_str(),
-            "name": repo.name.as_str(),
-            "number": number,
-        }),
-    )
-    .await?;
-    let conn = data.repository.pull_request.reviews;
-    Ok((conn.nodes, conn.page_info))
-}
-
 pub async fn fetch_reviews(
     client: &GraphQLClient,
     repo: &RepoInfo,
     number: u64,
 ) -> Result<Vec<PullRequestReview>, VkError> {
-    paginate(|c| fetch_review_page(client, repo, number, c)).await
+    let mut vars = Map::new();
+    vars.insert("owner".into(), json!(repo.owner.as_str()));
+    vars.insert("name".into(), json!(repo.name.as_str()));
+    vars.insert("number".into(), json!(number));
+    client
+        .paginate_all(REVIEWS_QUERY, vars, None, |data: ReviewData| {
+            let conn = data.repository.pull_request.reviews;
+            Ok((conn.nodes, conn.page_info))
+        })
+        .await
 }
 
 pub fn latest_reviews(reviews: Vec<PullRequestReview>) -> Vec<PullRequestReview> {

--- a/src/reviews.rs
+++ b/src/reviews.rs
@@ -69,8 +69,8 @@ pub async fn fetch_reviews(
     number: u64,
 ) -> Result<Vec<PullRequestReview>, VkError> {
     let mut vars = Map::new();
-    vars.insert("owner".into(), json!(repo.owner.as_str()));
-    vars.insert("name".into(), json!(repo.name.as_str()));
+    vars.insert("owner".into(), json!(repo.owner.clone()));
+    vars.insert("name".into(), json!(repo.name.clone()));
     vars.insert("number".into(), json!(number));
     client
         .paginate_all(REVIEWS_QUERY, vars, None, |data: ReviewData| {

--- a/src/reviews.rs
+++ b/src/reviews.rs
@@ -7,6 +7,7 @@ use chrono::{DateTime, Utc};
 use serde::Deserialize;
 use serde_json::json;
 
+use crate::api::fetch_page;
 use crate::{GraphQLClient, PageInfo, User, VkError, paginate, ref_parser::RepoInfo};
 use std::collections::HashMap;
 
@@ -69,17 +70,17 @@ pub async fn fetch_review_page(
     number: u64,
     cursor: Option<String>,
 ) -> Result<(Vec<PullRequestReview>, PageInfo), VkError> {
-    let data: ReviewData = client
-        .run_query(
-            REVIEWS_QUERY,
-            json!({
-                "owner": repo.owner.as_str(),
-                "name": repo.name.as_str(),
-                "number": number,
-                "cursor": cursor,
-            }),
-        )
-        .await?;
+    let data: ReviewData = fetch_page(
+        client,
+        REVIEWS_QUERY,
+        cursor,
+        json!({
+            "owner": repo.owner.as_str(),
+            "name": repo.name.as_str(),
+            "number": number,
+        }),
+    )
+    .await?;
     let conn = data.repository.pull_request.reviews;
     Ok((conn.nodes, conn.page_info))
 }


### PR DESCRIPTION
## Summary
- add `fetch_page` helper to inject cursors into GraphQL variables
- use `fetch_page` in comment, thread, review, and issue queries
- test cursor injection behaviour

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a96ed2b31c8322a6c0a641abaac96a

## Summary by Sourcery

Introduce a fetch_page helper to inject cursors into GraphQL variables and refactor existing pagination functions to use it

New Features:
- Add fetch_page helper to merge optional cursor into GraphQL query variables

Enhancements:
- Refactor comment, thread, review, and issue fetching functions to use fetch_page instead of direct run_query calls

Tests:
- Add a test to verify fetch_page correctly injects the cursor into request payload