### PR TITLE
Clarify CLI args_os reference

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -57,7 +57,6 @@ use clap::{Parser, Subcommand};
 use ortho_config::{OrthoConfig, SubcmdConfigMerge};
 use regex::Regex;
 use serde::{Deserialize, Serialize};
-use std::env;
 use std::io::{ErrorKind, Write};
 use std::sync::LazyLock;
 #[cfg(feature = "unstable-rest-resolve")]
@@ -432,7 +431,7 @@ async fn main() -> Result<(), VkError> {
         .with_writer(std::io::stderr)
         .init();
     let cli = Cli::parse();
-    let mut global = GlobalArgs::load_from_iter(env::args_os().take(1))?;
+    let mut global = GlobalArgs::load_from_iter(std::env::args_os().take(1))?;
     global.merge(cli.global);
     let result = match cli.command {
         Commands::Pr(pr_cli) => {


### PR DESCRIPTION
## Summary
* restore an explicit call to `std::env::args_os()` when loading global CLI arguments so the new `environment` helpers do not shadow the std API
* drop the now-unneeded `use std::env;` import

## Testing
* make fmt
* make lint
* make test

------
https://chatgpt.com/codex/tasks/task_e_68d092444de48322a208bf018b18b895