### PR TITLE
Refactor pagination cursor handling

### DIFF
--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -212,3 +212,33 @@ async fn paginate_missing_cursor_errors() {
         other => panic!("unexpected result: {other:?}"),
     }
 }
+
+#[test]
+fn next_cursor_none_when_complete() {
+    let info = PageInfo {
+        has_next_page: false,
+        end_cursor: None,
+    };
+    let next = super::next_cursor(&info).expect("cursor");
+    assert!(next.is_none());
+}
+
+#[test]
+fn next_cursor_propagates_cursor() {
+    let info = PageInfo {
+        has_next_page: true,
+        end_cursor: Some("abc".into()),
+    };
+    let next = super::next_cursor(&info).expect("cursor");
+    assert_eq!(next.as_deref(), Some("abc"));
+}
+
+#[test]
+fn next_cursor_errors_without_cursor() {
+    let info = PageInfo {
+        has_next_page: true,
+        end_cursor: None,
+    };
+    let err = super::next_cursor(&info).expect_err("missing cursor");
+    assert!(matches!(err, VkError::BadResponse(_)));
+}

--- a/src/review_threads.rs
+++ b/src/review_threads.rs
@@ -9,6 +9,7 @@ use serde::Deserialize;
 use serde_json::{Map, json};
 use std::collections::HashSet;
 
+use crate::api::next_cursor;
 use crate::boxed::BoxedStr;
 use crate::graphql_queries::{COMMENT_QUERY, THREADS_QUERY};
 use crate::ref_parser::RepoInfo;
@@ -115,9 +116,7 @@ pub async fn fetch_review_threads(
     for thread in &mut threads {
         let initial = std::mem::take(&mut thread.comments);
         let mut comments = initial.nodes;
-        if initial.page_info.has_next_page
-            && let Some(cursor) = initial.page_info.end_cursor
-        {
+        if let Some(cursor) = next_cursor(&initial.page_info)? {
             let thread_id = thread.id.clone();
             let mut vars = Map::new();
             vars.insert("id".into(), json!(&thread_id));


### PR DESCRIPTION
## Summary
- extract `next_cursor` helper for PageInfo
- refactor pagination loops to use `next_cursor`
- test cursor utility behaviour

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68aba0af92948322a0658a55ef198828