### PR TITLE
Add tag name to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,6 +69,7 @@ jobs:
           name: ${{ env.REPO_NAME }}
       - uses: softprops/action-gh-release@v2
         with:
+          tag_name: ${{ github.ref_name }}
           generate_release_notes: true
           fail_on_unmatched_files: true
           files: ${{ steps.download.outputs.download-path }}/${{ env.REPO_NAME }}


### PR DESCRIPTION
## Summary
- ensure release workflow specifies tag name so the release is tied to the pushed tag

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68ae1033eef483229848f4134652da88

## Summary by Sourcery

CI:
- Add tag_name input to softprops/action-gh-release step in release workflow