### PR TITLE
Add cargo-binstall Linux release support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,12 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+          - target: aarch64-unknown-linux-gnu
     steps:
       - uses: actions/checkout@v5
       - name: Setup Python 3.11
@@ -38,6 +44,11 @@ jobs:
           echo "Release tag $tag matches Cargo.toml version."
       - name: Setup Rust
         uses: leynos/shared-actions/.github/actions/setup-rust@69f9c29d18a28b6bdf4b02dcd743ef416817ba18
+      - name: Add Rust target
+        run: rustup target add ${{ matrix.target }}
+      - name: Install AArch64 linker
+        if: ${{ matrix.target == 'aarch64-unknown-linux-gnu' }}
+        run: sudo apt-get update && sudo apt-get install -y gcc-aarch64-linux-gnu
       - name: Cache cargo registry
         uses: actions/cache@v4
         with:
@@ -45,16 +56,31 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-${{ matrix.target }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
+            ${{ runner.os }}-${{ matrix.target }}-cargo-
             ${{ runner.os }}-cargo-
       - name: Build release binary
-        run: cargo build --release
-      - name: Upload release artifact
+        env:
+          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
+        run: cargo build --locked --release --target ${{ matrix.target }} --bin ${{ env.REPO_NAME }}
+      - name: Package release artifact
+        env:
+          TARGET: ${{ matrix.target }}
+        run: |
+          set -euo pipefail
+          version="${GITHUB_REF_NAME#v}"
+          archive_dir="${REPO_NAME}-${TARGET}-v${version}"
+          archive_name="${archive_dir}.tgz"
+          mkdir -p dist/"${archive_dir}"
+          install -m 0755 "target/${TARGET}/release/${REPO_NAME}" \
+            "dist/${archive_dir}/${REPO_NAME}"
+          tar -C dist -czf "${archive_name}" "${archive_dir}"
+      - name: Upload packaged artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ env.REPO_NAME }}
-          path: target/release/${{ env.REPO_NAME }}
+          name: ${{ env.REPO_NAME }}-${{ matrix.target }}
+          path: ${{ env.REPO_NAME }}-${{ matrix.target }}-${{ github.ref_name }}.tgz
 
   release:
     needs: build
@@ -66,7 +92,7 @@ jobs:
       - id: download
         uses: actions/download-artifact@v5
         with:
-          name: ${{ env.REPO_NAME }}
+          path: release-artifacts
       #- uses: softprops/action-gh-release@v2
       #  with:
       #    tag_name: ${{ github.ref_name }}
@@ -75,6 +101,8 @@ jobs:
       #    files: ${{ steps.download.outputs.download-path }}/${{ env.REPO_NAME }}
       - name: Upload release
         run: |
-          gh release upload "${{ github.ref_name }}" ${{ steps.download.outputs.download-path }}/${{ env.REPO_NAME }}
+          set -euo pipefail
+          mapfile -d '' assets < <(find "${{ steps.download.outputs.download-path }}" -type f -name '*.tgz' -print0)
+          gh release upload --clobber "${{ github.ref_name }}" "${assets[@]}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,9 +99,12 @@ jobs:
       #    generate_release_notes: true
       #    fail_on_unmatched_files: true
       #    files: ${{ steps.download.outputs.download-path }}/${{ env.REPO_NAME }}
-      - name: Upload release
+      - name: Create or update release
         run: |
           set -euo pipefail
+          if ! gh release view "${{ github.ref_name }}" >/dev/null 2>&1; then
+            gh release create "${{ github.ref_name }}" --verify-tag --generate-notes
+          fi
           mapfile -d '' assets < <(find "${{ steps.download.outputs.download-path }}" -type f -name '*.tgz' -print0)
           gh release upload --clobber "${{ github.ref_name }}" "${assets[@]}"
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,6 +61,10 @@ jobs:
             ${{ runner.os }}-${{ matrix.target }}-cargo-
             ${{ runner.os }}-cargo-
       - name: Build release binary
+        if: ${{ matrix.target != 'aarch64-unknown-linux-gnu' }}
+        run: cargo build --locked --release --target ${{ matrix.target }} --bin ${{ env.REPO_NAME }}
+      - name: Build release binary
+        if: ${{ matrix.target == 'aarch64-unknown-linux-gnu' }}
         env:
           CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
         run: cargo build --locked --release --target ${{ matrix.target }} --bin ${{ env.REPO_NAME }}

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -8,13 +8,7 @@
       "tables": false,
       "headings": false
     },
-    "MD029": { "style": "ordered" },
-    "MD046": { "style": "fenced" }
+    "MD029": { "style": "ordered" }
   },
-  "ignores": [
-    "**/.git/**",
-    "**/.venv/**",
-    "**/node_modules/**",
-    "**/target/**"
-  ]
+  "ignores": ["**/.venv/**", "**/node_modules/**", "**/.uv-cache/**", "**/target/**"]
 }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.5.0"
 edition = "2024"
 rust-version = "1.89"
 license = "ISC"
+description = "View unresolved GitHub pull request review comments in the terminal"
+readme = "README.md"
+repository = "https://github.com/leynos/vk"
 
 [dependencies]
 clap = { version = "4.5.47", features = ["derive"] }
@@ -53,6 +56,11 @@ insta = { version = "1.43", features = ["redactions"] }
 
 [target.'cfg(unix)'.dev-dependencies]
 libc = "0.2"
+
+[package.metadata.binstall]
+pkg-url = "{ repo }/releases/download/v{ version }/{ name }-{ target }-v{ version }{ archive-suffix }"
+bin-dir = "{ name }-{ target }-v{ version }/{ bin }{ binary-ext }"
+pkg-fmt = "tgz"
 
 [lints.clippy]
 pedantic = { level = "warn", priority = -1 }

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ APP ?= vk
 CARGO ?= cargo
 BUILD_JOBS ?=
 CLIPPY_FLAGS ?= --all-targets --all-features -- -D warnings
-MDLINT ?= markdownlint
+MDLINT ?= markdownlint-cli2
 NIXIE ?= nixie
 
 build: target/debug/$(APP) ## Build debug binary
