### PR TITLE
Fix release workflow YAML syntax

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,8 @@
+---
+# yamllint disable rule:line-length
 name: Release Binary
 
-on:
+'on':
   push:
     tags:
       - 'v*.*.*'
@@ -26,10 +28,10 @@ jobs:
           cargo_version="$(
             CARGO_TOML_PATH="$toml_path" \
             "${{ steps.setup-python.outputs.python-path }}" - <<'PY' || echo ""
-import os, tomllib
-with open(os.environ['CARGO_TOML_PATH'], 'rb') as f:
-    print(tomllib.load(f)['package']['version'])
-PY
+            import os, tomllib
+            with open(os.environ['CARGO_TOML_PATH'], 'rb') as f:
+                print(tomllib.load(f)['package']['version'])
+            PY
           )"
           if [ -z "${cargo_version:-}" ]; then
             echo "::error title=Cargo.toml parse failure::Could not read package.version from ${toml_path}. Ensure Python ≥3.11 (tomllib available) and that the manifest contains [package], or set CARGO_TOML_PATH to the crate's Cargo.toml."


### PR DESCRIPTION
## Summary
- fix release workflow YAML parsing by quoting `on` and adding document start
- indent embedded Python block for tag verification
- disable yamllint line-length rule on workflow file

## Testing
- `uvx yamllint .github/workflows/release.yml`
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68ac0bc039f4832296c6a8ec65e9db1c