### PR TITLE
Add regression tests for coderabbit comment spacing

### DIFF
--- a/src/html.rs
+++ b/src/html.rs
@@ -118,6 +118,7 @@ fn collect_text(node: &Handle) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::borrow::Cow;
 
     #[test]
     fn collapse_replaces_root_details() {
@@ -159,5 +160,13 @@ mod tests {
             "<details><summary>two</summary>b</details>"
         );
         assert_eq!(collapse_details(input), "\u{25B6} one\n\u{25B6} two\n");
+    }
+
+    #[test]
+    fn normalize_line_endings_replaces_bare_carriage_returns() {
+        let input = "line1\rline2\r\nline3";
+        let normalised = normalize_line_endings(input);
+        assert_eq!(normalised.as_ref(), "line1\nline2\nline3");
+        assert!(matches!(normalised, Cow::Owned(_)));
     }
 }

--- a/src/html.rs
+++ b/src/html.rs
@@ -6,8 +6,8 @@ use html5ever::tendril::TendrilSink as _;
 use markup5ever_rcdom::{Handle, NodeData, RcDom};
 use std::borrow::Cow;
 use std::default::Default;
-const CARRIAGE_RETURN: char = 0x000D as char;
-const LINE_FEED: char = 0x000A as char;
+const CARRIAGE_RETURN: char = '\r';
+const LINE_FEED: char = '\n';
 
 /// Collapse root `<details>` blocks in the given text.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ pub mod banners;
 pub mod bool_predicates;
 pub mod cli_args;
 pub mod environment;
+pub mod html;
 #[path = "test_utils_env.rs"]
 pub mod test_utils;
 

--- a/src/printer/mod.rs
+++ b/src/printer/mod.rs
@@ -261,7 +261,9 @@ mod tests {
 
     use crate::{
         ReviewComment, User,
-        test_utils::{assert_diff_lines_contiguous, assert_no_triple_newlines, strip_ansi_codes},
+        test_utils::{
+            assert_diff_lines_not_blank_separated, assert_no_triple_newlines, strip_ansi_codes,
+        },
     };
 
     const CODERABBIT_COMMENT: &str = include_str!("../../tests/fixtures/comment_coderabbit.txt");
@@ -391,7 +393,7 @@ mod tests {
             plain.contains("▶ 📝 Committable suggestion"),
             "collapsed suggestion summary missing:\n{plain}"
         );
-        assert_diff_lines_contiguous(&plain, "printf");
+        assert_diff_lines_not_blank_separated(&plain, "printf");
     }
 
     #[test]