@@ -32,7 +32,7 @@ check-fmt: ## Verify formatting
 	$(CARGO) fmt --all -- --check
 
 markdownlint: ## Lint Markdown files
-	find . -type f -name '*.md' -not -path './target/*' -print0 | xargs -0 -- $(MDLINT)
+	find . -type f -name '*.md' -not -path '*/target/*' -not -path '*/node_modules/*' -print0 | xargs -0 $(MDLINT)
 
 nixie: ## Validate Mermaid diagrams
 	find . -type f -name '*.md' -not -path './target/*' -print0 | xargs -0 -- $(NIXIE)

--- a/README.md
+++ b/README.md
@@ -84,7 +84,18 @@ accordingly. `vk` prints a warning when it detects a non UTF-8 locale.
 
 ## Installing
 
-Build from source using Cargo:
+Install the pre-built Linux release artifact with `cargo-binstall`:
+
+```bash
+cargo binstall vk
+```
+
+Release archives are published for:
+
+- `x86_64-unknown-linux-gnu`
+- `aarch64-unknown-linux-gnu`
+
+Other targets can still build from source using Cargo:
 
 ```bash
 cargo install --path .

--- a/docs/execplans/adopt-ortho-config-v0-8-0.md
+++ b/docs/execplans/adopt-ortho-config-v0-8-0.md
@@ -12,8 +12,8 @@ tests, and documentation with the v0.8.0 migration requirements.
   <https://raw.githubusercontent.com/leynos/ortho-config/refs/tags/v0.8.0/docs/users-guide.md>.
 - Apply the v0.7.0 migration guidance from
   <https://raw.githubusercontent.com/leynos/ortho-config/refs/tags/v0.8.0/docs/v0-7-0-migration-guide.md>
-  before closing the v0.8.0 migration work, because this repository is still on
-  v0.6.x today.
+   before closing the v0.8.0 migration work, because this repository is still
+  on v0.6.x today.
 - Apply the v0.8.0 migration notes for dependency versions, crate aliasing,
   clap defaults, YAML parsing, re-export usage, and optional `cargo orthohelp`
   metadata.
@@ -48,10 +48,9 @@ tests, and documentation with the v0.8.0 migration requirements.
 - Confirm that the active toolchain remains compatible with the new minimum
   Rust version.
 - Review the additive v0.7.0 APIs and behaviours:
-  `compose_layers()` / `compose_layers_from_iter(...)`,
-  `PostMergeHook`, `FluentLocalizer`,
-  `localize_clap_error_with_command`, and `cli_default_as_absent` flows that
-  require `ArgMatches`.
+  `compose_layers()` / `compose_layers_from_iter(...)`, `PostMergeHook`,
+  `FluentLocalizer`, `localize_clap_error_with_command`, and
+  `cli_default_as_absent` flows that require `ArgMatches`.
 - Audit YAML-backed tests and sample configuration for YAML 1.2 compatibility,
   especially any unquoted `yes`, `on`, or `off` literals and any duplicate
   mapping keys.
@@ -109,9 +108,8 @@ tests, and documentation with the v0.8.0 migration requirements.
 ### 3. Reconcile the v0.7.0 and v0.8.0 API surface
 
 - Search for code paths that would benefit from or depend on the v0.7.0
-  additions:
-  `compose_layers()`, `compose_layers_from_iter(...)`, `PostMergeHook`,
-  `FluentLocalizer`, `localize_clap_error_with_command`,
+  additions: `compose_layers()`, `compose_layers_from_iter(...)`,
+  `PostMergeHook`, `FluentLocalizer`, `localize_clap_error_with_command`,
   `SelectedSubcommandMerge`, and `cli_default_as_absent`.
 - Where the repository manually inspects or synthesizes layers in tests,
   evaluate whether `compose_layers()` or `merge_from_layers()` should replace

--- a/docs/github-token.md
+++ b/docs/github-token.md
@@ -7,11 +7,11 @@ Follow these steps to create one:
 
 1. Visit <https://github.com/settings/tokens> and choose **Generate new token**.
    GitHub may prompt for a classic or fine‑grained token – either works.
-1. Give the token a note and set an expiration.
-1. Under **Select scopes**, enable `public_repo`. If private repositories are
+2. Give the token a note and set an expiration.
+3. Under **Select scopes**, enable `public_repo`. If private repositories are
    required, select the broader `repo` scope instead.
-1. Click **Generate token** and copy the value.
-1. Export the token as `VK_GITHUB_TOKEN` (or `GITHUB_TOKEN`):
+4. Click **Generate token** and copy the value.
+5. Export the token as `VK_GITHUB_TOKEN` (or `GITHUB_TOKEN`):
 
 <!-- mdformat on -->
 
@@ -19,15 +19,14 @@ Follow these steps to create one:
 export VK_GITHUB_TOKEN=YOUR_TOKEN
 ```
 
-Alternatively, store it in `~/.config/vk/config.toml` (or a file referenced
-by `VK_CONFIG_PATH`):
+Alternatively, store it in `~/.config/vk/config.toml` (or a file referenced by
+`VK_CONFIG_PATH`):
 
 ```toml
 github_token = "YOUR_TOKEN"
 ```
 
-The token can also be passed directly with `--github-token` when running
-`vk`.
+The token can also be passed directly with `--github-token` when running `vk`.
 
 Token precedence (highest to lowest):
 

