### PR TITLE
Silence clap-generated lint warnings

### DIFF
--- a/src/cli_args.rs
+++ b/src/cli_args.rs
@@ -2,8 +2,8 @@
 //!
 //! Isolates clap derivations so lint expectations remain scoped, keeping
 //! `main.rs` focused on runtime logic.
-#![expect(non_snake_case, reason = "clap generates non-snake-case modules")]
-#![expect(unused_imports, reason = "clap derives import the struct internally")]
+#![allow(non_snake_case, reason = "clap generates non-snake-case modules")]
+#![allow(unused_imports, reason = "clap derives import the struct internally")]
 
 use clap::Parser;
 use ortho_config::OrthoConfig;


### PR DESCRIPTION
## Summary
- allow clap's non-snake-case modules and unused imports to avoid unfulfilled lint expectations

## Testing
- `make lint`
- `make test`
- `make markdownlint`


------
https://chatgpt.com/codex/tasks/task_e_68ae076038908322ae9dffed7591e966