### PR TITLE
Handle discussion comment references

### DIFF
--- a/docs/vk-design.md
+++ b/docs/vk-design.md
@@ -19,6 +19,12 @@ even when multiple comments reference the same code.
   comments for those files.
 - **Focused thread**: include a `#discussion_r<ID>` fragment in the pull
   request reference to view a single thread starting from that comment.
+- **Fragment semantics**: the unresolved filter still applies when a
+  `#discussion_r<ID>` fragment is supplied and file filters are ignored. If the
+  discussion has no unresolved comments, the tool prints an explicit message.
+- **Permalink format**: GitHub review comment links always end with a
+  `#discussion_r<ID>` fragment as documented in
+  [GitHub's guide to linking to pull request comments](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/commenting-on-a-pull-request#linking-to-a-pull-request-comment).
 - **Concise output**: Each thread shows the diff once followed by all comments,
   reducing clutter when multiple remarks target the same line.
 - **Error visibility**: Failures encountered while printing a thread are logged

--- a/docs/vk-design.md
+++ b/docs/vk-design.md
@@ -17,6 +17,8 @@ even when multiple comments reference the same code.
   colourful formatting.
 - **Targeted review**: append file paths after the pull request to show only
   comments for those files.
+- **Focused thread**: include a `#discussion_r<ID>` fragment in the pull
+  request reference to view a single thread starting from that comment.
 - **Concise output**: Each thread shows the diff once followed by all comments,
   reducing clutter when multiple remarks target the same line.
 - **Error visibility**: Failures encountered while printing a thread are logged
@@ -54,6 +56,9 @@ focused on orchestrating API calls and printing results. The public
 `GlobalArgs`, `PrArgs`, and `IssueArgs` structures are fully documented so
 their purpose and merge semantics are clear to downstream users. `PrArgs`
 accepts an optional list of file paths that limits output to matching comments.
+When the reference includes a `#discussion_r<ID>` fragment the command fetches
+all threads and selects the one containing the specified comment, trimming the
+thread so printing begins with that entry.
 
 Networking logic resides in [src/api/mod.rs](../src/api/mod.rs). It exposes the
 `GraphQLClient` alongside `run_query`, `fetch_page`, and `paginate_all` helpers

--- a/docs/vk-design.md
+++ b/docs/vk-design.md
@@ -19,9 +19,9 @@ even when multiple comments reference the same code.
   comments for those files.
 - **Focused thread**: include a `#discussion_r<ID>` fragment in the pull
   request reference to view a single thread starting from that comment.
-- **Fragment semantics**: the unresolved filter still applies when a
-  `#discussion_r<ID>` fragment is supplied, and file filters are ignored. If
-  the discussion has no unresolved comments, the tool prints an explicit
+- **Fragment semantics**: when a `#discussion_r<ID>` fragment is supplied,
+  file filters are ignored and both resolved and unresolved threads are
+  searched. If the discussion lacks comments, the tool prints an explicit
   message.
 - **Permalink format**: GitHub review comment links always end with a
   `#discussion_r<ID>` fragment as documented in
@@ -64,8 +64,8 @@ focused on orchestrating API calls and printing results. The public
 their purpose and merge semantics are clear to downstream users. `PrArgs`
 accepts an optional list of file paths that limits output to matching comments.
 When the reference includes a `#discussion_r<ID>` fragment, the command fetches
-all threads and selects the one containing the specified comment, trimming the
-thread so printing begins with that entry.
+all threads, including resolved ones, and selects the one containing the
+specified comment, trimming the thread so printing begins with that entry.
 
 Networking logic resides in [src/api/mod.rs](../src/api/mod.rs). It exposes the
 `GraphQLClient` alongside `run_query`, `fetch_page`, and `paginate_all` helpers

--- a/docs/vk-design.md
+++ b/docs/vk-design.md
@@ -20,8 +20,9 @@ even when multiple comments reference the same code.
 - **Focused thread**: include a `#discussion_r<ID>` fragment in the pull
   request reference to view a single thread starting from that comment.
 - **Fragment semantics**: the unresolved filter still applies when a
-  `#discussion_r<ID>` fragment is supplied and file filters are ignored. If the
-  discussion has no unresolved comments, the tool prints an explicit message.
+  `#discussion_r<ID>` fragment is supplied, and file filters are ignored. If
+  the discussion has no unresolved comments, the tool prints an explicit
+  message.
 - **Permalink format**: GitHub review comment links always end with a
   `#discussion_r<ID>` fragment as documented in
   [GitHub's guide to linking to pull request comments](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/commenting-on-a-pull-request#linking-to-a-pull-request-comment).
@@ -62,7 +63,7 @@ focused on orchestrating API calls and printing results. The public
 `GlobalArgs`, `PrArgs`, and `IssueArgs` structures are fully documented so
 their purpose and merge semantics are clear to downstream users. `PrArgs`
 accepts an optional list of file paths that limits output to matching comments.
-When the reference includes a `#discussion_r<ID>` fragment the command fetches
+When the reference includes a `#discussion_r<ID>` fragment, the command fetches
 all threads and selects the one containing the specified comment, trimming the
 thread so printing begins with that entry.
 

--- a/src/cli_args.rs
+++ b/src/cli_args.rs
@@ -40,9 +40,9 @@ impl GlobalArgs {
 #[derive(Parser, Deserialize, Serialize, Debug, OrthoConfig, Clone, Default)]
 #[ortho_config(prefix = "VK")]
 pub struct PrArgs {
-    /// Pull request URL or number. Passing a `#discussion_r<ID>` fragment
-    /// shows only that discussion thread. The unresolved filter remains active
-    /// and file filters are ignored.
+    /// Pull request URL or number.
+    /// Passing a `#discussion_r<ID>` fragment shows only that discussion thread; file
+    /// filters are ignored and unresolved filtering still applies.
     #[arg(required = true)]
     // Clap marks the argument as required so parsing yields `Some(value)`. The
     // `Option` allows `PrArgs::default()` and config merging to leave it unset.

--- a/src/cli_args.rs
+++ b/src/cli_args.rs
@@ -40,7 +40,7 @@ impl GlobalArgs {
 #[derive(Parser, Deserialize, Serialize, Debug, OrthoConfig, Clone, Default)]
 #[ortho_config(prefix = "VK")]
 pub struct PrArgs {
-    /// Pull request URL or number
+    /// Pull request URL or number. Passing a `#discussion_r<ID>` fragment shows only that discussion thread.
     #[arg(required = true)]
     // Clap marks the argument as required so parsing yields `Some(value)`. The
     // `Option` allows `PrArgs::default()` and config merging to leave it unset.

--- a/src/cli_args.rs
+++ b/src/cli_args.rs
@@ -40,7 +40,9 @@ impl GlobalArgs {
 #[derive(Parser, Deserialize, Serialize, Debug, OrthoConfig, Clone, Default)]
 #[ortho_config(prefix = "VK")]
 pub struct PrArgs {
-    /// Pull request URL or number. Passing a `#discussion_r<ID>` fragment shows only that discussion thread.
+    /// Pull request URL or number. Passing a `#discussion_r<ID>` fragment
+    /// shows only that discussion thread. The unresolved filter remains active
+    /// and file filters are ignored.
     #[arg(required = true)]
     // Clap marks the argument as required so parsing yields `Some(value)`. The
     // `Option` allows `PrArgs::default()` and config merging to leave it unset.

--- a/src/main.rs
+++ b/src/main.rs
@@ -317,6 +317,9 @@ async fn run_pr(args: PrArgs, global: &GlobalArgs) -> Result<(), VkError> {
     };
 
     let threads = {
+        // fetch_review_threads returns only unresolved threads
+        // When a discussion fragment is given we ignore file filters and
+        // slice the thread so printing starts at the referenced comment.
         let all = fetch_review_threads(&client, &repo, number).await?;
         if let Some(comment_id) = comment {
             thread_for_comment(all, comment_id).into_iter().collect()

--- a/src/ref_parser.rs
+++ b/src/ref_parser.rs
@@ -1,4 +1,4 @@
-//! Parse pull request and issue references into repository and number pairs.
+//! Parse pull request and issue references into repository and number pairs, optionally including discussion comment IDs.
 
 use crate::VkError;
 use regex::Regex;
@@ -260,5 +260,15 @@ mod tests {
         assert_eq!(repo.name, "repo");
         assert_eq!(number, 1);
         assert_eq!(comment, Some(99));
+    }
+
+    use rstest::rstest;
+
+    #[rstest]
+    #[case("https://github.com/o/r/pull/1#discussion_r")]
+    #[case("https://github.com/o/r/pull/1#discussion_rabc")]
+    fn parse_pr_thread_reference_rejects_bad_fragment(#[case] input: &str) {
+        let err = parse_pr_thread_reference(input, None).expect_err("invalid ref");
+        assert!(matches!(err, VkError::InvalidRef));
     }
 }

--- a/src/ref_parser.rs
+++ b/src/ref_parser.rs
@@ -129,6 +129,18 @@ pub fn parse_pr_reference(
 /// and an optional `#discussion_r` fragment. Returns the repository, pull
 /// request number, and `Some(comment_id)` when a valid fragment is present.
 ///
+/// # Examples
+///
+/// ```
+/// # use crate::ref_parser::parse_pr_thread_reference;
+/// let (repo, number, comment) = parse_pr_thread_reference("https://github.com/o/r/pull/1#discussion_r2", None)
+///     .expect("valid reference");
+/// assert_eq!(repo.owner, "o");
+/// assert_eq!(repo.name, "r");
+/// assert_eq!(number, 1);
+/// assert_eq!(comment, Some(2));
+/// ```
+///
 /// # Errors
 ///
 /// Returns [`VkError::InvalidRef`] when the fragment is present but empty or

--- a/src/ref_parser.rs
+++ b/src/ref_parser.rs
@@ -123,6 +123,16 @@ pub fn parse_pr_reference(
     parse_reference(input, default_repo, ResourceType::PullRequest)
 }
 
+/// Parse a pull request reference with an optional discussion fragment.
+///
+/// Accepts either a full GitHub URL or a bare number (using `default_repo`),
+/// and an optional `#discussion_r` fragment. Returns the repository, pull
+/// request number, and `Some(comment_id)` when a valid fragment is present.
+///
+/// # Errors
+///
+/// Returns [`VkError::InvalidRef`] when the fragment is present but empty or
+/// non-numeric, or when the input is not a valid pull request reference.
 pub fn parse_pr_thread_reference(
     input: &str,
     default_repo: Option<&str>,

--- a/src/ref_parser.rs
+++ b/src/ref_parser.rs
@@ -123,6 +123,23 @@ pub fn parse_pr_reference(
     parse_reference(input, default_repo, ResourceType::PullRequest)
 }
 
+pub fn parse_pr_thread_reference(
+    input: &str,
+    default_repo: Option<&str>,
+) -> Result<(RepoInfo, u64, Option<u64>), VkError> {
+    const FRAG: &str = "#discussion_r";
+    let (base, comment) = match input.split_once(FRAG) {
+        Some((base, id)) if !id.is_empty() => {
+            let cid = id.parse().map_err(|_| VkError::InvalidRef)?;
+            (base, Some(cid))
+        }
+        Some(_) => return Err(VkError::InvalidRef),
+        None => (input, None),
+    };
+    let (repo, number) = parse_pr_reference(base, default_repo)?;
+    Ok((repo, number, comment))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -232,5 +249,16 @@ mod tests {
         assert_eq!(repo.owner, "baz");
         assert_eq!(repo.name, "qux");
         assert_eq!(number, 8);
+    }
+
+    #[test]
+    fn parse_pr_thread_reference_with_comment() {
+        let (repo, number, comment) =
+            parse_pr_thread_reference("https://github.com/owner/repo/pull/1#discussion_r99", None)
+                .expect("parse");
+        assert_eq!(repo.owner, "owner");
+        assert_eq!(repo.name, "repo");
+        assert_eq!(number, 1);
+        assert_eq!(comment, Some(99));
     }
 }

--- a/src/review_threads.rs
+++ b/src/review_threads.rs
@@ -197,6 +197,84 @@ pub async fn fetch_review_threads(
     Ok(threads)
 }
 
+/// Fetch review threads from a pull request.
+///
+/// When `include_resolved` is true, returns both resolved and unresolved
+/// threads. When false, returns only unresolved threads (same as
+/// [`fetch_review_threads`]).
+///
+/// This function follows the same pagination and validation logic as
+/// [`fetch_review_threads`] but bypasses the unresolved filtering when
+/// requested.
+///
+/// # Examples
+/// ```no_run
+/// use vk::{api::GraphQLClient, ref_parser::RepoInfo};
+/// # async fn run() -> Result<(), vk::VkError> {
+/// let client = GraphQLClient::new("token", None).expect("client");
+/// let repo = RepoInfo { owner: "o".into(), name: "r".into() };
+/// let threads = vk::review_threads::fetch_review_threads_with_resolution(
+///     &client,
+///     &repo,
+///     1,
+///     true,
+/// ).await?;
+/// assert!(!threads.is_empty());
+/// # Ok(())
+/// # }
+/// ```
+///
+/// # Errors
+///
+/// Returns [`VkError::InvalidNumber`] if `number` exceeds `i32::MAX`, or a
+/// general [`VkError`] if any API request fails or the response is malformed.
+pub async fn fetch_review_threads_with_resolution(
+    client: &GraphQLClient,
+    repo: &RepoInfo,
+    number: u64,
+    include_resolved: bool,
+) -> Result<Vec<ReviewThread>, VkError> {
+    debug_assert!(
+        i32::try_from(number).is_ok(),
+        "pull-request number {number} exceeds GraphQL Int (i32) range",
+    );
+    let number_i32 = i32::try_from(number).map_err(|_| VkError::InvalidNumber)?;
+
+    let mut vars = Map::new();
+    vars.insert("owner".into(), json!(repo.owner.clone()));
+    vars.insert("name".into(), json!(repo.name.clone()));
+    vars.insert("number".into(), json!(number_i32));
+
+    let threads = client
+        .paginate_all(THREADS_QUERY, vars, None, |data: ThreadData| {
+            let conn = data.repository.pull_request.review_threads;
+            Ok((conn.nodes, conn.page_info))
+        })
+        .await?;
+
+    // Apply unresolved filtering only when include_resolved is false
+    let mut threads = if include_resolved {
+        threads
+    } else {
+        filter_unresolved_threads(threads)
+    };
+
+    // Rest of the function remains identical to fetch_review_threads
+    for thread in &mut threads {
+        let initial = std::mem::take(&mut thread.comments);
+        thread.comments = fetch_all_comments(client, &thread.id, initial).await?;
+        for (idx, comment) in thread.comments.nodes.iter().enumerate() {
+            if comment.path.trim().is_empty() {
+                return Err(VkError::EmptyCommentPath {
+                    thread_id: thread.id.clone().into_boxed_str(),
+                    index: idx,
+                });
+            }
+        }
+    }
+    Ok(threads)
+}
+
 /// Fetch all comments for a thread, following pagination when required.
 ///
 /// # Errors

--- a/src/review_threads.rs
+++ b/src/review_threads.rs
@@ -311,5 +311,25 @@ pub fn filter_threads_by_files(threads: Vec<ReviewThread>, files: &[String]) -> 
         })
         .collect()
 }
+/// Find the thread containing `comment_id` and trim preceding comments.
+#[must_use]
+pub fn thread_for_comment(threads: Vec<ReviewThread>, comment_id: u64) -> Option<ReviewThread> {
+    let suffix = format!("#discussion_r{comment_id}");
+    threads.into_iter().find_map(|mut t| {
+        if let Some(idx) = t
+            .comments
+            .nodes
+            .iter()
+            .position(|c| c.url.ends_with(&suffix))
+        {
+            let remaining = t.comments.nodes.split_off(idx);
+            t.comments.nodes = remaining;
+            Some(t)
+        } else {
+            None
+        }
+    })
+}
+
 #[cfg(test)]
 mod tests;

--- a/src/review_threads.rs
+++ b/src/review_threads.rs
@@ -312,6 +312,9 @@ pub fn filter_threads_by_files(threads: Vec<ReviewThread>, files: &[String]) -> 
         .collect()
 }
 /// Find the thread containing `comment_id` and trim preceding comments.
+///
+/// GitHub review comment permalinks always end with `#discussion_r<ID>`.
+/// See <https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/commenting-on-a-pull-request#linking-to-a-pull-request-comment>.
 #[must_use]
 pub fn thread_for_comment(threads: Vec<ReviewThread>, comment_id: u64) -> Option<ReviewThread> {
     let suffix = format!("#discussion_r{comment_id}");

--- a/src/review_threads.rs
+++ b/src/review_threads.rs
@@ -343,6 +343,9 @@ pub fn filter_threads_by_files(threads: Vec<ReviewThread>, files: &[String]) -> 
 /// ```
 #[must_use]
 pub fn thread_for_comment(threads: Vec<ReviewThread>, comment_id: u64) -> Option<ReviewThread> {
+    // GitHub permalinks to review comments end with `#discussion_r<ID>` as
+    // noted in GitHub's "linking to a pull request comment" docs, so matching
+    // by suffix is reliable
     let suffix = format!("#discussion_r{comment_id}");
     threads.into_iter().find_map(|mut t| {
         if let Some(idx) = t

--- a/src/review_threads.rs
+++ b/src/review_threads.rs
@@ -315,6 +315,32 @@ pub fn filter_threads_by_files(threads: Vec<ReviewThread>, files: &[String]) -> 
 ///
 /// GitHub review comment permalinks always end with `#discussion_r<ID>`.
 /// See <https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/commenting-on-a-pull-request#linking-to-a-pull-request-comment>.
+///
+/// # Examples
+///
+/// ```
+/// # use crate::review_threads::{
+/// #     thread_for_comment, CommentConnection, ReviewComment, ReviewThread,
+/// # };
+/// let threads = vec![ReviewThread {
+///     comments: CommentConnection {
+///         nodes: vec![
+///             ReviewComment {
+///                 url: "https://example.com#discussion_r1".into(),
+///                 ..Default::default()
+///             },
+///             ReviewComment {
+///                 url: "https://example.com#discussion_r2".into(),
+///                 ..Default::default()
+///             },
+///         ],
+///         ..Default::default()
+///     },
+///     ..Default::default()
+/// }];
+/// let thread = thread_for_comment(threads, 2).expect("thread present");
+/// assert_eq!(thread.comments.nodes.len(), 1);
+/// ```
 #[must_use]
 pub fn thread_for_comment(threads: Vec<ReviewThread>, comment_id: u64) -> Option<ReviewThread> {
     let suffix = format!("#discussion_r{comment_id}");

--- a/src/review_threads/tests.rs
+++ b/src/review_threads/tests.rs
@@ -198,11 +198,7 @@ fn thread_for_comment_picks_correct_thread_among_multiple() {
     ];
     let thread = thread_for_comment(threads, 2).expect("thread present");
     assert_eq!(thread.comments.nodes.len(), 1);
-    let url = thread
-        .comments
-        .nodes
-        .first()
-        .map(|c| c.url.as_str());
+    let url = thread.comments.nodes.first().map(|c| c.url.as_str());
     assert_eq!(url, Some("https://example.com#discussion_r2"));
 }
 

--- a/src/review_threads/tests.rs
+++ b/src/review_threads/tests.rs
@@ -132,6 +132,31 @@ async fn run_query_missing_nodes_reports_path(
     let _ = join.await;
 }
 
+#[test]
+fn thread_for_comment_returns_slice_starting_at_id() {
+    let threads = vec![ReviewThread {
+        comments: CommentConnection {
+            nodes: vec![
+                ReviewComment {
+                    url: "https://example.com#discussion_r1".into(),
+                    ..Default::default()
+                },
+                ReviewComment {
+                    body: "second".into(),
+                    url: "https://example.com#discussion_r2".into(),
+                    ..Default::default()
+                },
+            ],
+            ..Default::default()
+        },
+        ..Default::default()
+    }];
+    let thread = thread_for_comment(threads, 2).expect("thread");
+    assert_eq!(thread.comments.nodes.len(), 1);
+    let body = thread.comments.nodes.first().map(|c| c.body.as_str());
+    assert_eq!(body, Some("second"));
+}
+
 #[rstest]
 #[case::empty("")]
 #[case::whitespace(" ")]

--- a/src/review_threads/tests.rs
+++ b/src/review_threads/tests.rs
@@ -151,10 +151,83 @@ fn thread_for_comment_returns_slice_starting_at_id() {
         },
         ..Default::default()
     }];
-    let thread = thread_for_comment(threads, 2).expect("thread");
+    let thread = thread_for_comment(threads, 2).expect("thread present");
     assert_eq!(thread.comments.nodes.len(), 1);
     let body = thread.comments.nodes.first().map(|c| c.body.as_str());
     assert_eq!(body, Some("second"));
+}
+
+#[test]
+fn thread_for_comment_returns_none_for_missing_id() {
+    let threads = vec![ReviewThread {
+        comments: CommentConnection {
+            nodes: vec![ReviewComment {
+                url: "https://example.com#discussion_r1".into(),
+                ..Default::default()
+            }],
+            ..Default::default()
+        },
+        ..Default::default()
+    }];
+    assert!(thread_for_comment(threads, 2).is_none());
+}
+
+#[test]
+fn thread_for_comment_picks_correct_thread_among_multiple() {
+    let threads = vec![
+        ReviewThread {
+            comments: CommentConnection {
+                nodes: vec![ReviewComment {
+                    url: "https://example.com#discussion_r1".into(),
+                    ..Default::default()
+                }],
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+        ReviewThread {
+            comments: CommentConnection {
+                nodes: vec![ReviewComment {
+                    url: "https://example.com#discussion_r2".into(),
+                    ..Default::default()
+                }],
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+    ];
+    let thread = thread_for_comment(threads, 2).expect("thread present");
+    assert_eq!(thread.comments.nodes.len(), 1);
+    let url = thread
+        .comments
+        .nodes
+        .first()
+        .map(|c| c.url.as_str());
+    assert_eq!(url, Some("https://example.com#discussion_r2"));
+}
+
+#[rstest]
+#[case(1, 2)]
+#[case(2, 1)]
+fn thread_for_comment_handles_position(#[case] id: u64, #[case] expected: usize) {
+    let threads = vec![ReviewThread {
+        comments: CommentConnection {
+            nodes: vec![
+                ReviewComment {
+                    url: "https://example.com#discussion_r1".into(),
+                    ..Default::default()
+                },
+                ReviewComment {
+                    url: "https://example.com#discussion_r2".into(),
+                    ..Default::default()
+                },
+            ],
+            ..Default::default()
+        },
+        ..Default::default()
+    }];
+    let thread = thread_for_comment(threads, id).expect("thread present");
+    assert_eq!(thread.comments.nodes.len(), expected);
 }
 
 #[rstest]
@@ -271,7 +344,7 @@ async fn threads_with_many_comments_do_not_duplicate_first_page(
     let threads = fetch_review_threads(&client, &repo, 1)
         .await
         .expect("fetch threads");
-    let thread = threads.first().expect("thread");
+    let thread = threads.first().expect("thread present");
     assert_eq!(thread.comments.nodes.len(), 101);
     let bodies: Vec<_> = thread
         .comments

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -126,13 +126,13 @@ async fn e2e_missing_nodes_reports_path() {
 }
 
 #[tokio::test]
-async fn pr_discussion_reference_fetches_single_thread() {
+async fn pr_discussion_reference_fetches_resolved_thread() {
     let (addr, handler, shutdown) = start_mitm().await.expect("start server");
     let threads_body = serde_json::json!({
         "data": {"repository": {"pullRequest": {"reviewThreads": {
             "nodes": [{
                 "id": "t1",
-                "isResolved": false,
+                "isResolved": true,
                 "comments": {
                     "nodes": [
                         { "body": "first", "diffHunk": "@@ -1 +1 @@\n-old\n+new\n", "originalPosition": null, "position": null, "path": "file.rs", "url": "https://github.com/o/r/pull/1#discussion_r1", "author": null },

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -61,7 +61,7 @@ async fn e2e_pr_42() {
     });
 
     Command::cargo_bin("vk")
-        .expect("binary")
+        .expect("binary executable")
         .env("GITHUB_GRAPHQL_URL", format!("http://{addr}"))
         .env("GITHUB_TOKEN", "dummy")
         .args(["pr", "https://github.com/leynos/shared-actions/pull/42"])
@@ -101,7 +101,7 @@ async fn e2e_missing_nodes_reports_path() {
         Duration::from_secs(10),
         tokio::task::spawn_blocking(move || {
             Command::cargo_bin("vk")
-                .expect("binary")
+                .expect("binary executable")
                 .env("GITHUB_GRAPHQL_URL", format!("http://{addr}"))
                 .env("GITHUB_TOKEN", "dummy")
                 .args(["pr", "https://github.com/leynos/cmd-mox/pull/25"])
@@ -147,15 +147,23 @@ async fn pr_discussion_reference_fetches_single_thread() {
             .expect("build response")
     });
 
-    Command::cargo_bin("vk")
-        .expect("binary")
-        .env("GITHUB_GRAPHQL_URL", format!("http://{addr}"))
-        .env("GITHUB_TOKEN", "dummy")
-        .args(["pr", "https://github.com/o/r/pull/1#discussion_r2"])
-        .assert()
-        .success()
-        .stdout(contains("second"))
-        .stdout(contains("first").not());
+    tokio::time::timeout(
+        Duration::from_secs(10),
+        tokio::task::spawn_blocking(move || {
+            Command::cargo_bin("vk")
+                .expect("binary executable")
+                .env("GITHUB_GRAPHQL_URL", format!("http://{addr}"))
+                .env("GITHUB_TOKEN", "dummy")
+                .args(["pr", "https://github.com/o/r/pull/1#discussion_r2"])
+                .assert()
+                .success()
+                .stdout(contains("second"))
+                .stdout(contains("first").not());
+        }),
+    )
+    .await
+    .expect("command timed out")
+    .expect("spawn blocking");
     shutdown.shutdown().await;
 }
 


### PR DESCRIPTION
## Summary
- allow `vk pr` to accept references with `#discussion_r…`
- fetch and print a single thread starting from the referenced comment
- document discussion fragment support and cover with unit and e2e tests

## Testing
- `make fmt`
- `make lint`
- `make test`
- `make markdownlint`
- `make nixie`

------
https://chatgpt.com/codex/tasks/task_e_68bc1ac100c483229e517adeb8e591de

## Summary by Sourcery

Enable pulling and displaying a single review thread by including a `#discussion_r<ID>` fragment in PR references, with corresponding parsing, thread-filtering logic, documentation, and tests

New Features:
- Support `#discussion_r<ID>` fragment in PR references to focus on a single review thread

Enhancements:
- Add `parse_pr_thread_reference` to extract comment IDs from PR references
- Implement `thread_for_comment` to select and trim threads starting from a given comment
- Modify PR command flow to fetch all threads and apply comment filtering when a fragment is provided

Documentation:
- Document discussion fragment support in design guide

Tests:
- Add unit tests for parsing thread references and extracting single-thread slices
- Add end-to-end test to verify fetching and printing a focused discussion thread