--- a/docs/ortho-config-users-guide.md
+++ b/docs/ortho-config-users-guide.md
@@ -52,7 +52,7 @@ The workspace bundles an executable Hello World example under
 `examples/hello_world`. It layers defaults, environment variables, and CLI
 flags via the derive macro; see its
 [README](https://github.com/leynos/ortho-config/blob/v0.8.0/examples/hello_world/README.md)
-for a step-by-step walkthrough and the `rstest-bdd` (Behaviour-Driven
+ for a step-by-step walkthrough and the `rstest-bdd` (Behaviour-Driven
 Development) scenarios that validate behaviour end-to-end.
 
 Run `make test` to execute the example’s coverage. The unit suite uses `rstest`
@@ -438,13 +438,13 @@ environment variables like `APP_PORT` and file names such as `.app.toml`.
 
 Field attributes modify how a field is sourced or merged:
 
-| Attribute | Behaviour |
-| --------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `default = expr` | Supplies a default value when no source provides one. The expression can be a literal or a function path. |
-| `cli_long = "name"` | Overrides the automatically generated long CLI flag (kebab-case). |
-| `cli_short = 'c'` | Adds a single-letter short flag for the field. |
+| Attribute                   | Behaviour                                                                                                                                                                                                                                                                      |
+| --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `default = expr`            | Supplies a default value when no source provides one. The expression can be a literal or a function path.                                                                                                                                                                      |
+| `cli_long = "name"`         | Overrides the automatically generated long CLI flag (kebab-case).                                                                                                                                                                                                              |
+| `cli_short = 'c'`           | Adds a single-letter short flag for the field.                                                                                                                                                                                                                                 |
 | `merge_strategy = "append"` | Controls how collections merge. `append` concatenates `Vec<T>` values and is the default for vector fields. `replace` is available for vectors and maps and makes later sources override earlier ones. `keyed` merges map-like types by key and is the default for map fields. |
-| `cli_default_as_absent` | Treats typed clap defaults (`default_value_t`, `default_values_t`) as absent during configuration merging. File and environment values take precedence, while explicit CLI overrides still win. |
+| `cli_default_as_absent`     | Treats typed clap defaults (`default_value_t`, `default_values_t`) as absent during configuration merging. File and environment values take precedence, while explicit CLI overrides still win.                                                                                |
 
 Unrecognized keys are ignored by the derive macro for forwards compatibility.
 Unknown keys will therefore silently do nothing. Developers who require
@@ -463,12 +463,12 @@ and a short flag. The macro chooses the short flag using these rules:
 - If both are unavailable, no short flag is assigned; specify `cli_short` to
   resolve the collision.
 
-| Scenario | Result |
+| Scenario                          | Result                 |
 | --------------------------------- | ---------------------- |
-| First letter free | `-p` |
-| Lowercase taken; uppercase free | `-P` |
-| Both cases taken | none (set `cli_short`) |
-| Explicit override via `cli_short` | `-r` |
+| First letter free                 | `-p`                   |
+| Lowercase taken; uppercase free   | `-P`                   |
+| Both cases taken                  | none (set `cli_short`) |
+| Explicit override via `cli_short` | `-r`                   |
 
 Collisions are evaluated against short flags already assigned within the same
 parser, and reserved characters such as clap's `-h` and `-V`. A character is
@@ -585,7 +585,7 @@ following steps:
 1. Builds a `figment` configuration profile. A defaults provider constructed
    from the `#[ortho_config(default = …)]` attributes is added first.
 
-1. Attempts to load a configuration file. Candidate file paths are searched in
+2. Attempts to load a configuration file. Candidate file paths are searched in
    the following order:
 
    1. If provided, a path supplied via the CLI flag generated by the
@@ -594,30 +594,30 @@ following steps:
       `APP_CONFIG_PATH` or `CONFIG_PATH`) takes precedence; see
       [Config path override](#config-path-override).
 
-   1. A dotfile named `.<prefix>.toml` in the current working directory.
+   2. A dotfile named `.<prefix>.toml` in the current working directory.
 
-   1. A dotfile of the same name in the user's home directory.
+   3. A dotfile of the same name in the user's home directory.
 
-   1. On Unix‑like systems, the XDG configuration directory (e.g.
+   4. On Unix‑like systems, the XDG configuration directory (e.g.
       `~/.config/app/config.toml`) is searched using the `xdg` crate; on
       Windows, the `%APPDATA%` and `%LOCALAPPDATA%` directories are checked.
 
-   1. If the `json5` or `yaml` features are enabled, files with `.json`,
+   5. If the `json5` or `yaml` features are enabled, files with `.json`,
       `.json5`, `.yaml`, or `.yml` extensions are also considered in these
       locations.
 
-1. Adds an environment provider using the prefix specified on the struct. Keys
+3. Adds an environment provider using the prefix specified on the struct. Keys
    are upper‑cased and nested fields use double underscores (`__`) to separate
    components.
 
-1. Adds a provider containing the CLI values (captured as `Option<T>` fields)
+4. Adds a provider containing the CLI values (captured as `Option<T>` fields)
    as the final layer.
 
-1. Merges collection fields according to the configured `merge_strategy`, using
+5. Merges collection fields according to the configured `merge_strategy`, using
    `append` by default for vectors, `keyed` by default for maps, and `replace`
    when later sources should override earlier ones.
 
-1. Attempts to extract the merged configuration into the concrete struct. On
+6. Attempts to extract the merged configuration into the concrete struct. On
    success it returns the completed configuration; otherwise an `OrthoError` is
    returned.
 
@@ -672,13 +672,13 @@ earlier ones. The precedence, from lowest to highest, is:
 1. **Application‑defined defaults** – values provided via `default` attributes
    or `Option<T>` fields are considered defaults.
 
-1. **Configuration file** – values from a TOML (or JSON5/YAML) file loaded from
+2. **Configuration file** – values from a TOML (or JSON5/YAML) file loaded from
    one of the paths listed above.
 
-1. **Environment variables** – variables prefixed with the struct's `prefix`
+3. **Environment variables** – variables prefixed with the struct's `prefix`
    (e.g. `APP_PORT`, `APP_DATABASE__URL`) override file values.
 
-1. **Command‑line arguments** – values parsed by `clap` override all other
+4. **Command‑line arguments** – values parsed by `clap` override all other
    sources.
 
 <!-- mdformat on -->
@@ -971,9 +971,9 @@ remains available for generated defaults/documentation metadata.
 <!-- mdformat off -->
 
 1. Struct default (`#[ortho_config(default = ...)]` or inferred from clap)
-1. Configuration file
-1. Environment variable
-1. Explicit CLI override (e.g. `--punctuation "?"`)
+2. Configuration file
+3. Environment variable
+4. Explicit CLI override (e.g. `--punctuation "?"`)
 
 <!-- mdformat on -->
 
@@ -1004,7 +1004,7 @@ action to perform. An enum of subcommands is annotated with
 function can be called on each variant before dispatching. See the
 `Subcommand Configuration` section of the `OrthoConfig`
 [README](https://github.com/leynos/ortho-config/blob/v0.8.0/README.md#subcommand-configuration)
-for a complete example.
+ for a complete example.
 
 ## Error handling
 
@@ -1204,15 +1204,15 @@ The generator produces standard man page sections in the canonical order:
 <!-- mdformat off -->
 
 1. **NAME** – binary name and one-line description
-1. **SYNOPSIS** – usage pattern with flags
-1. **DESCRIPTION** – expanded about text
-1. **OPTIONS** – CLI flags with types, defaults, and possible values
-1. **ENVIRONMENT** – environment variables mapped to fields
-1. **FILES** – configuration file paths and discovery locations
-1. **PRECEDENCE** – source priority order (defaults → file → env → CLI)
-1. **EXAMPLES** – usage examples from the IR
-1. **SEE ALSO** – related commands and documentation links
-1. **EXIT STATUS** – standard exit codes
+2. **SYNOPSIS** – usage pattern with flags
+3. **DESCRIPTION** – expanded about text
+4. **OPTIONS** – CLI flags with types, defaults, and possible values
+5. **ENVIRONMENT** – environment variables mapped to fields
+6. **FILES** – configuration file paths and discovery locations
+7. **PRECEDENCE** – source priority order (defaults → file → env → CLI)
+8. **EXAMPLES** – usage examples from the IR
+9. **SEE ALSO** – related commands and documentation links
+10. **EXIT STATUS** – standard exit codes
 
 <!-- mdformat on -->
 

--- a/docs/ortho-config-v0-6-0-migration-guide.md
+++ b/docs/ortho-config-v0-6-0-migration-guide.md
@@ -25,12 +25,12 @@ throughout.
 
 ## At-a-glance breaking changes
 
-| Area | Impact | Section |
+| Area               | Impact                                                                                       | Section                                                                                            |
 | ------------------ | -------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
-| Dependency surface | Macro crate now inherits parser features and consumes the re-exported dependency graph. | [1](#1-update-crate-versions-and-feature-flags), [2](#2-simplify-imports-using-the-new-re-exports) |
-| Discovery | Declarative attributes replace bespoke builders, altering discovery configuration points. | [3](#3-adopt-declarative-configuration-discovery) |
-| Error handling | `ConfigDiscovery::load_first` now errors when every candidate fails, affecting control flow. | [4](#4-handle-stricter-discovery-outcomes) |
-| YAML parsing | `SaphyrYaml` replaces the Figment YAML provider and enforces YAML 1.2 semantics. | [5](#5-switch-to-the-new-stricter-yaml-provider) |
+| Dependency surface | Macro crate now inherits parser features and consumes the re-exported dependency graph.      | [1](#1-update-crate-versions-and-feature-flags), [2](#2-simplify-imports-using-the-new-re-exports) |
+| Discovery          | Declarative attributes replace bespoke builders, altering discovery configuration points.    | [3](#3-adopt-declarative-configuration-discovery)                                                  |
+| Error handling     | `ConfigDiscovery::load_first` now errors when every candidate fails, affecting control flow. | [4](#4-handle-stricter-discovery-outcomes)                                                         |
+| YAML parsing       | `SaphyrYaml` replaces the Figment YAML provider and enforces YAML 1.2 semantics.             | [5](#5-switch-to-the-new-stricter-yaml-provider)                                                   |
 
 ## 1. Update crate versions and feature flags
 
@@ -52,11 +52,11 @@ ortho_config_macros = "0.6.0"
    crates, and supporting tools) to `"0.6.0"`. This keeps the runtime crate and
    the derive macro in lockstep, ensuring generated code matches the new
    library behaviour.
-1. Retain any optional features (such as `json5`, `yaml`, or `toml`) on the
+2. Retain any optional features (such as `json5`, `yaml`, or `toml`) on the
    main `ortho_config` dependency. The macro crate now inherits those flags,
    removing the need for duplicate feature declarations on
    `ortho_config_macros`.[^forwarded-features]
-1. Rebuild the project to confirm the upgraded macro compiles cleanly before
+3. Rebuild the project to confirm the upgraded macro compiles cleanly before
    proceeding with behavioural changes.
 
 The `hello_world` example continues to expose feature toggles via the parent
@@ -225,46 +225,46 @@ is ready for release.
 <!-- mdformat off -->
 
 \[^forwarded-features\]: Optional parser features on `ortho_config`
-automatically enable matching flags on the macro crate, keeping generated
-code in sync with runtime capabilities. See
+automatically enable matching flags on the macro crate, keeping generated code
+in sync with runtime capabilities. See
 [`ortho_config/Cargo.toml`](https://github.com/leynos/ortho-config/blob/v0.6.0/ortho_config/Cargo.toml).
-\[^hello-world-cargo\]: The `hello_world` crate forwards its parser feature flags
-to `ortho_config`, so enabling a format once covers both runtime and macro
-usage. See
+ \[^hello-world-cargo\]: The `hello_world` crate forwards its parser feature
+flags to `ortho_config`, so enabling a format once covers both runtime and
+macro usage. See
 [`examples/hello_world/Cargo.toml`](https://github.com/leynos/ortho-config/blob/v0.6.0/examples/hello_world/Cargo.toml).
-\[^reexports\]: `ortho_config` re-exports Figment, optional parser crates, and
-supporting utilities for consumers, eliminating redundant direct
-dependencies. See
+ \[^reexports\]: `ortho_config` re-exports Figment, optional parser crates, and
+supporting utilities for consumers, eliminating redundant direct dependencies.
+See
 [`ortho_config/src/lib.rs`](https://github.com/leynos/ortho-config/blob/v0.6.0/ortho_config/src/lib.rs).
-\[^hello-world-figment\]: The `hello_world` example pulls Figment providers from
-the `ortho_config` namespace when layering configuration data, and reuses
+ \[^hello-world-figment\]: The `hello_world` example pulls Figment providers
+from the `ortho_config` namespace when layering configuration data, and reuses
 the same imports in tests to assert behaviour under YAML overrides. See
 [`examples/hello_world/src/cli/config_loading.rs`](https://github.com/leynos/ortho-config/blob/v0.6.0/examples/hello_world/src/cli/config_loading.rs)
-and
+ and
 [`examples/hello_world/src/cli/tests/overrides.rs`](https://github.com/leynos/ortho-config/blob/v0.6.0/examples/hello_world/src/cli/tests/overrides.rs).
-\[^discovery-attr\]: The derive macro accepts a `discovery(...)` attribute on
+ \[^discovery-attr\]: The derive macro accepts a `discovery(...)` attribute on
 config structs, enabling declarative discovery policies. See
 [`examples/hello_world/src/cli/mod.rs`](https://github.com/leynos/ortho-config/blob/v0.6.0/examples/hello_world/src/cli/mod.rs).
-\[^hello-world-discovery\]: The CLI struct uses the discovery attribute to define
-file names, CLI flags, and environment overrides without manual builder
+ \[^hello-world-discovery\]: The CLI struct uses the discovery attribute to
+define file names, CLI flags, and environment overrides without manual builder
 plumbing. See
 [`examples/hello_world/src/cli/mod.rs`](https://github.com/leynos/ortho-config/blob/v0.6.0/examples/hello_world/src/cli/mod.rs).
-\[^discovery-errors\]: `ConfigDiscovery::load_first` now aggregates discovery
-errors, returning `Err` whenever every candidate fails but at least one
-error occurred. See
+ \[^discovery-errors\]: `ConfigDiscovery::load_first` now aggregates discovery
+errors, returning `Err` whenever every candidate fails but at least one error
+occurred. See
 [`ortho_config/src/discovery/mod.rs`](https://github.com/leynos/ortho-config/blob/v0.6.0/ortho_config/src/discovery/mod.rs).
-\[^hello-world-discover-config\]: The shared discovery helper wraps
-`ConfigDiscovery::load_first` and maps aggregated errors into
-`HelloWorldError` for callers. See
+ \[^hello-world-discover-config\]: The shared discovery helper wraps
+`ConfigDiscovery::load_first` and maps aggregated errors into `HelloWorldError`
+for callers. See
 [`examples/hello_world/src/cli/discovery.rs`](https://github.com/leynos/ortho-config/blob/v0.6.0/examples/hello_world/src/cli/discovery.rs).
-\[^saphyr\]: The `SaphyrYaml` provider reads files with strict YAML 1.2 semantics
-and backs the format-specific branch of `parse_config_by_format`. See
+ \[^saphyr\]: The `SaphyrYaml` provider reads files with strict YAML 1.2
+semantics and backs the format-specific branch of `parse_config_by_format`. See
 [`ortho_config/src/file/mod.rs`](https://github.com/leynos/ortho-config/blob/v0.6.0/ortho_config/src/file/mod.rs).
-\[^hello-world-yaml\]: Behavioural tests in `hello_world` create YAML fixtures,
-load them through `ortho_config::load_config_file`, and assert strict
+ \[^hello-world-yaml\]: Behavioural tests in `hello_world` create YAML
+fixtures, load them through `ortho_config::load_config_file`, and assert strict
 parsing behaviour. See
 [`examples/hello_world/src/cli/tests/overrides.rs`](https://github.com/leynos/ortho-config/blob/v0.6.0/examples/hello_world/src/cli/tests/overrides.rs).
-\[^changelog\]: The Unreleased changelog summarizes the v0.6.0 additions and
+ \[^changelog\]: The Unreleased changelog summarizes the v0.6.0 additions and
 behaviour changes discussed in this guide. See
 [`CHANGELOG.md`](https://github.com/leynos/ortho-config/blob/v0.6.0/CHANGELOG.md).
 

--- a/docs/ortho-config-v0-7-0-migration-guide.md
+++ b/docs/ortho-config-v0-7-0-migration-guide.md
@@ -23,11 +23,11 @@ map the new helpers to matching configuration styles and test setups.
 
 ## At-a-glance breaking changes
 
-| Area | Impact | Section |
+| Area              | Impact                                                                                                             | Section                                  |
 | ----------------- | ------------------------------------------------------------------------------------------------------------------ | ---------------------------------------- |
-| Core API | No mandatory breaking changes; v0.7.0 is additive for typical usage. | N/A |
-| CLI defaults | `cli_default_as_absent` is opt-in and changes precedence for `default_value_t` fields when used with `ArgMatches`. | [5](#5-treat-clap-defaults-as-absent) |
-| Behavioural tests | The `hello_world` behavioural suite now uses `rstest-bdd` instead of `cucumber-rs`. | [6](#6-refresh-error-handling-and-tests) |
+| Core API          | No mandatory breaking changes; v0.7.0 is additive for typical usage.                                               | N/A                                      |
+| CLI defaults      | `cli_default_as_absent` is opt-in and changes precedence for `default_value_t` fields when used with `ArgMatches`. | [5](#5-treat-clap-defaults-as-absent)    |
+| Behavioural tests | The `hello_world` behavioural suite now uses `rstest-bdd` instead of `cucumber-rs`.                                | [6](#6-refresh-error-handling-and-tests) |
 
 ## 1. Update crate versions and feature flags
 
@@ -48,11 +48,11 @@ ortho_config_macros = "0.7.0"
 <!-- mdformat off -->
 
 1. Update every `ortho_config` and `ortho_config_macros` dependency to `0.7.0`.
-1. Keep format features (`toml`, `json5`, `yaml`) on `ortho_config` as before.
-1. When default features are disabled, enable `serde_json` explicitly whenever
-   `cli_default_as_absent` or selected-subcommand merging helpers are
-   required. The default feature set already enables it.
-1. Expect new transitive dependencies (`fluent-bundle`, `fluent-syntax`,
+2. Keep format features (`toml`, `json5`, `yaml`) on `ortho_config` as before.
+3. When default features are disabled, enable `serde_json` explicitly whenever
+   `cli_default_as_absent` or selected-subcommand merging helpers are required.
+   The default feature set already enables it.
+4. Expect new transitive dependencies (`fluent-bundle`, `fluent-syntax`,
    `unic-langid`, and `tracing`) to land with v0.7.0, as they power CLI
    localization support.[^deps-0-7]
 
@@ -159,8 +159,8 @@ in those cases.
 or an explicit `#[ortho_config(default = ...)]`. Parser-faithful
 `default_value` inference is planned as a day-2 follow-up.
 
-When this attribute is in use, pass `ArgMatches` so `value_source()` can
-detect which fields were truly provided:
+When this attribute is in use, pass `ArgMatches` so `value_source()` can detect
+which fields were truly provided:
 
 ```rust
 let matches = GreetArgs::command().get_matches();
@@ -193,40 +193,39 @@ step. Variants that depend on `cli_default_as_absent` should be annotated with
 \[^deps-0-7\]: v0.7.0 adds Fluent and localization dependencies alongside the
 existing feature flags in the runtime crate and macro crate metadata. See
 [`ortho_config/Cargo.toml`](https://github.com/leynos/ortho-config/blob/v0.7.0/ortho_config/Cargo.toml)
-and
+ and
 [`ortho_config_macros/Cargo.toml`](https://github.com/leynos/ortho-config/blob/v0.7.0/ortho_config_macros/Cargo.toml).
-\[^compose-layers\]: Derived configuration structs now expose
+ \[^compose-layers\]: Derived configuration structs now expose
 `compose_layers()` and `compose_layers_from_iter(...)` and return
 `LayerComposition` for staged merging and error aggregation. See
 [`ortho_config_macros/src/derive/load_impl.rs`](https://github.com/leynos/ortho-config/blob/v0.7.0/ortho_config_macros/src/derive/load_impl.rs)
-and
+ and
 [`ortho_config/src/declarative.rs`](https://github.com/leynos/ortho-config/blob/v0.7.0/ortho_config/src/declarative.rs).
-\[^post-merge\]: `PostMergeHook` and `PostMergeContext` enable post-merge
-adjustments and are invoked when `#[ortho_config(post_merge_hook)]` is
-present. See
-[`ortho_config/src/post_merge.rs`](https://github.com/leynos/ortho-config/blob/v0.7.0/ortho_config/src/post_merge.rs).
-\[^localizer\]: `Localizer`, `LocalizationArgs`, and `FluentLocalizer` define
-the CLI localization surface and provide a Fluent-backed implementation.
+ \[^post-merge\]: `PostMergeHook` and `PostMergeContext` enable post-merge
+adjustments and are invoked when `#[ortho_config(post_merge_hook)]` is present.
 See
+[`ortho_config/src/post_merge.rs`](https://github.com/leynos/ortho-config/blob/v0.7.0/ortho_config/src/post_merge.rs).
+ \[^localizer\]: `Localizer`, `LocalizationArgs`, and `FluentLocalizer` define
+the CLI localization surface and provide a Fluent-backed implementation. See
 [`ortho_config/src/localizer/mod.rs`](https://github.com/leynos/ortho-config/blob/v0.7.0/ortho_config/src/localizer/mod.rs).
-\[^localizeclap\]: `localize_clap_error_with_command` rewrites clap error
+ \[^localizeclap\]: `localize_clap_error_with_command` rewrites clap error
 messages while keeping the existing rendered tail intact. See
 [`ortho_config/src/localizer/clap_error.rs`](https://github.com/leynos/ortho-config/blob/v0.7.0/ortho_config/src/localizer/clap_error.rs).
-\[^cli-defaults\]: `cli_default_as_absent` is implemented via the
-`CliValueExtractor` trait to exclude clap defaults from the CLI layer
-unless explicitly provided. See
+ \[^cli-defaults\]: `cli_default_as_absent` is implemented via the
+`CliValueExtractor` trait to exclude clap defaults from the CLI layer unless
+explicitly provided. See
 [`ortho_config/src/merge.rs`](https://github.com/leynos/ortho-config/blob/v0.7.0/ortho_config/src/merge.rs).
-\[^selectedsubcommand\]: `SelectedSubcommandMerge` and
+ \[^selectedsubcommand\]: `SelectedSubcommandMerge` and
 `load_globals_and_merge_selected_subcommand` let the chosen subcommand be
 merged without manual `match` scaffolding. See
 [`ortho_config/src/subcommand/selected.rs`](https://github.com/leynos/ortho-config/blob/v0.7.0/ortho_config/src/subcommand/selected.rs).
-\[^display-request\]: `is_display_request` preserves clap's help and version
+ \[^display-request\]: `is_display_request` preserves clap's help and version
 exit behaviour when callers use `try_parse()`. See
 [`ortho_config/src/error.rs`](https://github.com/leynos/ortho-config/blob/v0.7.0/ortho_config/src/error.rs).
-\[^json-merge\]: `OrthoJsonMergeExt` maps `serde_json::Error` into merge
+ \[^json-merge\]: `OrthoJsonMergeExt` maps `serde_json::Error` into merge
 failures while preserving detailed diagnostics. See
 [`ortho_config/src/result_ext.rs`](https://github.com/leynos/ortho-config/blob/v0.7.0/ortho_config/src/result_ext.rs).
-\[^rstest-bdd\]: The behavioural suites moved from `cucumber-rs` to
+ \[^rstest-bdd\]: The behavioural suites moved from `cucumber-rs` to
 `rstest-bdd`, including tag-aware filtering for YAML scenarios. See
 [`docs/adr-002-replace-cucumber-with-rstest-bdd.md`](https://github.com/leynos/ortho-config/blob/v0.7.0/docs/adr-002-replace-cucumber-with-rstest-bdd.md).
 

--- a/docs/vk-design.md
+++ b/docs/vk-design.md
@@ -85,8 +85,8 @@ The code centres on three printing helpers:
 
 1. `write_comment_body` formats a single comment body to any `Write`
    implementation.
-1. `write_comment` includes the diff for the first comment in a thread.
-1. `write_thread` iterates over a thread and prints each comment body in turn.
+2. `write_comment` includes the diff for the first comment in a thread.
+3. `write_thread` iterates over a thread and prints each comment body in turn.
 
 <!-- mdformat on -->
 

--- a/docs/vk-end-to-end-testing-guide.md
+++ b/docs/vk-end-to-end-testing-guide.md
@@ -154,14 +154,14 @@ predicates = "3.1"
 
 The table below outlines the purpose of each dependency within the test suite.
 
-| Crate | Recommended Version | Purpose in Test Suite |
+| Crate       | Recommended Version | Purpose in Test Suite                                                                                                                                   |
 | ----------- | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| assert_cmd | ~2.0 | The core test orchestrator for executing the vk binary and asserting on its behaviour.[^8] |
-| insta | ~1.34 | For snapshot testing of the styled terminal output, handling the complexity of termimad.[^17] The redactions feature is enabled to handle dynamic data. |
-| third-wheel | ~0.6 | An embedded MITM proxy to intercept and mock GitHub API calls, ensuring deterministic tests.[^18] |
-| tokio | ~1.0 | An async runtime required to run the third-wheel mock server concurrently with the test logic. The full feature flag is recommended for simplicity. |
-| serde_json | ~1.0 | A utility for loading and manipulating the JSON fixture files used as mock API responses. |
-| tempfile | ~3.8 | For creating temporary configuration files and directories to test vk's configuration logic in an isolated manner.[^19] |
+| assert_cmd  | ~2.0                | The core test orchestrator for executing the vk binary and asserting on its behaviour.[^8]                                                              |
+| insta       | ~1.34               | For snapshot testing of the styled terminal output, handling the complexity of termimad.[^17] The redactions feature is enabled to handle dynamic data. |
+| third-wheel | ~0.6                | An embedded MITM proxy to intercept and mock GitHub API calls, ensuring deterministic tests.[^18]                                                       |
+| tokio       | ~1.0                | An async runtime required to run the third-wheel mock server concurrently with the test logic. The full feature flag is recommended for simplicity.     |
+| serde_json  | ~1.0                | A utility for loading and manipulating the JSON fixture files used as mock API responses.                                                               |
+| tempfile    | ~3.8                | For creating temporary configuration files and directories to test vk's configuration logic in an isolated manner.[^19]                                 |
 
 ### Test File Organization: Following Rust Conventions
 
@@ -248,11 +248,11 @@ this test provides high confidence that:
 
 1. The `[dev-dependencies]` are correctly configured.
 
-1. Cargo's test runner can find and compile the `tests/e2e.rs` file.
+2. Cargo's test runner can find and compile the `tests/e2e.rs` file.
 
-1. `assert_cmd` is able to locate the `vk` binary produced by the build process.
+3. `assert_cmd` is able to locate the `vk` binary produced by the build process.
 
-1. The basic assertion mechanism is working as expected.
+4. The basic assertion mechanism is working as expected.
 
 <!-- mdformat on -->
 
@@ -640,7 +640,7 @@ developer to:
 
 1. Quickly identify an unintended change (a regression).
 
-1. Consciously "approve" an intentional change, causing the snapshot to be
+2. Consciously "approve" an intentional change, causing the snapshot to be
    updated with the new, correct output.
 
 ### Integrating insta with assert_cmd
@@ -681,12 +681,12 @@ intuitive, revolving around the `cargo-insta` command-line tool.[^13]
    creates a new file, for example, `tests/snapshots/e2e__my_test_name.snap`.
    This file contains the raw `stdout` captured during the test run.
 
-1. **Reviewing the Snapshot:** The developer's next step is to open the newly
+2. **Reviewing the Snapshot:** The developer's next step is to open the newly
    created `.snap` file and inspect its contents. This is the "approval" step
    of approval testing. The developer verifies that the output, including all
    styling, is correct.
 
-1. **Interactive Review and Acceptance with** `cargo insta review`**:** Instead
+3. **Interactive Review and Acceptance with** `cargo insta review`**:** Instead
    of manually managing files, the recommended workflow is to use the
    interactive review tool. After running the tests, the developer runs
    `cargo insta review`. This tool will find all pending (new or changed)
@@ -703,7 +703,7 @@ intuitive, revolving around the `cargo-insta` command-line tool.[^13]
    - **Skip (**`s` **or** `Space`**):** Skips reviewing this snapshot for now,
      leaving it in a pending state.
 
-1. **Non-Interactive Updates (for CI/CD):** The `INSTA_UPDATE` environment
+4. **Non-Interactive Updates (for CI/CD):** The `INSTA_UPDATE` environment
    variable controls `insta`'s behaviour in non-interactive environments like
    CI pipelines.[^13]
 
@@ -720,8 +720,8 @@ intuitive, revolving around the `cargo-insta` command-line tool.[^13]
   should be used with extreme caution as it bypasses the crucial review step.
 
 - `INSTA_UPDATE=new`: This is the default for local runs. It writes new or
-  changed snapshots to files with a `.new` extension, marking them as
-  pending for review with `cargo insta review`.
+  changed snapshots to files with a `.new` extension, marking them as pending
+  for review with `cargo insta review`.
 
 ### Handling Non-Deterministic Data with Redactions
 
@@ -1027,8 +1027,8 @@ foundation of quality and confidence for future development.
 
 <!-- mdformat off -->
 
-\[^1\]: People following @[vee.cool](http://vee.cool) — Bluesky, accessed on July
-20, 2025, <https://web-cdn.bsky.app/profile/vee.cool/followers>
+\[^1\]: People following @[vee.cool](http://vee.cool) — Bluesky, accessed on
+July 20, 2025, <https://web-cdn.bsky.app/profile/vee.cool/followers>
 
 \[^2\]: Canop/termimad: A library to display rich (Markdown) snippets and texts
 in a rust terminal application - GitHub, accessed on July 20, 2025,
@@ -1041,19 +1041,19 @@ Rust Users Forum, accessed on July 20, 2025,
 \[^4\]: termimad - Rust - Docs.rs, accessed on July 20, 2025,
 <https://docs.rs/termimad>
 
-\[^5\]: The Hitchhiker's Guide to E2E Testing | by Tally Barak - Medium, accessed
-on July 20, 2025,
+\[^5\]: The Hitchhiker's Guide to E2E Testing | by Tally Barak - Medium,
+accessed on July 20, 2025,
 <https://tally-b.medium.com/the-hitchhikers-guide-to-e2e-testing-b2a9eebeeb27>
 
-\[^6\]: How to Write Tests - The Rust Programming Language - Rust Documentation,
-accessed on July 20, 2025,
+\[^6\]: How to Write Tests - The Rust Programming Language - Rust
+Documentation, accessed on July 20, 2025,
 <https://doc.rust-lang.org/book/ch11-01-writing-tests.html>
 
-\[^7\]: termimad - [crates.io](http://crates.io): Rust Package Registry, accessed
-on July 20, 2025, <https://crates.io/crates/termimad/0.9.7>
+\[^7\]: termimad - [crates.io](http://crates.io): Rust Package Registry,
+accessed on July 20, 2025, <https://crates.io/crates/termimad/0.9.7>
 
-\[^8\]: assert_cmd - Rust - [Docs.rs](http://Docs.rs), accessed on July 20, 2025,
-<https://docs.rs/assert_cmd>
+\[^8\]: assert_cmd - Rust - [Docs.rs](http://Docs.rs), accessed on July 20,
+2025, <https://docs.rs/assert_cmd>
 
 \[^9\]: assert_cmd - [crates.io](http://crates.io): Rust Package Registry,
 accessed on July 20, 2025, <https://crates.io/crates/assert_cmd>
@@ -1072,11 +1072,11 @@ accessed on July 20, 2025, <https://github.com/campbellC/third-wheel>
 
 \[^14\]: Insta Snapshots, accessed on July 20, 2025, <https://insta.rs/>
 
-\[^15\]: Testing - Command Line Applications in Rust, accessed on July 20, 2025,
-<https://rust-cli.github.io/book/tutorial/testing.html>
+\[^15\]: Testing - Command Line Applications in Rust, accessed on July 20,
+2025, <https://rust-cli.github.io/book/tutorial/testing.html>
 
-\[^16\]: Test Organization - The Rust Programming Language, accessed on July 20,
-2025, <https://doc.rust-lang.org/book/ch11-03-test-organization.html>
+\[^16\]: Test Organization - The Rust Programming Language, accessed on July
+20, 2025, <https://doc.rust-lang.org/book/ch11-03-test-organization.html>
 
 \[^17\]: insta - [crates.io](http://crates.io): Rust Package Registry, accessed
 on July 20, 2025, <https://crates.io/crates/insta>
@@ -1084,8 +1084,8 @@ on July 20, 2025, <https://crates.io/crates/insta>
 \[^18\]: third-wheel - [crates.io](http://crates.io): Rust Package Registry,
 accessed on July 20, 2025, <https://crates.io/crates/third-wheel>
 
-\[^19\]: tempfile - Rust - [Docs.rs](http://Docs.rs), accessed on July 20, 2025,
-<https://docs.rs/tempfile>
+\[^19\]: tempfile - Rust - [Docs.rs](http://Docs.rs), accessed on July 20,
+2025, <https://docs.rs/tempfile>
 
 \[^20\]: Should unit tests really be put in the same file as the source? - Rust
 Users Forum, accessed on July 20, 2025,
@@ -1095,8 +1095,8 @@ Users Forum, accessed on July 20, 2025,
 accessed on July 20, 2025,
 <https://lpalmieri.com/posts/skeleton-and-principles-for-a-maintainable-test-suite/>
 
-\[^22\]: Command in assert_cmd::cmd - Rust - [Docs.rs](http://Docs.rs), accessed
-on July 20, 2025,
+\[^22\]: Command in assert_cmd::cmd - Rust - [Docs.rs](http://Docs.rs),
+accessed on July 20, 2025,
 <https://docs.rs/assert_cmd/latest/assert_cmd/cmd/struct.Command.html>
 
 \[^23\]: How I test Rust command-line apps with assert_cmd - alexwlchan,

--- a/src/html.rs
+++ b/src/html.rs
@@ -55,21 +55,21 @@ pub fn collapse_details(input: &str) -> String {
 
 fn collapse_node(node: &Handle, out: &mut String, in_details: bool) {
     match &node.data {
-        NodeData::Element { name, .. } if name.local.eq_str_ignore_ascii_case("details") => {
-            if should_collapse_details(node, in_details) {
-                write_collapsed_summary(node, out);
-            }
+        NodeData::Element { name, .. }
+            if name.local.eq_str_ignore_ascii_case("details")
+                && should_collapse_details(node, in_details) =>
+        {
+            write_collapsed_summary(node, out);
             // drop children entirely when collapsing
         }
+        NodeData::Element { name, .. } if name.local.eq_str_ignore_ascii_case("details") => {}
         NodeData::Element { .. } => {
             for child in node.children.borrow().iter() {
                 collapse_node(child, out, in_details);
             }
         }
-        NodeData::Text { contents } => {
-            if !in_details {
-                out.push_str(&contents.borrow());
-            }
+        NodeData::Text { contents } if !in_details => {
+            out.push_str(&contents.borrow());
         }
         _ => {}
     }


### PR DESCRIPTION
Add explicit `cargo-binstall` metadata to `Cargo.toml` and publish Linux release archives in the shape that `binstall` expects.

Build tagged releases for both `x86_64-unknown-linux-gnu` and `aarch64-unknown-linux-gnu`, package each binary into a versioned `.tgz`, and upload the full set of assets to the GitHub release. Document the new install path in `README.md`.

Keep the small `html.rs` match cleanup that Clippy required while validating the branch, and retain the repo-wide Markdown list-numbering normalisation from `make fmt` so the Markdown lint gate passes.

## Summary by Sourcery

Add support for publishing Linux release archives consumable by cargo-binstall and document the new installation path while updating formatting and tooling to satisfy markdown linting and Clippy requirements.

New Features:
- Expose pre-built Linux binaries for vk via cargo-binstall-compatible release archives for x86_64-unknown-linux-gnu and aarch64-unknown-linux-gnu, referenced in the installation instructions.

Enhancements:
- Add cargo-binstall metadata to Cargo.toml, including package description, readme, repository URL, and archive layout configuration.
- Adjust HTML collapsing logic to satisfy Clippy while preserving behavior.
- Normalize Markdown formatting, tables, and ordered lists across documentation to align with the markdownlint configuration.

Build:
- Extend the release GitHub Actions workflow to build, cross-compile, package, and upload versioned .tgz artifacts for both x86_64 and aarch64 Linux targets.
- Update the Makefile markdownlint target to use markdownlint-cli2 and exclude target and node_modules directories from linting.

Documentation:
- Document cargo-binstall-based installation and supported Linux targets in the README, while tightening various docs and guides formatting for consistency with markdown linting rules.