### PR TITLE
Refactor review thread fetching into modular helpers

### DIFF
--- a/src/review_threads/tests.rs
+++ b/src/review_threads/tests.rs
@@ -186,6 +186,23 @@ fn filter_threads_by_files_retains_matches() {
     assert_eq!(path, Some("README.md"));
 }
 
+#[test]
+fn filter_unresolved_threads_discards_resolved() {
+    let threads = vec![
+        ReviewThread {
+            is_resolved: false,
+            ..Default::default()
+        },
+        ReviewThread {
+            is_resolved: true,
+            ..Default::default()
+        },
+    ];
+    let filtered = filter_unresolved_threads(threads);
+    assert_eq!(filtered.len(), 1);
+    assert!(filtered.first().is_some_and(|t| !t.is_resolved));
+}
+
 #[rstest]
 #[tokio::test]
 async fn threads_with_many_comments_do_not_duplicate_first_page(


### PR DESCRIPTION
## Summary
- extract comment pagination into a dedicated `fetch_all_comments` helper
- add `filter_unresolved_threads` to remove resolved threads before hydration
- streamline `fetch_review_threads` to orchestrate new helpers
- cover unresolved filtering with a new unit test

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68aba0cfb5008322b8f66ad4d2858753