### PR TITLE
Handle GitHub comment node encoding fragility

### DIFF
--- a/docs/vk-design.md
+++ b/docs/vk-design.md
@@ -39,10 +39,12 @@ even when multiple comments reference the same code.
 - **Resolve threads**: `vk resolve <comment-ref>` resolves the thread via the
   `resolveReviewThread` GraphQL mutation. When compiled with the
   `unstable-rest-resolve` feature, it posts a reply via the REST API before
-  resolving. The thread identifier is obtained by querying the review comment's
-  node in GraphQL and reading `pullRequestReviewThread.id`. This subcommand
-  requires `GITHUB_TOKEN`; if absent, it aborts rather than performing
-  anonymous calls.
+  resolving. The thread identifier is obtained by synthesising the review
+  comment's node identifier as `base64("PullRequestReviewComment:<id>")` and
+  querying its thread via GraphQL. If this lookup fails (for example if GitHub
+  changes the encoding), vk fetches the comment's `node_id` using the REST API
+  and retries the query. This subcommand requires `GITHUB_TOKEN`; if absent, it
+  aborts rather than performing anonymous calls.
 
 ## Architecture
 


### PR DESCRIPTION
## Summary
- document and fall back when GitHub comment node encoding changes
- describe node ID assumptions and REST fallback in docs

## Testing
- `make fmt`
- `make lint`
- `make test`
- `make markdownlint`
- `make nixie`


------
https://chatgpt.com/codex/tasks/task_e_68c06493d49c83228169762681f7aaa2