### PR TITLE
Accept borrowed cursors for pagination

### DIFF
--- a/docs/vk-design.md
+++ b/docs/vk-design.md
@@ -53,12 +53,13 @@ accepts an optional list of file paths that limits output to matching comments.
 Networking logic resides in [src/api/mod.rs](../src/api/mod.rs). It exposes the
 `GraphQLClient` alongside `run_query`, `fetch_page`, and `paginate_all` helpers
 used throughout the application. The client employs lightweight `Token`,
-`Endpoint`, `Query`, and `Cursor` types to avoid parameter mix-ups. `run_query`
-retries transient request failures with `backon`'s jittered exponential
-backoff, attempting each query up to five times. `fetch_page` merges an
-optional cursor into a variables map and rejects non-object input upfront. The
-`paginate_all` helper loops until `PageInfo` indicates completion, discarding
-any items fetched before an error occurs.
+`Endpoint`, and `Query` types to avoid parameter mix-ups and accepts borrowed
+cursors via `Cow<'_, str>` to prevent needless allocation. `run_query` retries
+transient request failures with `backon`'s jittered exponential backoff,
+attempting each query up to five times. `fetch_page` merges an optional cursor
+into a variables map and rejects non-object input upfront. The `paginate_all`
+helper loops until `PageInfo` indicates completion, discarding any items
+fetched before an error occurs.
 
 ## Utility
 

--- a/docs/vk-design.md
+++ b/docs/vk-design.md
@@ -54,12 +54,18 @@ Networking logic resides in [src/api/mod.rs](../src/api/mod.rs). It exposes the
 `GraphQLClient` alongside `run_query`, `fetch_page`, and `paginate_all` helpers
 used throughout the application. The client employs lightweight `Token`,
 `Endpoint`, and `Query` types to avoid parameter mix-ups and accepts borrowed
-cursors via `Cow<'_, str>` to prevent needless allocation. `run_query` retries
-transient request failures with `backon`'s jittered exponential backoff,
-attempting each query up to five times. `fetch_page` merges an optional cursor
-into a variables map and rejects non-object input upfront. The `paginate_all`
-helper loops until `PageInfo` indicates completion, discarding any items
-fetched before an error occurs.
+cursors via `Cow<'_, str>` to prevent needless allocation. For example:
+
+```rust
+fetch_page("query", Some(Cow::Borrowed("c1")), vars).await?;
+fetch_page("query", Some(Cow::Owned(String::from("c2"))), vars).await?;
+```
+
+`run_query` retries transient request failures with `backon`'s jittered
+exponential backoff, attempting each query up to five times. `fetch_page`
+merges an optional cursor into a variables map and rejects non-object input
+upfront. The `paginate_all` helper loops until `PageInfo` indicates completion,
+discarding any items fetched before an error occurs.
 
 ## Utility
 

