### PR TITLE
Fix release workflow asset handling

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,10 +67,12 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v4
+      - id: download
+        uses: actions/download-artifact@v4
         with:
           name: ${{ env.REPO_NAME }}
-      - uses: softprops/action-gh-release@v1
+      - uses: softprops/action-gh-release@v2
         with:
           generate_release_notes: true
-          files: ${{ env.REPO_NAME }}
+          fail_on_unmatched_files: true
+          files: ${{ steps.download.outputs.download-path }}/${{ env.REPO_NAME }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,15 +63,14 @@ jobs:
   release:
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
-      - uses: softprops/action-gh-release@v1
-        with:
-          generate_release_notes: true
-          files: target/release/${{ env.REPO_NAME }}
       - uses: actions/download-artifact@v4
         with:
           name: ${{ env.REPO_NAME }}
-      - run: gh release upload "${{ github.ref_name }}" ${{ env.REPO_NAME }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: softprops/action-gh-release@v1
+        with:
+          generate_release_notes: true
+          files: ${{ env.REPO_NAME }}


### PR DESCRIPTION
## Summary
- fix release workflow asset handling and grant write permission

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68ac578480a88322a34889a8873171ca

## Summary by Sourcery

Ensure the GitHub release workflow can upload artifacts by granting write access and consolidating upload steps through the softprops/action-gh-release action

CI:
- Grant write permission on contents for the release job
- Download build artifact and upload it using softprops/action-gh-release with the corrected files reference
- Remove the manual gh release upload step