### PR TITLE
Destructure comment connection before pagination

### DIFF
--- a/src/review_threads.rs
+++ b/src/review_threads.rs
@@ -185,8 +185,11 @@ async fn fetch_all_comments(
     thread_id: &str,
     initial: CommentConnection,
 ) -> Result<CommentConnection, VkError> {
-    let mut comments = initial.nodes;
-    if let Some(cursor) = initial.page_info.next_cursor()? {
+    let CommentConnection {
+        nodes: mut comments,
+        page_info,
+    } = initial;
+    if let Some(cursor) = page_info.next_cursor()? {
         let mut vars = Map::new();
         vars.insert("id".into(), json!(thread_id));
         let more = client


### PR DESCRIPTION
## Summary
- avoid partial moves in `fetch_all_comments` by destructuring the initial comment connection

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68ae3ffdcff48322b8390b7b6d80c08e

## Summary by Sourcery

Enhancements:
- Destructure the initial CommentConnection into its fields to avoid partial moves during pagination