### PR TITLE
Clarify OrthoConfig short flag generation

### DIFF
--- a/docs/ortho-config-users-guide.md
+++ b/docs/ortho-config-users-guide.md
@@ -139,10 +139,13 @@ Unknown keys will therefore silently do nothing. Developers who require
 stricter validation may add manual `compile_error!` guards.
 
 By default, each field receives a long flag derived from its name in kebab-case
-and a short flag. Collisions must be resolved explicitly via `cli_short`. Short
-flags must be single ASCII alphanumeric characters and may not use clap's
-global `-h` or `-V` options. Long flags must contain only ASCII alphanumeric
-characters, hyphens or underscores and cannot be named `help` or `version`.
+and a short flag. The short flag is generated from the field's first ASCII
+alphanumeric character; if that character is taken or reserved, its upper-case
+form is tried next. Collisions that remain must be resolved explicitly via
+`cli_short`. Short flags must be single ASCII alphanumeric characters and may
+not use clap's global `-h` or `-V` options. Long flags must contain only ASCII
+alphanumeric characters, hyphens or underscores and cannot be named `help` or
+`version`.
 
 ### Example configuration struct
 
@@ -215,7 +218,7 @@ following steps:
    1. A `--config-path` CLI argument. A hidden option is generated
       automatically by the derive macro; if the user defines a `config_path`
       field in their struct then that will override the hidden option.
-      Alternatively the environment variable `<PREFIX>CONFIG_PATH` (for
+      Alternatively, the environment variable `<PREFIX>CONFIG_PATH` (for
       example, `APP_CONFIG_PATH`; or `CONFIG_PATH` if no prefix is set) can
       specify an explicit file.
 

--- a/docs/ortho-config-users-guide.md
+++ b/docs/ortho-config-users-guide.md
@@ -139,13 +139,31 @@ Unknown keys will therefore silently do nothing. Developers who require
 stricter validation may add manual `compile_error!` guards.
 
 By default, each field receives a long flag derived from its name in kebab-case
-and a short flag. The short flag is generated from the field's first ASCII
-alphanumeric character; if that character is taken or reserved, its upper-case
-form is tried next. Collisions that remain must be resolved explicitly via
-`cli_short`. Short flags must be single ASCII alphanumeric characters and may
+and a short flag. The macro chooses the short flag using these rules:
+
+- Use the field's first ASCII alphanumeric character.
+- If that character is taken or reserved, try its upper-case form.
+- If both are unavailable, no short flag is assigned; specify `cli_short` to
+  resolve the collision.
+
+The macro does not scan other characters in the field name when deriving the
+short flag. Short flags must be single ASCII alphanumeric characters and may
 not use clap's global `-h` or `-V` options. Long flags must contain only ASCII
 alphanumeric characters, hyphens or underscores and cannot be named `help` or
 `version`.
+
+For example, when multiple fields begin with the same character, `cli_short`
+can disambiguate the final field:
+
+```rust
+#[derive(OrthoConfig)]
+struct Options {
+    port: u16,                         // -p
+    path: String,                      // -P
+    #[ortho_config(cli_short = 'r')]
+    peer: String,                      // -r via override
+}
+```
 
 ### Example configuration struct
 

--- a/docs/ortho-config-users-guide.md
+++ b/docs/ortho-config-users-guide.md
@@ -138,20 +138,21 @@ Unrecognized keys are ignored by the derive macro for forwards compatibility.
 Unknown keys will therefore silently do nothing. Developers who require
 stricter validation may add manual `compile_error!` guards.
 
-By default, each field receives a long flag derived from its name in kebab-case
-and a short flag. The macro chooses the short flag using these rules:
+By default, each field receives a long-flag derived from its name in kebab-case
+and a short-flag. The macro chooses the short-flag using these rules:
 
 - Use the field's first ASCII alphanumeric character.
-- If that character is taken or reserved, try its upper‑case form.
-- If both are unavailable, no short flag is assigned; specify `cli_short` to
+- If that character is already taken or reserved, try its upper-case form.
+- If both are unavailable, no short-flag is assigned; specify `cli_short` to
   resolve the collision.
 
-Collisions are evaluated against short flags already assigned within the same
-parser and any reserved flags.
+Collisions are evaluated against short-flags already assigned within the same
+parser and reserved characters such as clap's `-h` and `-V`. A character is
+considered taken if it matches either set.
 
 The macro does not scan other characters in the field name when deriving the
-short flag. Short flags must be single ASCII alphanumeric characters and may
-not use clap's global `-h` or `-V` options. Long flags must contain only ASCII
+short-flag. Short-flags must be single ASCII alphanumeric characters and may
+not use clap's global `-h` or `-V` options. Long-flags must contain only ASCII
 alphanumeric characters, hyphens or underscores and cannot be named `help` or
 `version`.
 

--- a/docs/ortho-config-users-guide.md
+++ b/docs/ortho-config-users-guide.md
@@ -142,9 +142,12 @@ By default, each field receives a long flag derived from its name in kebab-case
 and a short flag. The macro chooses the short flag using these rules:
 
 - Use the field's first ASCII alphanumeric character.
-- If that character is taken or reserved, try its upper-case form.
+- If that character is taken or reserved, try its upper‑case form.
 - If both are unavailable, no short flag is assigned; specify `cli_short` to
   resolve the collision.
+
+Collisions are evaluated against short flags already assigned within the same
+parser and any reserved flags.
 
 The macro does not scan other characters in the field name when deriving the
 short flag. Short flags must be single ASCII alphanumeric characters and may
@@ -237,7 +240,7 @@ following steps:
       automatically by the derive macro; if the user defines a `config_path`
       field in their struct then that will override the hidden option.
       Alternatively, the environment variable `<PREFIX>CONFIG_PATH` (for
-      example, `APP_CONFIG_PATH`; or `CONFIG_PATH` if no prefix is set) can
+      example, `APP_CONFIG_PATH`, or `CONFIG_PATH` if no prefix is set) can
       specify an explicit file.
 
    1. A dotfile named `.config.toml` or `.<prefix>.toml` in the current working


### PR DESCRIPTION
## Summary
- document how short CLI flags are derived and how collisions are resolved
- fix missing comma in config-path environment variable sentence

## Testing
- `make fmt`
- `make lint`
- `make test`
- `make markdownlint`
- `make nixie`


------
https://chatgpt.com/codex/tasks/task_e_68aead67233c832284100c83a9859868

## Summary by Sourcery

Clarify the generation and collision resolution of short CLI flags in the OrthoConfig user guide and correct a missing comma in the environment variable description.

Documentation:
- Document that short flags are derived from a field’s first ASCII alphanumeric character, with its uppercase form tried on collision, and require explicit `cli_short` if still unresolved
- Add missing comma after “Alternatively” in the environment variable `<PREFIX>CONFIG_PATH` sentence