### PR TITLE
Refactor printer entry formatting

### DIFF
--- a/src/printer/mod.rs
+++ b/src/printer/mod.rs
@@ -19,7 +19,7 @@ use crate::{ReviewComment, ReviewThread};
 /// # Examples
 ///
 /// ```ignore
-/// use vk::printer::{write_entry_body, EntryDisplayInfo};
+/// use crate::printer::{write_entry_body, EntryDisplayInfo};
 /// use termimad::MadSkin;
 /// use std::borrow::Cow;
 /// let info = EntryDisplayInfo {
@@ -30,6 +30,7 @@ use crate::{ReviewComment, ReviewThread};
 /// let mut buf = Vec::new();
 /// write_entry_body(&mut buf, &MadSkin::default(), &info, "Hi").unwrap();
 /// ```
+#[derive(Debug, Clone)]
 struct EntryDisplayInfo<'a> {
     icon: &'a str,
     login: Option<&'a str>,
@@ -37,6 +38,7 @@ struct EntryDisplayInfo<'a> {
 }
 
 /// A comment or review rendered by [`write_entry`].
+#[derive(Debug, Copy, Clone)]
 enum Entry<'a> {
     Comment(&'a ReviewComment),
     Review(&'a PullRequestReview),


### PR DESCRIPTION
## Summary
- extract shared `write_entry_body` helper for printing comment bodies
- refactor `write_comment_body` and `write_review` to use the new helper
- expand unit tests for comment and review formatting

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68aba0baae1883229f32517c73bb4cc0

## Summary by Sourcery

Extract common printing logic for review comments and reviews into a shared helper and refactor existing functions to use it, while expanding tests for banner formatting and detail collapsing.

Enhancements:
- Introduce Entry and EntryDisplayInfo types and extract write_entry_body helper for shared comment/review rendering.
- Refactor write_comment_body and write_review to delegate to the new write_entry helper.

Tests:
- Add unit tests to verify banner formatting with and without author login and correct icon rendering.
- Add tests to ensure collapse_details is applied when formatting comment bodies.