--- a/src/printer/mod.rs
+++ b/src/printer/mod.rs
@@ -260,19 +260,25 @@ mod tests {
         let mut out = String::with_capacity(input.len());
         let mut chars = input.chars();
         while let Some(ch) = chars.next() {
-            if ch == (0x1b as char) {
-                if chars.next().is_some_and(|next| next == '[') {
-                    for c in chars.by_ref() {
-                        if ('@'..='~').contains(&c) {
-                            break;
-                        }
-                    }
-                }
+            if ch == (0x1b as char) && skip_ansi_sequence(&mut chars) {
+                // Sequence consumed by helper
             } else {
                 out.push(ch);
             }
         }
         out
+    }
+
+    fn skip_ansi_sequence(chars: &mut impl Iterator<Item = char>) -> bool {
+        if !chars.next().is_some_and(|next| next == '[') {
+            return false;
+        }
+        for c in chars {
+            if ('@'..='~').contains(&c) {
+                return true;
+            }
+        }
+        true
     }
 
     #[test]

--- a/src/printer/mod.rs
+++ b/src/printer/mod.rs
@@ -259,35 +259,9 @@ mod tests {
     use chrono::Utc;
     use rstest::rstest;
 
-    use crate::{ReviewComment, User};
+    use crate::{ReviewComment, User, test_utils::strip_ansi_codes};
 
     const CODERABBIT_COMMENT: &str = include_str!("../../tests/fixtures/comment_coderabbit.txt");
-
-    fn strip_ansi_codes(input: &str) -> String {
-        let mut out = String::with_capacity(input.len());
-        let mut chars = input.chars();
-        while let Some(ch) = chars.next() {
-            if ch == (0x1b as char) && skip_ansi_sequence(&mut chars) {
-                // Sequence consumed by helper
-            } else {
-                out.push(ch);
-            }
-        }
-        out
-    }
-
-    fn skip_ansi_sequence(chars: &mut impl Iterator<Item = char>) -> bool {
-        match chars.next() {
-            Some('[') => {}
-            _ => return false,
-        }
-        for c in chars {
-            if ('@'..='~').contains(&c) {
-                return true;
-            }
-        }
-        true
-    }
 
     #[test]
     fn print_reviews_formats_authors_and_states() {

--- a/src/printer/mod.rs
+++ b/src/printer/mod.rs
@@ -114,7 +114,8 @@ fn write_formattable<W: std::io::Write, T: Formattable>(
     write_author_line(&mut out, item.icon(), item.author_login(), &suffix)?;
     let collapsed = collapse_details(item.body());
     let collapsed = collapse_excessive_newlines(collapsed);
-    skin.write_text_on(&mut out, &collapsed)
+    let formatted = skin.text(&collapsed, None);
+    std::io::Write::write_fmt(&mut out, format_args!("{formatted}"))
         .map_err(anyhow::Error::from)?;
     writeln!(out)?;
     Ok(())

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -15,7 +15,9 @@ use third_wheel::hyper::{
     service::{make_service_fn, service_fn},
 };
 use tokio::{task::JoinHandle, time::Duration};
-pub use vk::test_utils::strip_ansi_codes;
+pub use vk::test_utils::{
+    assert_diff_lines_contiguous, assert_no_triple_newlines, strip_ansi_codes,
+};
 
 /// Stub client and server handle for HTTP tests.
 pub struct TestClient {

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -5,6 +5,7 @@
 
 use crate::api::{GraphQLClient, RetryConfig};
 use crate::environment;
+
 use std::sync::{
     Arc,
     atomic::{AtomicUsize, Ordering},
@@ -14,6 +15,7 @@ use third_wheel::hyper::{
     service::{make_service_fn, service_fn},
 };
 use tokio::{task::JoinHandle, time::Duration};
+pub use vk::test_utils::strip_ansi_codes;
 
 /// Stub client and server handle for HTTP tests.
 pub struct TestClient {

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -16,7 +16,7 @@ use third_wheel::hyper::{
 };
 use tokio::{task::JoinHandle, time::Duration};
 pub use vk::test_utils::{
-    assert_diff_lines_contiguous, assert_no_triple_newlines, strip_ansi_codes,
+    assert_diff_lines_not_blank_separated, assert_no_triple_newlines, strip_ansi_codes,
 };
 
 /// Stub client and server handle for HTTP tests.

--- a/src/test_utils_env.rs
+++ b/src/test_utils_env.rs
@@ -26,6 +26,9 @@ pub fn assert_no_triple_newlines(text: &str) {
 
 /// Assert that diff lines matching `pattern` are not separated by blank lines.
 ///
+/// Non-blank lines may appear between matching diff lines; only blank line
+/// separators trigger a failure.
+///
 /// # Panics
 ///
 /// Panics if fewer than three matching diff lines are present or if blank
@@ -36,12 +39,12 @@ pub fn assert_no_triple_newlines(text: &str) {
 /// # Examples
 ///
 /// ```
-/// use vk::test_utils::assert_diff_lines_contiguous;
+/// use vk::test_utils::assert_diff_lines_not_blank_separated;
 ///
 /// let diff = "-              printf old\n+              printf new\n";
-/// assert_diff_lines_contiguous(diff, "printf");
+/// assert_diff_lines_not_blank_separated(diff, "printf");
 /// ```
-pub fn assert_diff_lines_contiguous(text: &str, pattern: &str) {
+pub fn assert_diff_lines_not_blank_separated(text: &str, pattern: &str) {
     let lines: Vec<_> = text.lines().collect();
     let diff_line_numbers: Vec<_> = lines
         .iter()

--- a/src/test_utils_env.rs
+++ b/src/test_utils_env.rs
@@ -1,9 +1,38 @@
-//! Test environment helpers.
+//! Test utilities used across integration and unit tests.
 //!
-//! Provides functions for setting and removing environment variables in a
-//! thread-safe manner for tests.
+//! This module provides helpers for managing environment variables during
+//! tests and for normalising terminal output.
 
 use crate::environment;
+
+/// Remove ANSI escape sequences from a string.
+///
+/// # Examples
+///
+/// ```
+/// use vk::test_utils::strip_ansi_codes;
+/// let coloured = "\x1b[31mred\x1b[0m";
+/// assert_eq!(strip_ansi_codes(coloured), "red");
+/// ```
+#[must_use]
+pub fn strip_ansi_codes(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    let mut chars = input.chars();
+    while let Some(ch) = chars.next() {
+        if ch == '\x1b' && skip_ansi_sequence(&mut chars) {
+            continue;
+        }
+        out.push(ch);
+    }
+    out
+}
+
+fn skip_ansi_sequence(chars: &mut impl Iterator<Item = char>) -> bool {
+    if !matches!(chars.next(), Some('[')) {
+        return false;
+    }
+    chars.any(|c| ('@'..='~').contains(&c))
+}
 
 /// Set an environment variable for testing.
 ///

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -64,16 +64,13 @@ fn strip_ansi_codes(input: &str) -> String {
 }
 
 fn skip_ansi_sequence(chars: &mut impl Iterator<Item = char>) -> bool {
-    match chars.next() {
-        Some('[') => {}
-        _ => return false,
+    // Early return if not a CSI sequence
+    if !matches!(chars.next(), Some('[')) {
+        return false;
     }
-    for c in chars {
-        if ('@'..='~').contains(&c) {
-            return true;
-        }
-    }
-    true
+
+    // Consume until we find the terminator
+    chars.any(|c| ('@'..='~').contains(&c))
 }
 
 #[rstest]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -15,7 +15,9 @@ use std::{
     sync::{Arc, Mutex},
 };
 use vk::banners::{COMMENTS_BANNER, END_BANNER, START_BANNER};
-use vk::test_utils::{assert_diff_lines_contiguous, assert_no_triple_newlines, strip_ansi_codes};
+use vk::test_utils::{
+    assert_diff_lines_not_blank_separated, assert_no_triple_newlines, strip_ansi_codes,
+};
 
 mod utils;
 use utils::{ShutdownHandle as MitmShutdown, start_mitm, vk_cmd};
@@ -238,7 +240,7 @@ async fn pr_renders_coderabbit_comment_without_extra_spacing() {
     let plain = extract_coderabbit_comment_section(&stdout);
 
     assert_no_triple_newlines(&plain);
-    assert_diff_lines_contiguous(&plain, "printf");
+    assert_diff_lines_not_blank_separated(&plain, "printf");
 
     assert_snapshot!("pr_renders_coderabbit_comment", plain);
     shutdown.shutdown().await;

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -54,19 +54,26 @@ fn strip_ansi_codes(input: &str) -> String {
     let mut out = String::with_capacity(input.len());
     let mut chars = input.chars();
     while let Some(ch) = chars.next() {
-        if ch == (0x1b as char) {
-            if chars.next().is_some_and(|next| next == '[') {
-                for c in chars.by_ref() {
-                    if ('@'..='~').contains(&c) {
-                        break;
-                    }
-                }
-            }
+        if ch == (0x1b as char) && skip_ansi_sequence(&mut chars) {
+            // Sequence consumed by helper
         } else {
             out.push(ch);
         }
     }
     out
+}
+
+fn skip_ansi_sequence(chars: &mut impl Iterator<Item = char>) -> bool {
+    match chars.next() {
+        Some('[') => {}
+        _ => return false,
+    }
+    for c in chars {
+        if ('@'..='~').contains(&c) {
+            return true;
+        }
+    }
+    true
 }
 
 #[rstest]

--- a/tests/fixtures/comment_coderabbit.txt
+++ b/tests/fixtures/comment_coderabbit.txt
@@ -1,0 +1,49 @@
+_⚠️ Potential issue_ | _🟡 Minor_
+
+**Consolidate the duplicate asset error annotation.**
+
+Lines 316-317 split the error annotation across two `printf` commands, producing a malformed GitHub Actions error annotation.
+
+
+
+Apply this diff to consolidate the message:
+
+```diff
+-              printf '%s' '::error title=Duplicate release asset::Asset name '
+-              printf '%s\n' "'${asset_name}' would be uploaded more than once"
++              printf '::error title=Duplicate release asset::Asset name '\''%s'\'' would be uploaded more than once\n' "${asset_name}"
+```
+
+<!-- suggestion_start -->
+
+<details>
+<summary>📝 Committable suggestion</summary>
+
+> ‼️ **IMPORTANT**
+> Carefully review the code before committing. Ensure that it accurately replaces the highlighted code, contains no missing lines, and has no issues with indentation. Thoroughly test & benchmark the code to ensure it meets the requirements.
+
+```suggestion
+                printf '::error title=Duplicate release asset::Asset name '\''%s'\'' would be uploaded more than once\n' "${asset_name}"
+```
+
+</details>
+
+<!-- suggestion_end -->
+
+<details>
+<summary>🤖 Prompt for AI Agents</summary>
+
+```
+.github/workflows/release.yml around lines 316 to 317: the GitHub Actions error
+annotation is split across two printf calls which produces a malformed
+annotation; replace the two separate printf commands with a single printf that
+constructs the full '::error title=Duplicate release asset::Asset name
+'<asset_name>' would be uploaded more than once' message (including the trailing
+newline) so the annotation is emitted as one valid line.
+```
+
+</details>
+
+<!-- This is an auto-generated comment by CodeRabbit -->
+
+✅ Addressed in commit 70c0c7a

--- a/tests/fixtures/review_threads_coderabbit.json
+++ b/tests/fixtures/review_threads_coderabbit.json
@@ -1,0 +1,40 @@
+{
+  "data": {
+    "repository": {
+      "pullRequest": {
+        "reviewThreads": {
+          "nodes": [
+            {
+              "id": "t1",
+              "isResolved": false,
+              "isOutdated": false,
+              "comments": {
+                "nodes": [
+                  {
+                    "body": "_⚠️ Potential issue_ | _🟡 Minor_\n\n**Consolidate the duplicate asset error annotation.**\n\nLines 316-317 split the error annotation across two `printf` commands, producing a malformed GitHub Actions error annotation.\n\n\n\nApply this diff to consolidate the message:\n\n```diff\n-              printf '%s' '::error title=Duplicate release asset::Asset name '\n-              printf '%s\\n' \"'${asset_name}' would be uploaded more than once\"\n+              printf '::error title=Duplicate release asset::Asset name '\\''%s'\\'' would be uploaded more than once\\n' \"${asset_name}\"\n```\n\n<!-- suggestion_start -->\n\n<details>\n<summary>📝 Committable suggestion</summary>\n\n> ‼️ **IMPORTANT**\n> Carefully review the code before committing. Ensure that it accurately replaces the highlighted code, contains no missing lines, and has no issues with indentation. Thoroughly test & benchmark the code to ensure it meets the requirements.\n\n```suggestion\n                printf '::error title=Duplicate release asset::Asset name '\\''%s'\\'' would be uploaded more than once\\n' \"${asset_name}\"\n```\n\n</details>\n\n<!-- suggestion_end -->\n\n<details>\n<summary>🤖 Prompt for AI Agents</summary>\n\n```\n.github/workflows/release.yml around lines 316 to 317: the GitHub Actions error\nannotation is split across two printf calls which produces a malformed\nannotation; replace the two separate printf commands with a single printf that\nconstructs the full '::error title=Duplicate release asset::Asset name\n'<asset_name>' would be uploaded more than once' message (including the trailing\nnewline) so the annotation is emitted as one valid line.\n```\n\n</details>\n\n<!-- This is an auto-generated comment by CodeRabbit -->\n\n✅ Addressed in commit 70c0c7a\n",
+                    "diffHunk": "@@ -1 +1 @@\n-old\n+new\n",
+                    "originalPosition": null,
+                    "position": null,
+                    "path": "release.sh",
+                    "url": "https://github.com/leynos/netsuke/pull/177#discussion_r2396284785",
+                    "author": {
+                      "login": "coderabbitai"
+                    }
+                  }
+                ],
+                "pageInfo": {
+                  "hasNextPage": false,
+                  "endCursor": null
+                }
+              }
+            }
+          ],
+          "pageInfo": {
+            "hasNextPage": false,
+            "endCursor": null
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/html.rs
+++ b/tests/html.rs
@@ -1,0 +1,12 @@
+//! Tests for HTML utilities.
+
+use vk::html::collapse_details;
+
+#[test]
+fn collapse_details_removes_carriage_returns() {
+    let separator = format!("{CR}{LF}", CR = 0x000D as char, LF = '\n');
+    let input = "line1\n```diff\n- a\n+ b\n```\n".replace('\n', &separator);
+    let output = collapse_details(&input);
+    assert!(!output.contains('\r'));
+    assert!(output.contains("```diff\n- a\n+ b\n```"));
+}

--- a/tests/snapshots/cli__pr_renders_coderabbit_comment.snap
+++ b/tests/snapshots/cli__pr_renders_coderabbit_comment.snap
@@ -1,0 +1,23 @@
+---
+source: tests/cli.rs
+assertion_line: 329
+expression: plain
+---
+💬  coderabbitai wrote:
+_⚠️ Potential issue_ | _🟡 Minor_
+
+Consolidate the duplicate asset error annotation.
+
+Lines 316-317 split the error annotation across two printf commands, producing a malformed GitHub Actions error annotation.
+
+Apply this diff to consolidate the message:
+
+-              printf '%s' '::error title=Duplicate release asset::Asset name '                                                        
+-              printf '%s\n' "'${asset_name}' would be uploaded more than once"                                                        
++              printf '::error title=Duplicate release asset::Asset name '\''%s'\'' would be uploaded more than once\n' "${asset_name}"
+
+▶ 📝 Committable suggestion
+
+▶ 🤖 Prompt for AI Agents
+
+✅ Addressed in commit 70c0c7a


### PR DESCRIPTION
## Summary
- share an ANSI-stripping helper in the printer tests so diff assertions can reuse it
- add fixtures and an end-to-end CLI test covering the CodeRabbit discussion to guard against extra blank lines
- capture the expected comment snapshot for the netsuke pull request discussion

## Testing
- make fmt
- make lint
- make test

------
https://chatgpt.com/codex/tasks/task_e_68ddda508234832290e69d256d804c35

## Summary by Sourcery

Add regression tests to prevent extra blank lines in CodeRabbit AI-generated comments and normalize newline handling, and enhance the printer and HTML utilities to collapse excessive newlines and carriage returns.

New Features:
- Add an end-to-end CLI test for rendering CodeRabbit AI comments without extra blank lines
- Add a unit test for write_comment_body to verify CodeRabbit comment formatting
- Add an HTML utility test for collapse_details to ensure carriage returns are removed

Enhancements:
- Implement logic in the printer to collapse sequences of more than two newlines into at most two
- Normalize carriage returns in collapse_details before HTML parsing to handle CRLF inputs correctly
- Expose the html module in the crate root
- Share an ANSI-stripping helper function across CLI and printer tests for diff assertions

Tests:
- Include fixtures and snapshot for CodeRabbit comment regression tests
- Add fixtures for review threads and empty reviews to support end-to-end testing
- Add snapshots for the CLI comment rendering test