--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -5,6 +5,7 @@ use crate::PageInfo;
 use rstest::{fixture, rstest};
 use serde_json::{Map, Value, json};
 use std::{
+    borrow::Cow,
     cell::RefCell,
     sync::{
         Arc, Mutex,
@@ -154,7 +155,7 @@ async fn fetch_page_cursor_handling(
 ) {
     let (client, captured, join) = mock_server_with_capture;
     let _: Value = client
-        .fetch_page("query", Some(cursor.into()), variables)
+        .fetch_page("query", Some(Cow::Borrowed(cursor)), variables)
         .await
         .expect("fetch");
     join.abort();

--- a/src/review_threads.rs
+++ b/src/review_threads.rs
@@ -7,7 +7,7 @@
 
 use serde::Deserialize;
 use serde_json::{Map, json};
-use std::collections::HashSet;
+use std::{borrow::Cow, collections::HashSet};
 
 use crate::boxed::BoxedStr;
 use crate::graphql_queries::{COMMENT_QUERY, THREADS_QUERY};
@@ -165,7 +165,7 @@ pub async fn fetch_review_threads(
                 .paginate_all(
                     COMMENT_QUERY,
                     vars,
-                    Some(cursor.into()),
+                    Some(Cow::Borrowed(cursor)),
                     move |wrapper: NodeWrapper<CommentNode>| {
                         let conn = wrapper
                             .node

--- a/src/review_threads.rs
+++ b/src/review_threads.rs
@@ -154,7 +154,7 @@ pub async fn fetch_review_threads(
         "pull-request number {number} exceeds GraphQL Int (i32) range",
     );
     let number_i32 = i32::try_from(number).map_err(|_| VkError::InvalidNumber)?;
-  
+
     let mut vars = Map::new();
     vars.insert("owner".into(), json!(repo.owner.clone()));
     vars.insert("name".into(), json!(repo.name.clone()));

--- a/src/review_threads.rs
+++ b/src/review_threads.rs
@@ -140,59 +140,86 @@ pub async fn fetch_review_threads(
     repo: &RepoInfo,
     number: u64,
 ) -> Result<Vec<ReviewThread>, VkError> {
-    // GitHub's API lacks filtering for unresolved threads, so filter client-side.
     let mut vars = Map::new();
     vars.insert("owner".into(), json!(repo.owner.clone()));
     vars.insert("name".into(), json!(repo.name.clone()));
     vars.insert("number".into(), json!(number));
-    let mut threads = client
+
+    let threads = client
         .paginate_all(THREADS_QUERY, vars, None, |data: ThreadData| {
             let conn = data.repository.pull_request.review_threads;
             Ok((conn.nodes, conn.page_info))
         })
         .await?;
-    threads.retain(|t| !t.is_resolved);
 
+    let mut threads = filter_unresolved_threads(threads);
     for thread in &mut threads {
         let initial = std::mem::take(&mut thread.comments);
-        let mut comments = initial.nodes;
-        // Propagate invalid pagination info as an error.
-        if let Some(cursor) = initial.page_info.next_cursor()? {
-            let thread_id = thread.id.clone();
-            let mut vars = Map::new();
-            vars.insert("id".into(), json!(&thread_id));
-            let more = client
-                .paginate_all(
-                    COMMENT_QUERY,
-                    vars,
-                    Some(Cow::Borrowed(cursor)),
-                    move |wrapper: NodeWrapper<CommentNode>| {
-                        let conn = wrapper
-                            .node
-                            .ok_or_else(|| {
-                                VkError::BadResponse(
-                                    format!(
-                                        "Missing comment node in response for thread {thread_id}"
-                                    )
-                                    .boxed(),
-                                )
-                            })?
-                            .comments;
-                        Ok((conn.nodes, conn.page_info))
-                    },
-                )
-                .await?;
-            comments.extend(more);
-        }
-        thread.comments = CommentConnection {
-            nodes: comments,
-            page_info: PageInfo {
-                has_next_page: false,
-                end_cursor: None,
-            },
-        };
+        thread.comments = fetch_all_comments(client, &thread.id, initial).await?;
     }
     Ok(threads)
+}
+
+/// Fetch all comments for a thread, following pagination when required.
+///
+/// # Errors
+///
+/// Propagates any API or pagination errors from the underlying client.
+async fn fetch_all_comments(
+    client: &GraphQLClient,
+    thread_id: &str,
+    initial: CommentConnection,
+) -> Result<CommentConnection, VkError> {
+    let mut comments = initial.nodes;
+    if let Some(cursor) = initial.page_info.next_cursor()? {
+        let mut vars = Map::new();
+        vars.insert("id".into(), json!(thread_id));
+        let more = client
+            .paginate_all(
+                COMMENT_QUERY,
+                vars,
+                Some(Cow::Borrowed(cursor)),
+                move |wrapper: NodeWrapper<CommentNode>| {
+                    let conn = wrapper
+                        .node
+                        .ok_or_else(|| {
+                            VkError::BadResponse(
+                                format!("Missing comment node in response for thread {thread_id}")
+                                    .boxed(),
+                            )
+                        })?
+                        .comments;
+                    Ok((conn.nodes, conn.page_info))
+                },
+            )
+            .await?;
+        comments.extend(more);
+    }
+    Ok(CommentConnection {
+        nodes: comments,
+        page_info: PageInfo {
+            has_next_page: false,
+            end_cursor: None,
+        },
+    })
+}
+
+/// Retain only unresolved review threads.
+///
+/// # Examples
+///
+/// ```ignore
+/// use vk::review_threads::{filter_unresolved_threads, ReviewThread};
+/// let threads = vec![
+///     ReviewThread { is_resolved: true, ..Default::default() },
+///     ReviewThread { is_resolved: false, ..Default::default() },
+/// ];
+/// let filtered = filter_unresolved_threads(threads);
+/// assert_eq!(filtered.len(), 1);
+/// assert!(!filtered[0].is_resolved);
+/// ```
+fn filter_unresolved_threads(threads: Vec<ReviewThread>) -> Vec<ReviewThread> {
+    threads.into_iter().filter(|t| !t.is_resolved).collect()
 }
 
 /// Filter review threads to those whose first comment matches one of `files`.

--- a/src/review_threads.rs
+++ b/src/review_threads.rs
@@ -185,8 +185,11 @@ async fn fetch_all_comments(
     thread_id: &str,
     initial: CommentConnection,
 ) -> Result<CommentConnection, VkError> {
-    let mut comments = initial.nodes;
-    if let Some(cursor) = initial.page_info.next_cursor()? {
+    let CommentConnection {
+        nodes: mut comments,
+        page_info,
+    } = initial;
+    if let Some(cursor) = page_info.next_cursor()? {
         let mut vars = Map::new();
         vars.insert("id".into(), json!(thread_id));
         let more = client

--- a/src/review_threads.rs
+++ b/src/review_threads.rs
@@ -194,7 +194,7 @@ async fn fetch_all_comments(
                 COMMENT_QUERY,
                 vars,
                 Some(Cow::Borrowed(cursor)),
-                move |wrapper: NodeWrapper<CommentNode>| {
+                |wrapper: NodeWrapper<CommentNode>| {
                     let conn = wrapper
                         .node
                         .ok_or_else(|| {

--- a/src/review_threads/tests.rs
+++ b/src/review_threads/tests.rs
@@ -130,7 +130,7 @@ fn filter_threads_by_files_retains_matches() {
 }
 
 #[test]
-fn filter_unresolved_threads_discards_resolved() {
+fn retains_only_unresolved_threads() {
     let threads = vec![
         ReviewThread {
             is_resolved: true,

--- a/src/review_threads/tests.rs
+++ b/src/review_threads/tests.rs
@@ -186,6 +186,23 @@ fn filter_threads_by_files_retains_matches() {
     assert_eq!(path, Some("README.md"));
 }
 
+#[test]
+fn filter_unresolved_threads_discards_resolved() {
+    let threads = vec![
+        ReviewThread {
+            is_resolved: true,
+            ..Default::default()
+        },
+        ReviewThread {
+            is_resolved: false,
+            ..Default::default()
+        },
+    ];
+    let filtered = filter_unresolved_threads(threads);
+    assert_eq!(filtered.len(), 1);
+    assert!(filtered.first().is_some_and(|t| !t.is_resolved));
+}
+
 #[rstest]
 #[tokio::test]
 async fn threads_with_many_comments_do_not_duplicate_first_page(


### PR DESCRIPTION
## Summary
- allow `paginate_all` to accept borrowed cursors to avoid start cursor allocations
- pass `Cow::Borrowed` when paginating comment pages

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68adf4234b8c8322b59f65b57d97b3f4

## Summary by Sourcery

Allow pagination to work with borrowed cursors by introducing Cow<'_, str> for cursor parameters and wrapping next cursors in Owned Cow instances.

Enhancements:
- Change paginate_all signature to take start_cursor as Option<Cow<'_, str>> and use &str for the query parameter
- Use Cow to manage cursor ownership in paginate_all, avoiding extra cursor allocations
- Update fetch_review_threads to pass borrowed cursors with Cow::Borrowed instead of allocating new Cursor