### PR TITLE
Serve REST resolve path through octocrab

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.3"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
 dependencies = [
  "memchr",
 ]
@@ -19,9 +19,9 @@ checksum = "e9d4ee0d472d1cd2e28c97dfa124b3d8d992e10eb0a035f33f5d12e3a177ba3b"
 
 [[package]]
 name = "android_system_properties"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+checksum = "ae221649c9976a6f6c56ae1facf410f3ddb33cc661c4b7b61020a912d4237fbc"
 dependencies = [
  "libc",
 ]
@@ -58,22 +58,22 @@ dependencies = [
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.10"
+version = "3.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -81,6 +81,15 @@ name = "anyhow"
 version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
+
+[[package]]
+name = "arc-swap"
+version = "1.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "arraydeque"
@@ -101,6 +110,17 @@ dependencies = [
  "predicates-core",
  "predicates-tree",
  "wait-timeout",
+]
+
+[[package]]
+name = "async-trait"
+version = "0.1.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -131,9 +151,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "backon"
@@ -145,6 +165,12 @@ dependencies = [
  "gloo-timers",
  "tokio",
 ]
+
+[[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
 name = "base64"
@@ -159,10 +185,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
 
 [[package]]
-name = "bitflags"
-version = "2.9.3"
+name = "base64ct"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34efbcccd345379ca2868b2b2c9d3782e9cc58ba87bc7d79d5b53d9c9ae6f25d"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
+name = "bitflags"
+version = "2.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "block-buffer"
@@ -175,26 +222,26 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.12.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "234113d19d0d7d613b40e86fb654acf958910802bcceab913a4f9e7cda03b1a4"
+checksum = "6bb31b46c14244e20ee9984b11bf5c992b91fb6939fea616e3512c8baecdbe5f"
 dependencies = [
  "memchr",
  "regex-automata",
- "serde",
+ "serde_core",
 ]
 
 [[package]]
 name = "bumpalo"
-version = "3.19.0"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytemuck"
-version = "1.23.2"
+version = "1.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3995eaeebcdf32f91f980d360f78732ddc061097ab4e39991ae7a6ace9194677"
+checksum = "95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797"
 
 [[package]]
 name = "bytes"
@@ -210,18 +257,18 @@ checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "camino"
-version = "1.2.1"
+version = "1.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "276a59bf2b2c967788139340c9f0c5b12d7fd6630315c15c217e559de85d2609"
+checksum = "bb1307f12aa967b5a58416e87b3653360e0fd614a016b6e970db08fecbb1b80d"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
 name = "cap-primitives"
-version = "4.0.2"
+version = "4.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdadbd7c002d3a484b35243669abdae85a0ebaded5a61117169dc3400f9a7ff0"
+checksum = "8b5f74729fd2f44701d1a8eb47e906cdb3ccd9ec0f02baad85a744b791940b18"
 dependencies = [
  "ambient-authority",
  "fs-set-times",
@@ -231,15 +278,15 @@ dependencies = [
  "maybe-owned",
  "rustix",
  "rustix-linux-procfs",
- "windows-sys 0.61.1",
+ "windows-sys 0.61.2",
  "winx",
 ]
 
 [[package]]
 name = "cap-std"
-version = "4.0.2"
+version = "4.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7281235d6e96d3544ca18bba9049be92f4190f8d923e3caef1b5f66cfa752608"
+checksum = "c1ec78e242cfa2cfe276807ac2ecc00315a6c97786977414bcd1c3963b6c91b8"
 dependencies = [
  "camino",
  "cap-primitives",
@@ -249,25 +296,61 @@ dependencies = [
 ]
 
 [[package]]
-name = "cc"
-version = "1.2.34"
+name = "cargo-platform"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42bc4aea80032b7bf409b0bc7ccad88853858911b7713a8062fdc0623867bedc"
+checksum = "87a0c0e6148f11f01f32650a2ea02d532b2ad4e81d8bd41e6e565b5adc5e6082"
 dependencies = [
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef987d17b0a113becdd19d3d0022d04d7ef41f9efe4f3fb63ac44ba61df3ade9"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.20",
+]
+
+[[package]]
+name = "cc"
+version = "1.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ad534f4357a5264cce5019c989cf66a4f0dc4e0d1b1d15f8aacec0ff7360273"
+dependencies = [
+ "find-msvc-tools",
  "shlex",
 ]
 
 [[package]]
 name = "cfg-if"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
+
+[[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "chrono"
@@ -280,7 +363,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-link 0.2.0",
+ "windows-link",
 ]
 
 [[package]]
@@ -302,7 +385,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -337,9 +420,9 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "colored"
@@ -360,14 +443,20 @@ checksum = "4fe5f465a4f6fee88fad41b85d990f84c835335e85b5d9e6e63e0d06d28cba7c"
 dependencies = [
  "encode_unicode",
  "libc",
- "windows-sys 0.61.1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
-name = "convert_case"
-version = "0.7.1"
+name = "const-oid"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb402b8d4c85569410425650ce3eddc7d698ed96d39a73f941b08fb63082f1e7"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
 dependencies = [
  "unicode-segmentation",
 ]
@@ -392,6 +481,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -407,10 +506,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "crokey"
-version = "1.3.0"
+name = "cpufeatures"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51360853ebbeb3df20c76c82aecf43d387a62860f1a59ba65ab51f00eea85aad"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crokey"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "074bc31bff1084f74e5a145ad5f6ac74469fa312159faa5144f0b1c4506b8d80"
 dependencies = [
  "crokey-proc_macros",
  "crossterm",
@@ -421,15 +529,15 @@ dependencies = [
 
 [[package]]
 name = "crokey-proc_macros"
-version = "1.3.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bf1a727caeb5ee5e0a0826a97f205a9cf84ee964b0b48239fef5214a00ae439"
+checksum = "b88c4ff2d5717616c3bb4a31d06b0b241ed811c7c0c41d077d77631bee7caad0"
 dependencies = [
  "crossterm",
  "proc-macro2",
  "quote",
  "strict",
- "syn 2.0.106",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -447,18 +555,18 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.15"
+version = "0.5.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+checksum = "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -466,27 +574,27 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-queue"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
+checksum = "803d13fb3b09d88be9f4dbc29062c66b19bf7170867ceb746d2a8689bf6c7a26"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "crossterm"
@@ -516,6 +624,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -526,33 +646,69 @@ dependencies = [
 ]
 
 [[package]]
-name = "deranged"
-version = "0.4.0"
+name = "curve25519-dalek"
+version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
- "powerfmt",
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "curve25519-dalek-derive",
+ "digest",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
-name = "derive_more"
-version = "2.0.1"
+name = "curve25519-dalek-derive"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "093242cf7570c207c83073cf82f79706fe7b8317e98620a47d5be7c3d8497678"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+
+[[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
 dependencies = [
  "derive_more-impl",
 ]
 
 [[package]]
 name = "derive_more-impl"
-version = "2.0.1"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
 dependencies = [
  "convert_case",
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "rustc_version",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -577,7 +733,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -619,25 +777,25 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "displaydoc"
-version = "0.2.5"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "document-features"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95249b50c6c185bee49034bcb378a49dc2b5dff0be90ff6616d31d64febab05d"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
 dependencies = [
  "litrs",
 ]
@@ -655,6 +813,65 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der",
+ "digest",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+ "spki",
+]
+
+[[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "serde",
+ "sha2",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "digest",
+ "ff",
+ "generic-array",
+ "group",
+ "hkdf",
+ "pem-rfc7468",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "sec1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -670,6 +887,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "endian-type"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -677,19 +900,35 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
+
+[[package]]
+name = "ff"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "figment"
@@ -719,6 +958,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "find-msvc-tools"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
+
+[[package]]
 name = "float-cmp"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -739,7 +984,7 @@ dependencies = [
  "intl_pluralrules",
  "rustc-hash",
  "self_cell",
- "smallvec 1.15.1",
+ "smallvec 1.15.2",
  "unic-langid",
 ]
 
@@ -806,9 +1051,12 @@ dependencies = [
 
 [[package]]
 name = "fragile"
-version = "2.0.1"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28dd6caf6059519a65843af8fe2a3ae298b14b80179855aeb4adc2c1934ee619"
+checksum = "8878864ba14bb86e818a412bfd6f18f9eabd4ec0f008a28e8f7eb61db532fcf9"
+dependencies = [
+ "futures-core",
+]
 
 [[package]]
 name = "fs-set-times"
@@ -904,9 +1152,9 @@ checksum = "cd417de3d1d015fc3bfd2b1ea46dfc7bab72ef86f1cc7cc9c78e728b34a6d1fd"
 
 [[package]]
 name = "futures-timer"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
 
 [[package]]
 name = "futures-util"
@@ -927,19 +1175,20 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.14.7"
+version = "0.14.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+checksum = "4bb6743198531e02858aeaea5398fcc883e71851fcbcb5a2f773e2fb6cb1edf2"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -950,23 +1199,35 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
- "wasi 0.14.3+wasi-0.2.4",
+ "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "glob"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
 
 [[package]]
 name = "gloo-timers"
@@ -981,21 +1242,32 @@ dependencies = [
 ]
 
 [[package]]
-name = "h2"
-version = "0.4.15"
+name = "group"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "839c0e8a181239723652be9062bb56ca5bf5f64011f73b623f6f4fc59086a228"
 dependencies = [
  "atomic-waker",
  "bytes 1.12.1",
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.3.1",
+ "http 1.5.0",
  "indexmap",
  "slab",
  "tokio",
- "tokio-util 0.7.16",
+ "tokio-util 0.7.19",
  "tracing",
 ]
 
@@ -1006,6 +1278,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -1048,6 +1329,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "html5ever"
 version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1071,12 +1370,11 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.3.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
+checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
 dependencies = [
  "bytes 1.12.1",
- "fnv",
  "itoa",
 ]
 
@@ -1093,12 +1391,12 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
 dependencies = [
  "bytes 1.12.1",
- "http 1.3.1",
+ "http 1.5.0",
 ]
 
 [[package]]
@@ -1109,9 +1407,19 @@ checksum = "23169fe34a5fbcdd3f3862e78fb9b6fccd5f02a6dc6f732547005d45631ce71c"
 dependencies = [
  "bytes 1.12.1",
  "futures-core",
- "http 1.3.1",
- "http-body 1.0.1",
+ "http 1.5.0",
+ "http-body 1.1.0",
  "pin-project-lite",
+]
+
+[[package]]
+name = "http-serde"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f056c8559e3757392c8d091e796416e4649d8e49e88b8d76df6c002f05027fd"
+dependencies = [
+ "http 1.5.0",
+ "serde",
 ]
 
 [[package]]
@@ -1160,32 +1468,46 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "h2",
- "http 1.3.1",
- "http-body 1.0.1",
+ "http 1.5.0",
+ "http-body 1.1.0",
  "httparse",
  "httpdate",
  "itoa",
  "pin-project-lite",
- "smallvec 1.15.1",
+ "smallvec 1.15.2",
  "tokio",
  "want",
 ]
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.7"
+version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
- "http 1.3.1",
+ "http 1.5.0",
  "hyper 1.11.0",
  "hyper-util",
+ "log",
  "rustls",
- "rustls-pki-types",
+ "rustls-native-certs",
  "tokio",
  "tokio-rustls",
  "tower-service",
  "webpki-roots",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
+dependencies = [
+ "hyper 1.11.0",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
 ]
 
 [[package]]
@@ -1214,14 +1536,14 @@ dependencies = [
  "bytes 1.12.1",
  "futures-channel",
  "futures-util",
- "http 1.3.1",
- "http-body 1.0.1",
+ "http 1.5.0",
+ "http-body 1.1.0",
  "hyper 1.11.0",
  "ipnet",
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.0",
+ "socket2 0.6.5",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -1231,9 +1553,9 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.63"
+version = "0.1.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0c919e5debc312ad217002b8048a17b7d83f80703865bbfcfebb0458b0b27d8"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -1255,12 +1577,13 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.0.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "200072f5d0e3614556f94a9930d5dc3e0662a652823904c3a75dc3b0af7fee47"
+checksum = "fa68d21081c4a05d5a901a1c62add574c77048b6a1c67be3b50ce0b60d4ca513"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -1268,9 +1591,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.0.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cde2700ccaed3872079a65fb1a78f6c0a36c91570f28755dda67bc8f7d9f00a"
+checksum = "d56e28588da92eee5c3201a6eff33fabdd49b62269c8938d4ff050ce4d900deb"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -1281,57 +1604,53 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.0.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "436880e8e18df4d7bbc06d58432329d6458cc84531f7ac5f024e93deadb37979"
+checksum = "12f9cf5f235641ed274641dd81c3f28d870e276763d0797aeeab72317b1c646f"
 dependencies = [
- "displaydoc",
  "icu_collections",
  "icu_normalizer_data",
  "icu_properties",
  "icu_provider",
- "smallvec 1.15.1",
+ "smallvec 1.15.2",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.0.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00210d6893afc98edb752b664b8890f0ef174c8adbb8d0be9710fa66fbbf72d3"
+checksum = "1563da1ed3e0b3bf3d74c9b85917ac9c56464d2f57242270c09c9e752f8021a0"
 
 [[package]]
 name = "icu_properties"
-version = "2.0.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "016c619c1eeb94efb86809b015c58f479963de65bdb6253345c1a1276f22e32b"
+checksum = "7e7ca276ad3145661a65914e6daf131ca5120cd3dcee8f8f3214b8875184a148"
 dependencies = [
  "displaydoc",
  "icu_collections",
  "icu_locale_core",
  "icu_properties_data",
  "icu_provider",
- "potential_utf",
  "zerotrie",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_properties_data"
-version = "2.0.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "298459143998310acd25ffe6810ed544932242d3f07083eee1084d83a71bd632"
+checksum = "e590f038c1464a96894fd6d10127e90a8be4509f56ff7ecef851b15cee0b7caa"
 
 [[package]]
 name = "icu_provider"
-version = "2.0.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03c80da27b5f4187909049ee2d72f276f0d9f99a42c306bd0131ecfe04d8e5af"
+checksum = "d27bbb9d3abbefac45d55f647c9de1d44aafcd1186eb91879afef17c396c3e73"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
- "stable_deref_trait",
- "tinystr",
  "writeable",
  "yoke",
  "zerofrom",
@@ -1346,15 +1665,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
 dependencies = [
  "idna_adapter",
- "smallvec 1.15.1",
+ "smallvec 1.15.2",
  "utf8_iter",
 ]
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -1434,40 +1753,41 @@ checksum = "2f0fb0570afe1fed943c5c3d4102d5358592d8625fda6a0007fdbe65a92fba96"
 
 [[package]]
 name = "ipnet"
-version = "2.11.0"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
 
 [[package]]
 name = "is-terminal"
-version = "0.4.16"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "is_terminal_polyfill"
-version = "1.70.1"
+version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itoa"
-version = "1.0.15"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.77"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+checksum = "0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a"
 dependencies = [
- "once_cell",
+ "cfg-if",
+ "futures-util",
  "wasm-bindgen",
 ]
 
@@ -1483,10 +1803,34 @@ dependencies = [
 ]
 
 [[package]]
-name = "lazy-regex"
-version = "3.4.1"
+name = "jsonwebtoken"
+version = "10.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60c7310b93682b36b98fa7ea4de998d3463ccbebd94d935d6b48ba5b6ffa7126"
+checksum = "eba32bfb4ffdeaca3e34431072faf01745c9b26d25504aa7a6cf5684334fc4fc"
+dependencies = [
+ "base64 0.22.1",
+ "ed25519-dalek",
+ "getrandom 0.2.17",
+ "hmac",
+ "js-sys",
+ "p256",
+ "p384",
+ "pem",
+ "rand 0.8.7",
+ "rsa",
+ "serde",
+ "serde_json",
+ "sha2",
+ "signature",
+ "simple_asn1",
+ "zeroize",
+]
+
+[[package]]
+name = "lazy-regex"
+version = "3.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4994ba703f78b083e2f7946dac9251abd83fd43a0365f030e99b69be5b4b9ef9"
 dependencies = [
  "lazy-regex-proc_macros",
  "once_cell",
@@ -1495,14 +1839,14 @@ dependencies = [
 
 [[package]]
 name = "lazy-regex-proc_macros"
-version = "3.4.1"
+version = "3.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ba01db5ef81e17eb10a5e0f2109d1b3a3e29bac3070fdbd7d156bf7dbd206a1"
+checksum = "fd97232314824e6dbef1918a871bb93f51070455e3715bf26e19a6d01aa977a0"
 dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.106",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1510,6 +1854,9 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin",
+]
 
 [[package]]
 name = "libc"
@@ -1518,12 +1865,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
-name = "libredox"
-version = "0.1.9"
+name = "libm"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "391290121bad3d37fbddad76d8f5d1c1c314cfc646d143d7e07a3086ddff0ce3"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "libredox"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d0a00925a9f930d679b6789b721e3a7f9ed110f41b86d2497caa780c3a070a"
 dependencies = [
- "bitflags",
  "libc",
 ]
 
@@ -1535,31 +1887,30 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.0"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
+checksum = "47d9d19d1d6efa0109d2f65ff4c85cddd50bd572e5a00127ab10987290bcefae"
 
 [[package]]
 name = "litrs"
-version = "0.4.2"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5e54036fe321fd421e10d732f155734c4e4afd610dd556d9a82833ab3ee0bed"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "lock_api"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
 dependencies = [
- "autocfg",
  "scopeguard",
 ]
 
 [[package]]
 name = "log"
-version = "0.4.28"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "lru-slab"
@@ -1604,7 +1955,7 @@ checksum = "ac84fd3f360fcc43dc5f5d186f02a94192761a080e8bc58621ad4d12296a58cf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1624,9 +1975,40 @@ checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
 
 [[package]]
 name = "memchr"
-version = "2.7.5"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
+
+[[package]]
+name = "metrics"
+version = "0.24.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89550ee9f79e88fef3119de263694973a8adb26c21d75322164fb8c493039fe2"
+dependencies = [
+ "portable-atomic",
+ "rapidhash",
+]
+
+[[package]]
+name = "metrics-util"
+version = "0.20.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96f8722f8562635f92f8ed992f26df0532266eb03d5202607c20c0d7e9745e13"
+dependencies = [
+ "aho-corasick",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "hashbrown 0.16.1",
+ "indexmap",
+ "metrics",
+ "ordered-float",
+ "quanta",
+ "radix_trie",
+ "rand 0.9.5",
+ "rand_xoshiro",
+ "rapidhash",
+ "sketches-ddsketch",
+]
 
 [[package]]
 name = "mime"
@@ -1645,14 +2027,14 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.0.4"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
 dependencies = [
  "libc",
  "log",
  "wasi 0.11.1+wasi-snapshot-preview1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1678,14 +2060,14 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "native-tls"
-version = "0.2.14"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
 dependencies = [
  "libc",
  "log",
@@ -1705,6 +2087,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
+name = "nibble_vec"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
+dependencies = [
+ "smallvec 1.15.2",
+]
+
+[[package]]
 name = "nohash-hasher"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1718,18 +2109,63 @@ checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
 name = "nu-ansi-term"
-version = "0.50.1"
+version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4a28e057d01f97e61255210fcff094d74ed0466038633e95017f5beb68e4399"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint-dig"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
+dependencies = [
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.8.7",
+ "smallvec 1.15.2",
+ "zeroize",
 ]
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
+name = "num-integer"
+version = "0.1.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ce2d95d4b3734dc35aa2f45e1aa22cd416814592a4f9d9205e11affd5b8e10b"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c92800bd69a1eac91786bcfe9da64a897eb72911b8dc3095decbd07429e8048b"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -1738,6 +2174,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -1750,28 +2187,67 @@ dependencies = [
 ]
 
 [[package]]
-name = "once_cell"
-version = "1.21.3"
+name = "octocrab"
+version = "0.54.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "432fad6f447c52acda76a7a0660f022b21f4c42f373bbdc29f04332ba19a89bf"
+dependencies = [
+ "arc-swap",
+ "async-trait",
+ "base64 0.22.1",
+ "bytes 1.12.1",
+ "cargo_metadata",
+ "cfg-if",
+ "chrono",
+ "futures",
+ "getrandom 0.2.17",
+ "http 1.5.0",
+ "http-body 1.1.0",
+ "http-body-util",
+ "http-serde",
+ "hyper 1.11.0",
+ "hyper-rustls",
+ "hyper-timeout",
+ "hyper-util",
+ "jsonwebtoken",
+ "percent-encoding",
+ "pin-project",
+ "rustls",
+ "secrecy",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "snafu",
+ "tokio",
+ "tower 0.5.3",
+ "tower-http",
+ "url",
+ "web-time",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
-version = "1.70.1"
+version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openssl"
-version = "0.10.73"
+version = "0.10.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8505734d46c8ab1e19a1dce3aef597ad87dcb4c37e7188231769bd6bd51cebf8"
+checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
 dependencies = [
  "bitflags",
  "cfg-if",
  "foreign-types",
  "libc",
- "once_cell",
  "openssl-macros",
  "openssl-sys",
 ]
@@ -1784,20 +2260,20 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "openssl-probe"
-version = "0.1.6"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.109"
+version = "0.9.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90096e2e47630d78b7d1c20952dc621f957103f8bc2c8359ec81290d75238571"
+checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
 dependencies = [
  "cc",
  "libc",
@@ -1810,6 +2286,15 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "ordered-float"
+version = "5.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c860fd3227ca4ac3cc032e2cd20cba3f02ccdf4b610538f8ee6584d56bb62e96"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "ortho_config"
@@ -1850,14 +2335,38 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
+]
+
+[[package]]
+name = "p384"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
 ]
 
 [[package]]
 name = "parking_lot"
-version = "0.12.4"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -1865,15 +2374,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.11"
+version = "0.9.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
- "smallvec 1.15.1",
- "windows-targets 0.52.6",
+ "smallvec 1.15.2",
+ "windows-link",
 ]
 
 [[package]]
@@ -1896,7 +2405,26 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64 0.22.1",
+ "serde_core",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
 ]
 
 [[package]]
@@ -1907,20 +2435,19 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pest"
-version = "2.8.1"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1db05f56d34358a8b1066f67cbb203ee3e7ed2ba674a6263a1d5ec6db2204323"
+checksum = "5a07a60cc7a4d00c91f95c685609d1d2f79050e6804b70ebedd7650f0b839bcf"
 dependencies = [
  "memchr",
- "thiserror 2.0.20",
  "ucd-trie",
 ]
 
 [[package]]
 name = "pest_derive"
-version = "2.8.1"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb056d9e8ea77922845ec74a1c4e8fb17e7c218cc4fc11a15c5d25e189aa40bc"
+checksum = "b3a83744a5c8455b8b3e0dc5031362780a347c878bdd11584d1a8984228cc88d"
 dependencies = [
  "pest",
  "pest_generator",
@@ -1928,25 +2455,24 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.8.1"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87e404e638f781eb3202dc82db6760c8ae8a1eeef7fb3fa8264b2ef280504966"
+checksum = "e0cd3451aa3de60d4b9a1e736885e4dea6b31617598026f12256ad566d63304a"
 dependencies = [
  "pest",
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "pest_meta"
-version = "2.8.1"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edd1101f170f5903fde0914f899bb503d9ff5271d7ba76bbb70bea63690cc0d5"
+checksum = "e04d3a0849e241d7dfce834c83b1c5edc8622009e8dd51a12ba1927c32f05496"
 dependencies = [
  "pest",
- "sha2",
 ]
 
 [[package]]
@@ -1975,7 +2501,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared",
- "rand 0.8.5",
+ "rand 0.8.7",
 ]
 
 [[package]]
@@ -1988,22 +2514,69 @@ dependencies = [
 ]
 
 [[package]]
-name = "pin-project-lite"
-version = "0.2.16"
+name = "pin-project"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der",
+ "pkcs8",
+ "spki",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
 
 [[package]]
 name = "pkg-config"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+checksum = "f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548"
+
+[[package]]
+name = "portable-atomic"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85"
 
 [[package]]
 name = "potential_utf"
-version = "0.1.3"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84df19adbe5b5a0782edcab45899906947ab039ccf4573713735ee7de1e6b08a"
+checksum = "d83eb9bc6d8e5cf568e7a1101d60ee05e81ed50ea106026f3d18deeb046d7661"
 dependencies = [
  "zerovec",
 ]
@@ -2045,27 +2618,36 @@ dependencies = [
 
 [[package]]
 name = "predicates-core"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "727e462b119fe9c93fd0eb1429a5f7647394014cf3c04ab2c0350eeb09095ffa"
+checksum = "cad38746f3166b4031b1a0d39ad9f954dd291e7854fcc0eed52ee41a0b50d144"
 
 [[package]]
 name = "predicates-tree"
-version = "1.0.12"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c"
+checksum = "d0de1b847b39c8131db0467e9df1ff60e6d0562ab8e9a16e568ad0fdb372e2f2"
 dependencies = [
  "predicates-core",
  "termtree",
 ]
 
 [[package]]
-name = "proc-macro-crate"
-version = "3.3.0"
+name = "primeorder"
+version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
 dependencies = [
- "toml_edit",
+ "elliptic-curve",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit 0.25.13+spec-1.1.0",
 ]
 
 [[package]]
@@ -2091,16 +2673,56 @@ checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.119",
  "version_check",
  "yansi",
 ]
 
 [[package]]
-name = "quinn"
-version = "0.11.9"
+name = "proptest"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags",
+ "num-traits",
+ "rand 0.9.5",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
+name = "quanta"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3ab5a9d756f0d97bdc89019bd2e4ea098cf9cde50ee7564dde6b81ccc8f06c7"
+dependencies = [
+ "crossbeam-utils",
+ "libc",
+ "once_cell",
+ "raw-cpuid",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
+name = "quinn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
 dependencies = [
  "bytes 1.12.1",
  "cfg_aliases",
@@ -2109,7 +2731,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.0",
+ "socket2 0.6.5",
  "thiserror 2.0.20",
  "tokio",
  "tracing",
@@ -2118,14 +2740,15 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.13"
+version = "0.11.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+checksum = "04759210543be93709136e28212294a659ef5001836ff4eab4d663e4529bba83"
 dependencies = [
  "bytes 1.12.1",
- "getrandom 0.3.3",
+ "getrandom 0.4.3",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.10.2",
+ "rand_pcg",
  "ring",
  "rustc-hash",
  "rustls",
@@ -2139,16 +2762,16 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.14"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
 dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.0",
+ "socket2 0.6.5",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2167,22 +2790,61 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
-name = "rand"
-version = "0.8.5"
+name = "r-efi"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "radix_trie"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
 dependencies = [
+ "endian-type",
+ "nibble_vec",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
  "rand_core 0.6.4",
 ]
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
- "rand_chacha",
- "rand_core 0.9.3",
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2192,7 +2854,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.9.3",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -2200,21 +2862,75 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
+]
 
 [[package]]
 name = "rand_core"
-version = "0.9.3"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
- "getrandom 0.3.3",
+ "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_xoshiro"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
+dependencies = [
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rapidhash"
+version = "4.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5da7e78a036ce858e8d55b7e7dc8ba3a88b78350fd2155d3591bbd966b58589e"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "11.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.17"
+version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags",
 ]
@@ -2225,7 +2941,7 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
  "libredox",
  "thiserror 1.0.69",
 ]
@@ -2236,7 +2952,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
  "libredox",
  "thiserror 2.0.20",
 ]
@@ -2287,8 +3003,8 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "h2",
- "http 1.3.1",
- "http-body 1.0.1",
+ "http 1.5.0",
+ "http-body 1.1.0",
  "http-body-util",
  "hyper 1.11.0",
  "hyper-rustls",
@@ -2310,7 +3026,7 @@ dependencies = [
  "tokio",
  "tokio-native-tls",
  "tokio-rustls",
- "tower 0.5.2",
+ "tower 0.5.3",
  "tower-http",
  "tower-service",
  "url",
@@ -2321,6 +3037,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac",
+ "subtle",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2328,10 +3054,30 @@ checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rsa"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
+dependencies = [
+ "const-oid",
+ "digest",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "signature",
+ "spki",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -2359,15 +3105,15 @@ dependencies = [
  "regex",
  "relative-path",
  "rustc_version",
- "syn 2.0.106",
+ "syn 2.0.119",
  "unicode-ident",
 ]
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.1"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustc_version"
@@ -2388,7 +3134,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2403,10 +3149,11 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.31"
+version = "0.23.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0ebcbd2f03de0fc1122ad9bb24b127a5a6cd51d72604a3f3c50ac459762b6cc"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
 dependencies = [
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -2416,10 +3163,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-pki-types"
-version = "1.12.0"
+name = "rustls-native-certs"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
 dependencies = [
  "web-time",
  "zeroize",
@@ -2427,9 +3186,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.4"
+version = "0.103.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a17884ae0c1b773f1ccd2bd4a8c72f16da897310a98b0e84bf349ad5ead92fc"
+checksum = "f3c3cf1d8b1e7d4927e2d154c3fcb02979afb9939629c62cd9048d4f07b60ac2"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -2438,15 +3197,27 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "ryu"
-version = "1.0.20"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "saphyr-parser"
@@ -2460,11 +3231,11 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.27"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2474,13 +3245,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
-name = "security-framework"
-version = "2.11.1"
+name = "sec1"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array",
+ "pkcs8",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "secrecy"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -2488,9 +3282,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.14.0"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49db231d56a190491cb4aeda9527f1ad45345af50b0851622a7adb8c03b01c32"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -2498,15 +3292,19 @@ dependencies = [
 
 [[package]]
 name = "self_cell"
-version = "1.2.2"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b12e76d157a900eb52e81bc6e9f3069344290341720e9178cde2407113ac8d89"
+checksum = "2ab42ca02749e120097e328d91d415325bdf43b1c72c4c8badf37375fe40a813"
 
 [[package]]
 name = "semver"
-version = "1.0.26"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+dependencies = [
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "serde"
@@ -2630,7 +3428,7 @@ checksum = "94e153fc76e1c6a068703d6d29c508a0b15c061c4b7e43da59cc097bc342673c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2640,7 +3438,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -2655,9 +3453,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook"
@@ -2671,9 +3469,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-mio"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34db1a06d485c9142248b7a054f034b349b212551f3dfd19c94d45a754a217cd"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
 dependencies = [
  "libc",
  "mio",
@@ -2682,11 +3480,22 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.6"
+version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2a4719bff48cee6b39d12c020eeb490953ad2443b7055bd0b21fca26bd8c28b"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
+ "errno",
  "libc",
+]
+
+[[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2694,6 +3503,18 @@ name = "similar"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+
+[[package]]
+name = "simple_asn1"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "thiserror 2.0.20",
+ "time 0.3.55",
+]
 
 [[package]]
 name = "simple_logger"
@@ -2704,33 +3525,60 @@ dependencies = [
  "atty",
  "colored",
  "log",
- "time 0.3.41",
+ "time 0.3.55",
  "winapi",
 ]
 
 [[package]]
 name = "siphasher"
-version = "1.0.1"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
+
+[[package]]
+name = "sketches-ddsketch"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c6f73aeb92d671e0cc4dca167e59b2deb6387c375391bc99ee743f326994a2b"
 
 [[package]]
 name = "slab"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "smallvec"
 version = "2.0.0-alpha.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef784004ca8777809dcdad6ac37629f0a97caee4c685fcea805278d81dd8b857"
+
+[[package]]
+name = "snafu"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e84b3f4eacbf3a1ce05eac6763b4d629d60cbc94d632e4092c54ade71f1e1a2"
+dependencies = [
+ "snafu-derive",
+]
+
+[[package]]
+name = "snafu-derive"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "socket2"
@@ -2744,19 +3592,35 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.0"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "spin"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
 ]
 
 [[package]]
 name = "stable_deref_trait"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "strict"
@@ -2803,9 +3667,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.106"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2840,7 +3704,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2850,7 +3714,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
  "bitflags",
- "core-foundation",
+ "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
 
@@ -2871,10 +3735,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.3",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2890,9 +3754,9 @@ dependencies = [
 
 [[package]]
 name = "termimad"
-version = "0.35.1"
+version = "0.35.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d53d4b1294b87e81925b7ae7f8f4d000376e3a5b3349d978429665428a793fcb"
+checksum = "bc986efe2e680fbd1051790103f01b176eb6b1bbc926e41d46adfe44ea43614c"
 dependencies = [
  "coolor",
  "crokey",
@@ -2959,7 +3823,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2975,9 +3839,9 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
 dependencies = [
  "cfg-if",
 ]
@@ -2995,32 +3859,31 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.41"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
+checksum = "cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134"
 dependencies = [
  "deranged",
- "itoa",
  "libc",
  "num-conv",
  "num_threads",
  "powerfmt",
- "serde",
+ "serde_core",
  "time-core",
  "time-macros",
 ]
 
 [[package]]
 name = "time-core"
-version = "0.1.4"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.22"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3526739392ec93fd8b359c8e98514cb3e8e021beb4e5f597b00a0221f8ed8a49"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
 dependencies = [
  "num-conv",
  "time-core",
@@ -3028,19 +3891,20 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.1"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d4f6d1145dcb577acf783d4e601bc1d76a13337bb54e6233add580b07344c8b"
+checksum = "b1e27c91459209c2986af3dcf603a5a74a4368754ce37414f59acc971167f643"
 dependencies = [
  "displaydoc",
+ "serde_core",
  "zerovec",
 ]
 
 [[package]]
 name = "tinyvec"
-version = "1.10.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -3053,9 +3917,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "bytes 1.12.1",
  "libc",
@@ -3063,20 +3927,20 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.0",
+ "socket2 0.6.5",
  "tokio-macros",
- "windows-sys 0.61.1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.1"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -3091,9 +3955,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.26.2"
+version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
  "tokio",
@@ -3115,13 +3979,14 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.16"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14307c986784f72ef81c89db7d9e28d6ac26d16213b109ea501696195e6e3ce5"
+checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
 dependencies = [
  "bytes 1.12.1",
  "futures-core",
  "futures-sink",
+ "libc",
  "pin-project-lite",
  "tokio",
 ]
@@ -3135,7 +4000,7 @@ dependencies = [
  "serde",
  "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
- "toml_edit",
+ "toml_edit 0.22.27",
 ]
 
 [[package]]
@@ -3182,7 +4047,19 @@ dependencies = [
  "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
  "toml_write",
- "winnow 0.7.13",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.13+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
+dependencies = [
+ "indexmap",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "winnow 1.0.4",
 ]
 
 [[package]]
@@ -3219,17 +4096,19 @@ dependencies = [
 
 [[package]]
 name = "tower"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
  "pin-project-lite",
  "sync_wrapper",
  "tokio",
+ "tokio-util 0.7.19",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -3241,12 +4120,13 @@ dependencies = [
  "bitflags",
  "bytes 1.12.1",
  "futures-util",
- "http 1.3.1",
- "http-body 1.0.1",
+ "http 1.5.0",
+ "http-body 1.1.0",
  "pin-project-lite",
- "tower 0.5.2",
+ "tower 0.5.3",
  "tower-layer",
  "tower-service",
+ "tracing",
  "url",
 ]
 
@@ -3282,7 +4162,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3317,7 +4197,7 @@ dependencies = [
  "once_cell",
  "regex-automata",
  "sharded-slab",
- "smallvec 1.15.1",
+ "smallvec 1.15.2",
  "thread_local",
  "tracing",
  "tracing-core",
@@ -3341,15 +4221,21 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.18.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "ucd-trie"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
+
+[[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "uncased"
@@ -3399,21 +4285,21 @@ checksum = "a1249a628de3ad34b821ecb1001355bca3940bcb2f88558f1a8bd82e977f75b5"
 dependencies = [
  "proc-macro-hack",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.119",
  "unic-langid-impl",
 ]
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.18"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.12.0"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-width"
@@ -3437,6 +4323,7 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -3496,9 +4383,13 @@ dependencies = [
  "insta",
  "libc",
  "markup5ever_rcdom",
+ "metrics",
+ "metrics-util",
  "mockall",
+ "octocrab",
  "ortho_config",
  "predicates",
+ "proptest",
  "regex",
  "reqwest",
  "rstest",
@@ -3547,58 +4438,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
-name = "wasi"
-version = "0.14.3+wasi-0.2.4"
+name = "wasip2"
+version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a51ae83037bdd272a9e28ce236db8c07016dd0d50c27038b3f407533c030c95"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
  "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.100"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+checksum = "1b70935747edd64d89de3efa29d73789b806c15798f8e7dca4d8ac356b50ce70"
 dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",
-]
-
-[[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.100"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
-dependencies = [
- "bumpalo",
- "log",
- "proc-macro2",
- "quote",
- "syn 2.0.106",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.50"
+version = "0.4.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
+checksum = "6b7777d5cc23d0e91404e53ce2d5e8ec7acae3026b16233dba62cd3246457950"
 dependencies = [
- "cfg-if",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.100"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+checksum = "77775f8f3f7217702089053b94958f8f54061a3f663417df76e19cbdcca29bc1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3606,31 +4481,31 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.100"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+checksum = "e11d33f857dc2fb11b8bc75aee111aa9cbeb12cd9f25efd3d4c2a3dd4e235284"
 dependencies = [
+ "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.106",
- "wasm-bindgen-backend",
+ "syn 2.0.119",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.100"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.77"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+checksum = "c435338968042f4f59a557f690a253676d47ce13ceb55d70100e7facf6620a30"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3643,6 +4518,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
+ "serde",
  "wasm-bindgen",
 ]
 
@@ -3660,9 +4536,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.2"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e8983c3ab33d6fb807cfcdad2491c4ea8cbc8ed839181c7dfd9c67c83e261b2"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -3691,78 +4567,72 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
-version = "0.61.2"
+version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-link 0.1.3",
+ "windows-link",
  "windows-result",
  "windows-strings",
 ]
 
 [[package]]
 name = "windows-implement"
-version = "0.60.0"
+version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "windows-interface"
-version = "0.59.1"
+version = "0.59.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "windows-link"
-version = "0.1.3"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
-
-[[package]]
-name = "windows-link"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-registry"
-version = "0.5.3"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
 dependencies = [
- "windows-link 0.1.3",
+ "windows-link",
  "windows-result",
  "windows-strings",
 ]
 
 [[package]]
 name = "windows-result"
-version = "0.3.4"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-link 0.1.3",
+ "windows-link",
 ]
 
 [[package]]
 name = "windows-strings"
-version = "0.4.2"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-link 0.1.3",
+ "windows-link",
 ]
 
 [[package]]
@@ -3798,16 +4668,16 @@ version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets 0.53.3",
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
 name = "windows-sys"
-version = "0.61.1"
+version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f109e41dd4a3c848907eb83d5a42ea98b3769495597450cf6d153507b166f0f"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link 0.2.0",
+ "windows-link",
 ]
 
 [[package]]
@@ -3843,19 +4713,19 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.53.3"
+version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
- "windows-link 0.1.3",
- "windows_aarch64_gnullvm 0.53.0",
- "windows_aarch64_msvc 0.53.0",
- "windows_i686_gnu 0.53.0",
- "windows_i686_gnullvm 0.53.0",
- "windows_i686_msvc 0.53.0",
- "windows_x86_64_gnu 0.53.0",
- "windows_x86_64_gnullvm 0.53.0",
- "windows_x86_64_msvc 0.53.0",
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -3872,9 +4742,9 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -3890,9 +4760,9 @@ checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3908,9 +4778,9 @@ checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
 
 [[package]]
 name = "windows_i686_gnullvm"
@@ -3920,9 +4790,9 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_gnullvm"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -3938,9 +4808,9 @@ checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3956,9 +4826,9 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -3974,9 +4844,9 @@ checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -3992,15 +4862,15 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "0.7.13"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
  "memchr",
 ]
@@ -4010,6 +4880,9 @@ name = "winnow"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winx"
@@ -4023,15 +4896,15 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
-version = "0.45.0"
+version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "052283831dbae3d879dc7f51f3d92703a316ca49f91540417d38591826127814"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "writeable"
-version = "0.6.1"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
+checksum = "3ad82d2a33cdc9674dc7465672f271e096168fcdbe0f799d9e6db8c5892679dc"
 
 [[package]]
 name = "xdg"
@@ -4057,11 +4930,10 @@ checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoke"
-version = "0.8.0"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f41bb01b8226ef4bfd589436a297c53d118f65921786300e427be8d487695cc"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
- "serde",
  "stable_deref_trait",
  "yoke-derive",
  "zerofrom",
@@ -4069,68 +4941,82 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.119",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.26"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
+checksum = "556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.26"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
+checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.119",
  "synstructure",
 ]
 
 [[package]]
 name = "zeroize"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "zerotrie"
-version = "0.2.2"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36f0bbd478583f79edad978b407914f61b2972f5af6fa089686016be8f9af595"
+checksum = "4ea269c3bd32f0a32c321907a2ae912ba6f4649bb0fc764a15627e99a7095a3f"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -4139,10 +5025,11 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.4"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7aa2bd55086f1ab526693ecbe444205da57e25f4489879da80635a46d90e73b"
+checksum = "bb0464e17806c1d976d5cba29399c7f08e516e279e2ba493f63123b5fca67dd8"
 dependencies = [
+ "serde",
  "yoke",
  "zerofrom",
  "zerovec-derive",
@@ -4150,13 +5037,13 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.1"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
+checksum = "34df6fc39dbd26ddc9c10e6a2984476e13acce22e64e4487636ef494369225da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 3.0.3",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3489,7 +3489,7 @@ dependencies = [
  "diffy",
  "futures",
  "html5ever",
- "http 1.3.1",
+ "http 1.5.0",
  "http-body-util",
  "hyper 1.11.0",
  "hyper-util",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3489,6 +3489,7 @@ dependencies = [
  "diffy",
  "futures",
  "html5ever",
+ "http 1.3.1",
  "http-body-util",
  "hyper 1.11.0",
  "hyper-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,6 +79,7 @@ pkg-fmt = "tgz"
 [lints.clippy]
 pedantic = { level = "warn", priority = -1 }
 trivially_copy_pass_by_ref = "warn"
+missing_docs_in_private_items = "deny"
 
 # 1. hygiene
 # Unfortunately, due to an 'unused-braces' false postive with
@@ -116,3 +117,15 @@ string_lit_as_bytes    = "deny"
 
 # 6. numerical foot-guns
 float_arithmetic = "deny"
+
+[lints.rust]
+missing_docs = "deny"
+
+[lints.rustdoc]
+missing_crate_level_docs = "deny"
+broken_intra_doc_links = "deny"
+private_intra_doc_links = "deny"
+bare_urls = "deny"
+invalid_html_tags = "deny"
+invalid_codeblock_attributes = "deny"
+unescaped_backticks = "deny"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,17 @@ anyhow = "1.0"
 backon = "1.5.2"
 html5ever = "0.35.0"
 markup5ever_rcdom = "0.35.0"
+# Tilde pin: octocrab has shipped breaking changes in patch releases
+# (upstream issue 899); widen only after review. The `retry` feature is
+# deliberately excluded so the REST reply path stays retry-free (see
+# docs/adr-001-github-api-client-modernisation.md).
+octocrab = { version = "~0.54", default-features = false, features = [
+    "default-client",
+    "jwt-rust-crypto",
+    "rustls",
+    "rustls-ring",
+    "timeout",
+] }
 ortho_config = "0.9.0"
 base64 = "0.23.0"
 tracing = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ chrono = { version = "0.4.42", features = ["serde", "clock"] }
 anyhow = "1.0"
 backon = "1.5.2"
 html5ever = "0.35.0"
+http = "1"
 markup5ever_rcdom = "0.35.0"
 # Tilde pin: octocrab has shipped breaking changes in patch releases
 # (upstream issue 899); widen only after review. The `retry` feature is

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ backon = "1.5.2"
 html5ever = "0.35.0"
 http = "1"
 markup5ever_rcdom = "0.35.0"
+metrics = "0.24.6"
 # Patch updates within octocrab 0.54 are accepted; widening to 0.55 requires
 # review. The `retry` feature is deliberately excluded so the REST reply path
 # stays retry-free (see docs/adr-001-github-api-client-modernisation.md).
@@ -64,6 +65,8 @@ http-body-util = "0.1"
 bytes = "1"
 futures = "0.3"
 insta = { version = "1.43", features = ["redactions"] }
+metrics-util = { version = "0.20.4", features = ["debugging"] }
+proptest = "1.11.0"
 
 [target.'cfg(unix)'.dev-dependencies]
 libc = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ reqwest = { version = "0.12.23", features = ["json", "rustls-tls"] }
 serde = { version = "1.0.196", features = ["derive"] }
 serde_json = "1.0.113"
 serde_path_to_error = "0.1.17"
-tokio = { version = "1.36.0", features = ["rt-multi-thread", "macros"] }
+tokio = { version = "1.36.0", features = ["rt-multi-thread", "macros", "time"] }
 termimad = "0.35.1"
 thiserror = "2.0.16"
 url = "2.5.0"
@@ -26,10 +26,9 @@ backon = "1.5.2"
 html5ever = "0.35.0"
 http = "1"
 markup5ever_rcdom = "0.35.0"
-# Tilde pin: octocrab has shipped breaking changes in patch releases
-# (upstream issue 899); widen only after review. The `retry` feature is
-# deliberately excluded so the REST reply path stays retry-free (see
-# docs/adr-001-github-api-client-modernisation.md).
+# Patch updates within octocrab 0.54 are accepted; widening to 0.55 requires
+# review. The `retry` feature is deliberately excluded so the REST reply path
+# stays retry-free (see docs/adr-001-github-api-client-modernisation.md).
 octocrab = { version = "~0.54", default-features = false, features = [
     "default-client",
     "jwt-rust-crypto",

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,10 @@
-.PHONY: help all clean test build release lint fmt check-fmt markdownlint nixie
+.PHONY: help all clean test typecheck build release lint fmt check-fmt markdownlint nixie
 
 APP ?= vk
 CARGO ?= cargo
 BUILD_JOBS ?=
 CLIPPY_FLAGS ?= --all-targets --all-features -- -D warnings
+RUSTDOC_FLAGS ?= --cfg docsrs -D warnings
 MDLINT ?= markdownlint-cli2
 NIXIE ?= nixie
 
@@ -18,11 +19,15 @@ clean: ## Remove build artifacts
 test: ## Run tests with warnings treated as errors
 	RUSTFLAGS="-D warnings" $(CARGO) test --all-targets --all-features $(BUILD_JOBS)
 
+typecheck: ## Check all targets and features
+	$(CARGO) check --all-targets --all-features $(BUILD_JOBS)
+
 target/%/$(APP): Cargo.toml ## Build binary in debug or release mode
 	$(CARGO) build $(BUILD_JOBS) $(if $(findstring release,$(@)),--release) --bin $(APP)
 
-lint: ## Run Clippy with warnings denied
+lint: ## Run Clippy and rustdoc with warnings denied
 	$(CARGO) clippy $(CLIPPY_FLAGS)
+	RUSTDOCFLAGS="$(RUSTDOC_FLAGS)" RUSTFLAGS="$${RUSTFLAGS:+$$RUSTFLAGS }-D warnings" $(CARGO) doc --no-deps
 
 fmt: ## Format Rust and Markdown sources
 	$(CARGO) fmt --all

--- a/docs/adr-001-github-api-client-modernisation.md
+++ b/docs/adr-001-github-api-client-modernisation.md
@@ -1,4 +1,4 @@
-# Architectural decision record (ADR) 001: GitHub API client modernisation
+# Architectural decision record (ADR) 001: GitHub API client modernization
 
 ## Status
 
@@ -40,7 +40,7 @@ arrangement carries four problems:
 - Bespoke REST plumbing (authentication, base-URI handling, header
   construction) that duplicates what a maintained library already provides.
 
-The question this record settles is how to modernise GitHub API access without
+The question this record settles is how to modernize GitHub API access without
 regressing the observable behaviour that the test suite pins: command output,
 error-message fragments, retry semantics, transcript format, authentication
 precedence, and the environment-variable endpoint overrides.
@@ -56,7 +56,7 @@ precedence, and the environment-variable endpoint overrides.
   exact error text; neither may change.
 - Converge on a single HTTP stack rather than maintaining two.
 - Gain compile-time validation of GraphQL queries and their variables.
-- Minimise bespoke plumbing by delegating maintained concerns to a library
+- Minimize bespoke plumbing by delegating maintained concerns to a library
   where doing so does not compromise observability.
 - Keep TLS rustls-only; introduce no native-tls or OpenSSL dependency.
 - Remain compatible with the minimum supported Rust version (MSRV) of 1.89.

--- a/docs/adr-001-github-api-client-modernisation.md
+++ b/docs/adr-001-github-api-client-modernisation.md
@@ -1,0 +1,181 @@
+# Architectural decision record (ADR) 001: GitHub API client modernisation
+
+## Status
+
+Accepted (2026-07-09). The project owner accepted the three-part programme
+after reviewing the ExecPlan draft: octocrab for the REST resolve path, a
+direct hyper transport inside the bespoke GraphQL client (removing reqwest), and
+`graphql_client` codegen for compile-time-checked GraphQL queries.
+
+## Date
+
+2026-07-09.
+
+## Context and problem statement
+
+`vk` is a command-line tool that shows unresolved GitHub pull request review
+comments. It talks to GitHub through two bespoke, hand-rolled clients built
+directly on the `reqwest` crate:
+
+- A GraphQL client (`src/api/client/`) used by every subcommand. It carries a
+  substantial observability investment: transcript recording of each request,
+  redacted error snippets in failure context, `backon` jittered-exponential
+  retry with transient-error classification (HTTP 5xx, HTTP 429, and
+  HTML-looking bodies), `serde_path_to_error` deserialization diagnostics, and
+  an environment-variable endpoint override (`GITHUB_GRAPHQL_URL`).
+- A feature-gated REST client (`src/resolve/rest.rs`, compiled only under the
+  `unstable-rest-resolve` feature) that posts review-comment replies with no
+  retry and its own environment-variable base-URL override (`GITHUB_API_URL`).
+
+The original decision to hand-roll these clients was never recorded, so the
+constraints that justified it are no longer legible to maintainers. The current
+arrangement carries four problems:
+
+- Two duplicated header-building and client-construction code paths that drift
+  independently.
+- No compile-time checking of GraphQL query strings: queries are raw `&str`
+  constants and operation names are recovered by string-sniffing the query text.
+- A dependency on `reqwest` for work that a single hyper stack could serve,
+  when the rest of the intended stack (hyper, rustls) is already present.
+- Bespoke REST plumbing (authentication, base-URI handling, header
+  construction) that duplicates what a maintained library already provides.
+
+The question this record settles is how to modernise GitHub API access without
+regressing the observable behaviour that the test suite pins: command output,
+error-message fragments, retry semantics, transcript format, authentication
+precedence, and the environment-variable endpoint overrides.
+
+## Decision drivers
+
+- Preserve the observability machinery. Transcript recording, error snippets,
+  and retry classification all depend on access to the raw HTTP response
+  (status and body), including partial-success GraphQL payloads that carry both
+  `data` and `errors`.
+- Preserve the test infrastructure. The environment-variable endpoint overrides
+  redirect the binary to loopback servers, and roughly twenty tests assert
+  exact error text; neither may change.
+- Converge on a single HTTP stack rather than maintaining two.
+- Gain compile-time validation of GraphQL queries and their variables.
+- Minimise bespoke plumbing by delegating maintained concerns to a library
+  where doing so does not compromise observability.
+- Keep TLS rustls-only; introduce no native-tls or OpenSSL dependency.
+- Remain compatible with the minimum supported Rust version (MSRV) of 1.89.
+
+## Options considered
+
+### Option 1: keep both bespoke clients (status quo)
+
+Retain the two `reqwest`-based clients unchanged. This preserves all behaviour
+at zero migration cost but resolves none of the problems: there is no
+compile-time query checking, the duplicated plumbing persists, and two HTTP
+paths remain.
+
+### Option 2: route all traffic through octocrab
+
+Adopt [octocrab](https://docs.rs/octocrab) as the single transport for both
+REST and GraphQL. Rejected: octocrab's `graphql()` helper hides the raw
+response, discarding the partial-success `data` and the response body that the
+transcript, error-snippet, and retry-classification machinery depend on. Its
+default builder accepts no custom middleware layers through which that
+machinery could be reattached, GraphQL cursor pagination remains hand-rolled
+regardless, and the escape-hatch `_post` method would become the primary
+interface. The compile-time-checking gain is marginal because octocrab does not
+type GraphQL queries itself.
+
+### Option 3: graphql_client codegen with reqwest retained
+
+Adopt `graphql_client` codegen for typed queries while keeping `reqwest` as the
+transport. This gains typed queries but keeps two HTTP stacks once octocrab
+arrives for the REST path, and retains the bespoke REST plumbing that a
+maintained library would otherwise absorb.
+
+### Option 4 (adopted): three-part split
+
+Separate the concerns by transport:
+
+- octocrab (tilde-pinned `~0.54`) serves the REST resolve path only, replacing
+  the bespoke `reqwest` REST client and inheriting maintained authentication
+  and base-URI plumbing.
+- A direct hyper transport (`hyper-util` legacy client plus `hyper-rustls`,
+  promoted from dev-dependencies to runtime dependencies) replaces `reqwest`
+  inside the bespoke GraphQL client, which retains its observability machinery.
+  `reqwest` then leaves the dependency graph.
+- `graphql_client` 0.16 codegen validates every query against GitHub's vendored
+  public schema
+  ([`schema.docs.graphql`](https://docs.github.com/public/fpt/schema.docs.graphql))
+  at compile time. Generated types stay private behind conversions to the
+  existing exported domain structs.
+
+| Dimension                     | Option 1 | Option 2 | Option 3 | Option 4 |
+| ----------------------------- | -------- | -------- | -------- | -------- |
+| Compile-time query checking   | No       | Marginal | Yes      | Yes      |
+| HTTP stacks after change      | Two      | One      | Two      | One      |
+| Observability preserved       | Yes      | No       | Yes      | Yes      |
+| Bespoke REST plumbing removed | No       | Yes      | No       | Yes      |
+| Maintained REST library       | No       | Yes      | Yes      | Yes      |
+
+_Table 1: Comparison of the four GitHub API client options against the decision
+drivers._
+
+## Decision outcome
+
+Adopt option 4, the three-part split. octocrab's value concentrates in its
+typed REST surface and maintained plumbing, whereas the bespoke GraphQL
+client's value is its observability, which octocrab's `graphql()` helper would
+discard. octocrab's own GraphQL example delegates query typing to
+`graphql_client`, confirming that the intended division of labour matches the
+tools' strengths.
+
+The programme is delivered as three pull requests, each behaviour-preserving
+and gated by the existing test suite:
+
+1. Adopt octocrab for the REST resolve path.
+2. Replace `reqwest` inside the GraphQL client with a hyper transport and
+   remove `reqwest` from the dependency graph.
+3. Adopt `graphql_client` codegen so malformed queries fail the build rather
+   than a runtime request.
+
+The REST-first ordering proves octocrab in-tree with the smallest blast radius;
+the transport change then removes `reqwest` before the largest change; the
+codegen change is type-level only and benefits from a settled transport beneath
+it.
+
+## Migration plan
+
+The migration is tracked as a living document in the ExecPlan
+[`docs/execplans/adopt-octocrab.md`](execplans/adopt-octocrab.md). Its numbered
+phases correspond to the three pull requests above, and it records the
+constraints, tolerances, risks, decision log, and per-phase acceptance criteria
+in detail. This record does not duplicate that content; consult the ExecPlan
+for the authoritative migration sequence and progress.
+
+## Known risks and limitations
+
+- octocrab has shipped breaking changes in patch releases (upstream issue 899).
+  The dependency is therefore tilde-pinned (`~0.54`) rather than caret-ranged,
+  with the reason recorded both here and in a `Cargo.toml` comment; widen only
+  after review.
+- The hyper transport must reproduce the pooling, TLS root-store, and
+  total-request timeout semantics that `reqwest` provided for free. A subtle
+  difference under failure could change behaviour; the retry and timeout unit
+  tests act as a characterization harness because the transport change alters
+  nothing else.
+- GitHub's vendored public schema is roughly 1.5 MB, and each
+  `#[derive(GraphQLQuery)]` re-parses it at compile time. The build-time impact
+  is bounded by the tolerance recorded in the ExecPlan; operations are grouped
+  per document to amortise the parse.
+- GitHub's custom scalars (`DateTime`, `URI`, `HTML`, and related types)
+  require Rust type aliases in scope of each derive. A shared `scalars` module
+  supplies them; a missing alias surfaces as an easily misread compile error.
+
+## Design for reuse
+
+The refitted GraphQL client is shaped for cheap future extraction into a shared
+crate. The sibling project frankie (a code-review terminal user interface,
+currently REST-only on octocrab) will need the same GraphQL review-thread
+surface, and the executor (transport, retry, transcript, typed operations, and
+cursor pagination) is the reusable part while query documents stay per-project.
+To keep extraction cheap, `vk`-specific coupling (`VkError` and
+`vk::environment`) is confined to the edges of the transport and typed modules
+rather than woven through them. Extraction itself is out of scope for this
+decision.

--- a/docs/adr-001-github-api-client-modernisation.md
+++ b/docs/adr-001-github-api-client-modernisation.md
@@ -163,7 +163,7 @@ for the authoritative migration sequence and progress.
 - GitHub's vendored public schema is roughly 1.5 MB, and each
   `#[derive(GraphQLQuery)]` re-parses it at compile time. The build-time impact
   is bounded by the tolerance recorded in the ExecPlan; operations are grouped
-  per document to amortise the parse.
+  per document to amortize the parse.
 - GitHub's custom scalars (`DateTime`, `URI`, `HTML`, and related types)
   require Rust type aliases in scope of each derive. A shared `scalars` module
   supplies them; a missing alias surfaces as an easily misread compile error.

--- a/docs/contents.md
+++ b/docs/contents.md
@@ -40,6 +40,8 @@
 - [Execution plans](execplans/): Use this directory for living implementation
   plans that need to survive context handoffs.
   - [Adopt octocrab](execplans/adopt-octocrab.md): Use this for the living
-    plan to replace the bespoke reqwest clients with the octocrab library.
+    plan to modernise GitHub API access — octocrab for REST, a hyper
+    transport for the bespoke GraphQL client, and `graphql_client` codegen
+    for typed queries.
   - [Adopt Ortho Config v0.8.0](execplans/adopt-ortho-config-v0-8-0.md): Use
     this for the recorded plan behind the v0.8.0 configuration adoption work.

--- a/docs/contents.md
+++ b/docs/contents.md
@@ -29,10 +29,10 @@
 
 ## Architecture decision records
 
-- [ADR 001: GitHub API client modernization](adr-001-github-api-client-modernisation.md):
-  Use this for the accepted decision to serve REST through octocrab, move the
-  bespoke GraphQL client onto hyper transport, and add `graphql_client` codegen
-  for typed queries.
+- [ADR 001: GitHub API client](adr-001-github-api-client-modernisation.md):
+  Records the accepted decision to serve REST through octocrab, move the
+  bespoke GraphQL client onto hyper transport, and add `graphql_client` code
+  generation for typed queries.
 
 ## Migration guides
 
@@ -46,9 +46,9 @@
 
 - [Execution plans](execplans/): Use this directory for living implementation
   plans that need to survive context handoffs.
-  - [Adopt octocrab](execplans/adopt-octocrab.md): Use this for the living
-    plan to modernize GitHub API access — octocrab for REST,
-    transport for the bespoke GraphQL client, and `graphql_client` codegen
-    for typed queries.
+  - [Adopt octocrab](execplans/adopt-octocrab.md):
+    Records the living plan to modernize GitHub API access: octocrab for REST,
+    hyper transport for the bespoke GraphQL client, and `graphql_client`
+    code generation for typed queries.
   - [Adopt Ortho Config v0.8.0](execplans/adopt-ortho-config-v0-8-0.md): Use
     this for the recorded plan behind the v0.8.0 configuration adoption work.

--- a/docs/contents.md
+++ b/docs/contents.md
@@ -29,10 +29,10 @@
 
 ## Architecture decision records
 
-- [ADR 001: GitHub API client modernisation](adr-001-github-api-client-modernisation.md):
+- [ADR 001: GitHub API client modernization](adr-001-github-api-client-modernisation.md):
   Use this for the accepted decision to serve REST through octocrab, move the
-  bespoke GraphQL client onto a hyper transport, and add `graphql_client`
-  codegen for typed queries.
+  bespoke GraphQL client onto hyper transport, and add `graphql_client` codegen
+  for typed queries.
 
 ## Migration guides
 
@@ -47,7 +47,7 @@
 - [Execution plans](execplans/): Use this directory for living implementation
   plans that need to survive context handoffs.
   - [Adopt octocrab](execplans/adopt-octocrab.md): Use this for the living
-    plan to modernise GitHub API access — octocrab for REST, a hyper
+    plan to modernize GitHub API access — octocrab for REST,
     transport for the bespoke GraphQL client, and `graphql_client` codegen
     for typed queries.
   - [Adopt Ortho Config v0.8.0](execplans/adopt-ortho-config-v0-8-0.md): Use

--- a/docs/contents.md
+++ b/docs/contents.md
@@ -39,5 +39,7 @@
 
 - [Execution plans](execplans/): Use this directory for living implementation
   plans that need to survive context handoffs.
+  - [Adopt octocrab](execplans/adopt-octocrab.md): Use this for the living
+    plan to replace the bespoke reqwest clients with the octocrab library.
   - [Adopt Ortho Config v0.8.0](execplans/adopt-ortho-config-v0-8-0.md): Use
     this for the recorded plan behind the v0.8.0 configuration adoption work.

--- a/docs/contents.md
+++ b/docs/contents.md
@@ -27,6 +27,13 @@
 - [Documentation style guide](documentation-style-guide.md): Use this for
   spelling, formatting, and document-structure rules.
 
+## Architecture decision records
+
+- [ADR 001: GitHub API client modernisation](adr-001-github-api-client-modernisation.md):
+  Use this for the accepted decision to serve REST through octocrab, move the
+  bespoke GraphQL client onto a hyper transport, and add `graphql_client`
+  codegen for typed queries.
+
 ## Migration guides
 
 - [Ortho Config v0.6.0 migration guide](ortho-config-v0-6-0-migration-guide.md):

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -83,6 +83,23 @@ Before extracting a helper, port, or abstraction, check whether one already
 exists and document the new ownership boundary in the relevant design or
 developer document.
 
+### REST resolve client
+
+REST review-comment replies use octocrab through its raw `_post` route. The
+`http` and `octocrab` entries in `Cargo.toml` are direct dependencies: `http`
+supplies the header types, while octocrab owns authentication, base-URI
+handling, and request execution. The octocrab `retry` feature remains excluded
+so the reply path stays retry-free.
+
+The connection timeout maps to octocrab's connect timeout. The request timeout
+configures octocrab's read and write timeouts and also wraps the complete
+`_post` operation, preserving a total deadline across connection, write, and
+response-read work.
+
+Status interpretation remains in `vk`: the resolve client warns and continues
+for HTTP 404, accepts other successful statuses, and maps every other non-2xx
+status to `VkError::RequestContext` with the route and status.
+
 ## Documentation maintenance
 
 Update documentation in the same branch as the behaviour it describes:

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -100,6 +100,19 @@ Status interpretation remains in `vk`: the resolve client warns and continues
 for HTTP 404, accepts other successful statuses, and maps every other non-2xx
 status to `VkError::RequestContext` with the route and status.
 
+The REST reply boundary emits bounded metrics through the `metrics` crate. The
+`vk.resolve.rest_reply.requests.total` counter and
+`vk.resolve.rest_reply.duration.seconds` histogram use the fixed `outcome`,
+`status_class`, and `failure_category` labels. `outcome` is one of `success`,
+`not_found`, or `failure`; `status_class` is one of `1xx`, `2xx`, `3xx`,
+`4xx`, `5xx`, `other`, or `none`; and `failure_category` is one of `none`,
+`http_status`, `timeout`, or `transport`. The `vk.resolve.rest_reply.timeouts.total`
+counter has no labels.
+These signals measure attempts, elapsed time, and total-deadline expirations
+without adding repository, comment, route, or raw-error values to metric
+cardinality. The module records metrics through the configured recorder and
+does not install a global recorder itself.
+
 ## Documentation maintenance
 
 Update documentation in the same branch as the behaviour it describes:

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -12,6 +12,10 @@ Read these documents before changing behaviour or architecture:
   gates.
 - [Documentation contents](contents.md): index of long-lived project
   documentation.
+- [GitHub API client modernisation ADR](adr-001-github-api-client-modernisation.md):
+  accepted REST and GraphQL client decisions.
+- [Octocrab adoption ExecPlan](execplans/adopt-octocrab.md): implementation
+  plan for the REST client migration.
 - [Repository layout](repository-layout.md): path responsibilities and source
   tree conventions.
 - [VK design](vk-design.md): application architecture and behaviour rationale.
@@ -104,14 +108,14 @@ The REST reply boundary emits bounded metrics through the `metrics` crate. The
 `vk.resolve.rest_reply.requests.total` counter and
 `vk.resolve.rest_reply.duration.seconds` histogram use the fixed `outcome`,
 `status_class`, and `failure_category` labels. `outcome` is one of `success`,
-`not_found`, or `failure`; `status_class` is one of `1xx`, `2xx`, `3xx`,
-`4xx`, `5xx`, `other`, or `none`; and `failure_category` is one of `none`,
-`http_status`, `timeout`, or `transport`. The `vk.resolve.rest_reply.timeouts.total`
-counter has no labels.
-These signals measure attempts, elapsed time, and total-deadline expirations
-without adding repository, comment, route, or raw-error values to metric
-cardinality. The module records metrics through the configured recorder and
-does not install a global recorder itself.
+`not_found`, or `failure`; `status_class` is one of `1xx`, `2xx`, `3xx`, `4xx`,
+`5xx`, `other`, or `none`; and `failure_category` is one of `none`,
+`http_status`, `timeout`, or `transport`. The
+`vk.resolve.rest_reply.timeouts.total` counter has no labels. These signals
+measure attempts, elapsed time, and total-deadline expirations without adding
+repository, comment, route, or raw-error values to metric cardinality. The
+module records metrics through the configured recorder and does not install a
+global recorder itself.
 
 ## Documentation maintenance
 

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -12,7 +12,7 @@ Read these documents before changing behaviour or architecture:
   gates.
 - [Documentation contents](contents.md): index of long-lived project
   documentation.
-- [GitHub API client modernisation ADR](adr-001-github-api-client-modernisation.md):
+- [GitHub API client modernization ADR](adr-001-github-api-client-modernisation.md):
   accepted REST and GraphQL client decisions.
 - [Octocrab adoption ExecPlan](execplans/adopt-octocrab.md): implementation
   plan for the REST client migration.

--- a/docs/execplans/adopt-octocrab.md
+++ b/docs/execplans/adopt-octocrab.md
@@ -183,8 +183,8 @@ escalation, not workarounds.
 - [x] (2026-07-09 15:30Z) Stage A: ADR
   `docs/adr-001-github-api-client-modernisation.md` authored and linked from
   `docs/vk-design.md` and `docs/contents.md`; octocrab `~0.54` added to
-  `Cargo.toml` (default features off; `default-client`, `rustls`, `rustls-ring`,
-  `timeout`; `retry` excluded deliberately).
+  `Cargo.toml` (default features off; `default-client`, `jwt-rust-crypto`,
+  `rustls`, `rustls-ring`, `timeout`; `retry` excluded deliberately).
 - [x] (2026-07-09 17:20Z) PR 1: octocrab REST resolve path complete.
   `src/resolve/rest.rs` reworked onto octocrab via the raw `_post` route with
   `RestClient::new` and `post_reply` signatures and semantics preserved,
@@ -195,6 +195,8 @@ escalation, not workarounds.
 - [x] (2026-07-28) Review follow-up restored the total REST reply deadline,
   strengthened raw POST coverage for the route, body, authentication, required
   headers, and status handling, and reconciled the documentation findings.
+- [x] (2026-08-03) Documentation review follow-up corrected the dependency
+  record, documentation index, Oxford spelling, and REST ownership guidance.
 - [ ] PR 2: hyper transport inside `GraphQLClient`; reqwest removed;
   `cargo tree -i reqwest` fails; full suite green.
 - [ ] PR 3: vendored schema, `.graphql` documents, generated types behind a

--- a/docs/execplans/adopt-octocrab.md
+++ b/docs/execplans/adopt-octocrab.md
@@ -1,4 +1,4 @@
-# Modernize GitHub API access: octocrab REST, hyper transport, typed GraphQL
+# Octocrab REST migration (PR 1): hyper transport and typed GraphQL roadmap
 
 This ExecPlan (execution plan) is a living document. The sections `Constraints`,
 `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`, `Decision Log`,
@@ -9,11 +9,16 @@ Status: IN PROGRESS
 ## Purpose / big picture
 
 `vk` is a command-line tool that shows unresolved GitHub pull request review
-comments in the terminal. Today it talks to GitHub through two hand-rolled HTTP
-clients built directly on the `reqwest` crate: a GraphQL client
-(`src/api/client/`) used by every subcommand, and a REST client
-(`src/resolve/rest.rs`, compiled only under the `unstable-rest-resolve`
-feature) used to post a reply before resolving a review thread.
+comments in the terminal. Its bespoke GraphQL client (`src/api/client/`) still
+uses `reqwest` and is used by every subcommand. When the
+`unstable-rest-resolve` feature is enabled, the REST reply path in
+`src/resolve/rest.rs` uses Octocrab's raw `_post` route. Octocrab supplies the
+authentication and base-URI plumbing; the builder adds
+`x-github-api-version: 2022-11-28` and `Accept: application/vnd.github+json`.
+`post_reply` wraps the complete request in the total deadline, while Octocrab
+also receives the connect, read, and write timeout settings. A 404 warns and
+continues to GraphQL resolution; success does the same, while another non-2xx
+response aborts with the reply route and status in the diagnostic.
 
 An earlier draft of this plan proposed routing everything through
 [octocrab](https://docs.rs/octocrab). Review concluded octocrab is a weak fit
@@ -23,8 +28,7 @@ the REST side (typed pull-request APIs, maintained auth and base-URI plumbing).
 The revised programme is therefore three separable changes, delivered as three
 pull requests:
 
-1. PR 1 — adopt octocrab for the REST resolve path, replacing the bespoke
-   `reqwest`-based `RestClient`.
+1. PR 1 — adopt octocrab for the REST resolve path.
 2. PR 2 — replace `reqwest` inside the bespoke GraphQL client with a direct
    hyper transport, then remove `reqwest` from the dependency graph. The binary
    converges on one HTTP stack (hyper/rustls), shared with octocrab.
@@ -319,7 +323,17 @@ escalation, not workarounds.
 
 ## Outcomes & retrospective
 
-To be completed as milestones land and at the end of the work.
+PR 1 is complete. The REST reply path uses Octocrab's raw `_post` route and
+preserves the route, headers, total deadline, authentication, and
+404-non-fatal/other-non-2xx-fatal semantics. The recorded PR 1 validation ran
+`cargo test --features unstable-rest-resolve --test resolve` and the repository
+gates; the 2026-07-28 follow-up added total-deadline coverage and strengthened
+the route, body, authentication, header, and status assertions.
+
+PR 2 remains future work: replace `reqwest` in the bespoke GraphQL client with
+the planned hyper transport and verify its removal from the dependency graph.
+PR 3 remains future work: add typed GraphQL code generation and migrate the
+query call sites without changing the public domain types.
 
 ## Context and orientation
 
@@ -361,14 +375,14 @@ wire shape; the exported ones (`ReviewThread`, `ReviewComment`,
 `CommentConnection`, `PageInfo`, `PullRequestReview`, `Issue`, `User`) are
 public API and survive all three PRs.
 
-The REST path: `src/resolve/rest.rs` (only compiled with
-`--features unstable-rest-resolve`) builds a second `reqwest::Client`
-(`github_client`) and a `RestClient` whose base URL comes from the
-`GITHUB_API_URL` env var (default `https://api.github.com`). Its one operation,
-`post_reply`, POSTs to
-`repos/{owner}/{name}/pulls/{pull_number}/comments/{comment_id}/replies`,
-treating 404 as non-fatal (warn and continue) and other non-2xx as fatal, with
-no retry.
+The REST reply boundary (only compiled with `--features unstable-rest-resolve`)
+uses an Octocrab client with the resolved GitHub API base URL, defaulting to
+`https://api.github.com`. Its raw `_post` route posts to
+`repos/{owner}/{name}/pulls/{pull_number}/comments/{comment_id}/replies` with
+the pinned API-version and JSON `Accept` headers. The complete request is
+bounded by the total deadline, in addition to Octocrab's connect, read, and
+write timeouts. A 404 is non-fatal (warn and continue), another non-2xx status
+is fatal with the route and status retained, and the path has no retry.
 
 Authentication: `src/auth.rs::resolve_github_token` implements the precedence
 chain; no `gh` CLI integration exists. The token is a plain string handed to
@@ -521,9 +535,8 @@ GraphQL section rewrite and schema-refresh procedure (PR 3), and
 
 ## Concrete steps
 
-All commands run from the repository root
-(`/home/leynos/Projects/vk.worktrees/adopt-octocrab`). Long outputs go through
-`tee` to a log file for review, for example:
+All commands run from the repository root. Long outputs go through `tee` to a
+log file for review, for example:
 
 ```shell
 make test 2>&1 | tee "/tmp/test-vk-adopt-octocrab.out"
@@ -597,21 +610,32 @@ Quality criteria: all gates above; documentation gates (`make markdownlint`,
 `make nixie`) for the ADR, design-doc, and `graphql/README.md` changes;
 build-time delta within the stated tolerance for PR 3.
 
+PR 1 uses a finite integration partition. `proptest` is not used because this
+behaviour is integration-only via Octocrab, not a pure function over which
+generated inputs would add useful coverage. The bounded tests cover zero, one,
+and multiple trailing slashes in the API URI, plus representative success, 404,
+and other non-2xx status classes.
+
 ## Idempotence and recovery
 
 Every step is an ordinary source edit gated by the test suite; re-running any
-command is safe. Each PR (and each commit within it) is independent, so a
-failed attempt is abandoned with `git restore` / `git reset --hard HEAD`
-without affecting completed work. The schema download is re-runnable and
+command is safe. If a plan step fails, inspect `git diff --name-only` and use
+targeted `git restore -- path/to/reviewed-file` only for files changed by that
+failed step. Preserve unrelated work and completed commits; do not use an
+unconditional hard reset. The schema download is re-runnable and
 version-controlled once vendored. Nothing in this plan touches user data, CI
 configuration, or anything outside the repository; the only files written
 outside it are `tee` logs under `/tmp`.
 
 ## Artifacts and notes
 
-Record here, as milestones complete: the final octocrab feature set, the
-`cargo tree -d` duplicate report, the clean-build baseline and post-PR 3 delta,
-a sample transcript line proving format parity, and the closing test counts.
+PR 1 artifact and evidence: Octocrab is configured with the recorded feature
+set, `tests/resolve.rs` verifies the raw reply route, headers, body,
+authentication, status handling, URI normalisation, and total deadline, and the
+recorded PR 1 gate run is green. The remaining artifacts are the PR 2
+`cargo tree -d` duplicate report and clean-build comparison, followed by the PR
+3 sample transcript line, schema/code-generation evidence, and closing test
+counts.
 
 ## Interfaces and dependencies
 

--- a/docs/execplans/adopt-octocrab.md
+++ b/docs/execplans/adopt-octocrab.md
@@ -1,0 +1,520 @@
+# Adopt octocrab as the GitHub API transport for vk
+
+This ExecPlan (execution plan) is a living document. The sections `Constraints`,
+`Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`, `Decision Log`,
+and `Outcomes & Retrospective` must be kept up to date as work proceeds.
+
+Status: DRAFT
+
+## Purpose / big picture
+
+`vk` is a command-line tool that shows unresolved GitHub pull request review
+comments in the terminal. Today it talks to GitHub through two hand-rolled HTTP
+clients built directly on the `reqwest` crate: a GraphQL client
+(`src/api/client/`) used by every subcommand, and a REST client
+(`src/resolve/rest.rs`, compiled only under the `unstable-rest-resolve`
+feature) used to post a reply before resolving a review thread.
+
+This plan replaces the `reqwest` transport underneath both clients with
+[octocrab](https://docs.rs/octocrab) (version 0.54.x, the maintained GitHub API
+client for Rust), while preserving `vk`'s externally observable behaviour:
+command output, error messages, retry semantics, transcript recording,
+authentication precedence, and the environment-variable endpoint overrides that
+the entire test suite depends on.
+
+After this change, a user sees no behavioural difference: `vk pr`, `vk issue`,
+and `vk resolve` work exactly as before, and `make test` passes with the same
+suite. What the project gains is a maintained transport layer (authentication
+plumbing, base-URI handling, connection management, rate-limit-aware retry
+available for future use) and a ready-made typed REST surface for future
+features, in exchange for deleting bespoke plumbing. Success is observable as:
+`cargo tree -i reqwest` reports the crate is absent from the dependency graph,
+`cargo tree -p vk | grep octocrab` shows octocrab present, and all existing
+gates (`make check-fmt`, `make lint`, `make test`, `make markdownlint`,
+`make nixie`) pass.
+
+## Constraints
+
+Hard invariants that must hold throughout implementation. Violation requires
+escalation, not workarounds.
+
+- The public CLI behaviour must not change: identical stdout/stderr for the
+  same inputs, including error-message fragments asserted by tests (for example
+  `"status 500"`, `"body snippet:"`, and serde error paths such as
+  `"repository.pullRequest.reviewThreads"`).
+- The environment-variable overrides `GITHUB_GRAPHQL_URL` (full GraphQL
+  endpoint URL) and `GITHUB_API_URL` (REST base URL) must keep working, because
+  every network-facing test redirects the binary to a loopback server through
+  them.
+- Token precedence must remain: `--github-token` flag, then
+  `VK_GITHUB_TOKEN`, then `GITHUB_TOKEN`, then the config-file value
+  (`src/auth.rs`).
+- Requests must keep sending `User-Agent: vk`,
+  `Accept: application/vnd.github+json`, and `Authorization: Bearer <token>`
+  (only when a token is present; anonymous access must keep working and keep
+  printing the "GitHub token not set, using anonymous API access" warning).
+- The transcript feature (`VK_TRANSCRIPT` / constructor parameter) must keep
+  writing the same JSON-lines format consumed by
+  `tests/e2e/common.rs::load_transcript` and the `tests/fixtures/pr42.json`
+  fixture: one object per line with keys `operation`, `status`, `request`, and
+  `response` (response body truncated to 500 characters).
+- Retry behaviour must be preserved: jittered exponential backoff via
+  `backon` with the transient-error classification in `src/api/retry.rs` (retry
+  on request errors, empty responses, HTTP 5xx, HTTP 429, and HTML-looking
+  bodies).
+- TLS must remain rustls-based; do not introduce a native-tls or OpenSSL
+  dependency.
+- Dependency versions must use caret requirements unless a tilde pin is
+  documented with a reason (see Decision Log for the octocrab pin).
+- The error type `VkError` and its variants remain the error surface of
+  `src/api/`; octocrab's `snafu`-based errors must be mapped at the transport
+  boundary and never leak into public signatures.
+- All commit gates pass on every commit: `make check-fmt`, `make lint`,
+  `make test`, and for documentation changes `make markdownlint` and
+  `make nixie`.
+- No single source file may exceed 400 lines; module-level `//!` comments
+  and en-GB-oxendict spelling are required in all new code.
+
+## Tolerances (exception triggers)
+
+- Scope: if the migration requires editing more than 25 source files or a
+  net change beyond roughly 1,500 lines, stop and escalate.
+- Interface: if a public API of the `vk` library crate (anything re-exported
+  from `src/lib.rs`, such as `GraphQLClient`, `Endpoint`, `Token`, `Query`,
+  `RetryConfig`, `CommentConnection`, `PageInfo`) must change signature, stop
+  and escalate. Internal (private or `pub(crate)`) signatures may change freely.
+- Dependencies: adding `octocrab` (and accepting its transitive hyper/tower
+  stack) is pre-approved by this plan. Any further new direct dependency
+  requires escalation.
+- Behaviour: if preserving an asserted behaviour (error text, transcript
+  format, header set) proves impossible on top of octocrab, stop and present
+  options; do not weaken tests to fit.
+- Iterations: if a gate still fails after three fix attempts on the same
+  failure, stop and escalate.
+- Prototype outcome: if Milestone 1 (the spike) shows octocrab cannot
+  expose raw response status and body for the transcript and error-snippet
+  machinery, stop and escalate with alternatives (see Risks).
+
+## Risks
+
+- Risk: octocrab's default builder does not accept custom tower layers, so
+  the transcript recorder cannot be a middleware; the plan instead relies on
+  octocrab's raw `_post` method returning an unprocessed `http::Response` from
+  which status and body can be read. Severity: high. Likelihood: low.
+  Mitigation: Milestone 1 is a spike proving the raw-response path against the
+  existing unit tests before any consumer changes. Fallback: build the client
+  via `OctocrabBuilder::new_empty().with_service(...)` with a custom recording
+  layer, or escalate.
+- Risk: octocrab has shipped breaking changes in patch releases before
+  (issue 899, the 0.49.8 GraphQL return-type change). Severity: medium.
+  Likelihood: medium. Mitigation: pin with a tilde requirement (`~0.54`) and
+  record the reason in `Cargo.toml` comment and the ADR (see Decision Log).
+- Risk: unit tests construct clients with endpoints that have no path
+  (`http://127.0.0.1:PORT`), while e2e tests use
+  `http://127.0.0.1:PORT/graphql`; octocrab joins a relative route onto a base
+  URI, so the endpoint-to-(base URI, route) split must handle both. Severity:
+  medium. Likelihood: high (it will definitely arise). Mitigation: a dedicated
+  pure function with rstest coverage written test-first (Milestone 2, Stage B).
+- Risk: double-retry — octocrab's default retry layer (`Simple(3)`) would
+  stack with `backon`, tripling observed attempts and breaking the retry unit
+  tests that count requests. Severity: medium. Likelihood: high. Mitigation:
+  configure `add_retry_config(RetryConfig::None)` on the octocrab builder; keep
+  `backon` as the single retry mechanism.
+- Risk: octocrab's REST models may not deserialize the minimal inline JSON
+  bodies used by `tests/resolve.rs`, breaking the REST reply path if it moves
+  to octocrab's typed `reply_to_comment`. Severity: low. Likelihood: medium.
+  Mitigation: use the raw `_post` route for the reply as well, preserving the
+  exact path and status-code semantics (404 non-fatal, 403/500 fatal); typed
+  handlers can be adopted later.
+- Risk: binary size and compile time grow while both reqwest and octocrab
+  are present mid-migration. Severity: low. Likelihood: certain but transient.
+  Mitigation: the final milestone removes reqwest; the overlap is bounded to
+  the life of this branch.
+
+## Progress
+
+- [x] (2026-07-09 12:20Z) Explored codebase (client layer, consumers, test
+  infrastructure, docs) and researched octocrab 0.54; findings folded into this
+  plan.
+- [x] (2026-07-09 12:40Z) ExecPlan drafted and linked from
+  `docs/contents.md`.
+- [ ] Stage A: author ADR `docs/adr-001-adopt-octocrab.md`; add octocrab
+  dependency; record pin rationale.
+- [ ] Milestone 1 (prototype): swap `GraphQLClient` transport to octocrab
+  behind the existing facade; `src/api/client/tests.rs` passes unchanged.
+- [ ] Milestone 2: endpoint-splitting function (test-first), transcript,
+  redaction, retry, and timeout parity; full `make test` green.
+- [ ] Milestone 3: REST resolve path on octocrab
+  (`--features unstable-rest-resolve`); `tests/resolve.rs` green.
+- [ ] Milestone 4: remove reqwest; update `docs/vk-design.md`,
+  `docs/repository-layout.md`, `docs/developers-guide.md` as needed; final
+  gates and retrospective.
+
+## Surprises & discoveries
+
+- Observation: despite the branch name, no octocrab groundwork exists; this
+  is a from-scratch adoption. Evidence: `grep octocrab Cargo.toml src/ -r`
+  returns nothing. Impact: the plan treats the migration as new work, not a
+  continuation.
+- Observation: `docs/vk-end-to-end-testing-guide.md` describes `third-wheel`
+  as a man-in-the-middle proxy, but the implementation only uses
+  `third_wheel::hyper` re-exports for a plain loopback stub server driven by
+  env-var endpoint overrides. Evidence: `tests/utils/mod.rs:186-192` sets
+  `GITHUB_GRAPHQL_URL` and `GITHUB_API_URL`; no proxy or certificate trust is
+  configured anywhere. Impact: the migration only needs to preserve the env-var
+  overrides, not proxy semantics; the guide should be corrected during
+  Milestone 4.
+- Observation: the transcript writes the raw, unredacted request payload;
+  redaction (`redact_sensitive`) applies only to error-context snippets.
+  Evidence: `src/api/client/transcript.rs` versus
+  `src/api/client/mod.rs:126-134`. Impact: parity is the goal; do not silently
+  change redaction behaviour during the migration. Flagged for a possible
+  follow-up outside this plan.
+
+## Decision log
+
+- Decision: keep the `GraphQLClient` facade and `VkError` taxonomy; replace
+  only the transport internals with octocrab. Rationale: consumers
+  (`src/commands.rs`, `src/review_threads.rs`, `src/reviews.rs`,
+  `src/issues.rs`, `src/branch_pr/`, `src/resolve/`) and roughly twenty network
+  tests couple to the facade, the error text, and the env-var overrides.
+  Swapping internals preserves all of that and bounds the blast radius;
+  rewriting consumers against octocrab's typed models would triple the diff for
+  no behavioural gain. Date/Author: 2026-07-09, planning session.
+- Decision: use octocrab's raw `_post` (returning `http::Response`) for
+  GraphQL and for the REST reply, not the convenience `graphql()` method or
+  typed REST handlers. Rationale: `graphql()` swallows the raw body and
+  discards partial-success data, which would break transcript recording,
+  body-snippet error context, and the HTML-body transient-retry heuristic.
+  `_post` inherits auth and base-URI middleware while leaving response
+  processing to `vk`. Date/Author: 2026-07-09, planning session.
+- Decision: keep `backon` retry and disable octocrab's retry layer
+  (`RetryConfig::None` on the builder). Rationale: a single retry authority
+  preserves the tested attempt counts and backoff behaviour. octocrab's
+  rate-limit-aware retry cannot see GraphQL rate-limit errors (they arrive as
+  HTTP 200 with an `errors` payload), so `backon` at the operation level
+  remains necessary anyway. Date/Author: 2026-07-09, planning session.
+- Decision: pin octocrab with a tilde requirement (`~0.54`).
+  Rationale: octocrab has a documented history of breaking changes in patch
+  releases (upstream issue 899). AGENTS.md permits tilde pins where the reason
+  is documented; this is that documentation, and the ADR repeats it.
+  Date/Author: 2026-07-09, planning session.
+- Decision: record the adoption in a new ADR,
+  `docs/adr-001-adopt-octocrab.md`. Rationale: no ADRs exist; the
+  bespoke-client choice was never recorded. AGENTS.md requires substantive
+  decisions to be captured as ADRs following
+  `docs/documentation-style-guide.md` (Status, Date, Context and Problem
+  Statement, Options Considered, Decision Outcome, Migration Plan, Known
+  Risks). Date/Author: 2026-07-09, planning session.
+
+## Outcomes & retrospective
+
+To be completed as milestones land and at the end of the work.
+
+## Context and orientation
+
+The repository is a single Rust crate (`vk`, edition 2024, MSRV 1.89) with
+sources under `src/` and integration tests under `tests/`. The `Makefile` is
+the canonical command runner. Read `AGENTS.md` before contributing.
+
+The API layer, all under `src/api/`:
+
+- `src/api/mod.rs` re-exports `GraphQLClient`, `Endpoint`, `Query`, `Token`
+  (from `client/`), `paginate` (from `pagination.rs`), and `RetryConfig` (from
+  `retry.rs`).
+- `src/api/client/mod.rs` defines `GraphQLClient` (fields: a
+  `reqwest::Client`, headers, endpoint, optional transcript, and retry config)
+  with constructors `new` (endpoint from the `GITHUB_GRAPHQL_URL` env var,
+  default `https://api.github.com/graphql`), `with_endpoint`, and
+  `with_endpoint_retry`; methods `run_query` (POST, backon retry loop),
+  `fetch_page` (cursor merge), and private `execute_single_request` /
+  `process_graphql_response` (status handling, transcript logging, GraphQL
+  error surfacing, `serde_path_to_error` deserialization).
+- `src/api/client/helpers.rs` builds headers (`User-Agent: vk`, `Accept`,
+  optional `Authorization`) and provides snippet/redaction helpers.
+- `src/api/client/types.rs` defines the `Query`, `Token`, and `Endpoint`
+  newtypes and the `GraphQLResponse<T>` envelope.
+- `src/api/client/transcript.rs` appends one JSON line per request to the
+  optional transcript file.
+- `src/api/client/pagination.rs` implements `paginate_all` (cursor loop,
+  1,000-page cap); `src/api/pagination.rs` holds the generic `paginate` helper
+  and `PageInfo` handling.
+- `src/api/retry.rs` defines `RetryConfig` (5 attempts, 200 ms base delay,
+  30 s request timeout, jitter) and `should_retry` transient classification.
+
+GraphQL queries are raw string constants in `src/graphql_queries.rs`
+(`THREADS_QUERY`, `COMMENT_QUERY`, `ISSUE_QUERY`, `PR_FOR_BRANCH_QUERY`) and in
+`src/resolve/graphql.rs` (`RESOLVE_THREAD_MUTATION`, `REVIEW_COMMENTS_PAGE`).
+Responses deserialize into per-module serde structs that mirror the GraphQL
+wire shape; these structs are unchanged by this plan.
+
+The REST path: `src/resolve/rest.rs` (only compiled with
+`--features unstable-rest-resolve`) builds a second `reqwest::Client`
+(`github_client`) and a `RestClient` whose base URL comes from the
+`GITHUB_API_URL` env var (default `https://api.github.com`). Its one operation,
+`post_reply`, POSTs to
+`repos/{owner}/{name}/pulls/{pull_number}/comments/{comment_id}/replies`,
+treating 404 as non-fatal and other non-2xx as fatal, with no retry.
+
+Authentication: `src/auth.rs::resolve_github_token` implements the precedence
+chain; no `gh` CLI integration exists. The token is a plain string handed to
+the client constructors.
+
+Tests that constrain this work:
+
+- `src/api/client/tests.rs` spins up loopback hyper servers and constructs
+  clients via `with_endpoint`/`with_endpoint_retry` using endpoints without a
+  path; it counts retry attempts and asserts error-text fragments.
+- `src/test_utils/test_http.rs` and `src/branch_pr/tests.rs` follow the same
+  pattern.
+- `tests/utils/mod.rs::vk_cmd` runs the real binary with
+  `GITHUB_GRAPHQL_URL=http://{addr}/graphql`, `GITHUB_API_URL=http://{addr}`,
+  and `GITHUB_TOKEN=dummy`.
+- `tests/auth.rs` asserts the captured `Authorization` header and the
+  anonymous-access warning.
+- `tests/resolve.rs` asserts the exact REST path and status-code semantics.
+- `tests/cli.rs` holds two insta snapshots of rendered output (client-swap
+  insensitive, data-shape sensitive).
+- `tests/e2e/common.rs::load_transcript` and `tests/fixtures/pr42.json`
+  encode the transcript JSON-lines format.
+
+Key octocrab facts (version 0.54.0, MSRV 1.85, rustls + ring by default):
+
+- It builds on hyper 1.x and tower, not reqwest. `OctocrabBuilder`
+  provides `personal_token`, `base_uri` (a tower layer rewriting relative
+  routes, applying to REST and GraphQL alike), `add_header`,
+  `add_retry_config`, and connect/read/write timeouts.
+- `Octocrab::_post(route, body)` returns the raw `http::Response`, from
+  which status and body bytes can be read — this is the hook that preserves
+  `vk`'s transcript, snippets, and retry classification.
+- The convenience `graphql()` method deserializes internally and discards
+  the raw body and partial-success data; it is not used by this plan.
+- Resolving a review thread has no REST endpoint; the `resolveReviewThread`
+  GraphQL mutation remains the only way, so GraphQL stays central.
+
+## Plan of work
+
+The work is four milestones, each ending in a commit (or small commit series)
+with all gates green. The public facade means consumers are untouched until
+Milestone 3, and most tests act as a characterization harness throughout: their
+continuing to pass is the acceptance evidence.
+
+Stage A (part of the first commit): author `docs/adr-001-adopt-octocrab.md`
+following the ADR template in `docs/documentation-style-guide.md` (Status:
+Accepted; Context: two bespoke reqwest clients, undocumented prior decision;
+Options Considered: keep bespoke, octocrab, graphql_client + reqwest codegen;
+Decision Outcome: octocrab as transport with retained facade; Migration Plan:
+reference this ExecPlan; Known Risks: semver history, hence tilde pin).
+Reference the ADR from `docs/vk-design.md` and list it in `docs/contents.md`.
+Add the dependency to `Cargo.toml`:
+
+    octocrab = { version = "~0.54", default-features = false, features = ["rustls", "rustls-ring", "timeout"] }
+
+(Feature list to be verified during the spike: the goal is rustls with the ring
+provider, timeouts available, octocrab's retry and tracing layers not required;
+adjust to the minimal set that compiles, and record the final set here.) Run
+`cargo tree -d` to check for duplicate major versions of shared transitive
+dependencies and note findings in `Surprises & discoveries`.
+
+Milestone 1 (prototyping, go/no-go): inside `src/api/client/`, add a private
+transport module (`src/api/client/transport.rs`) that owns an
+`octocrab::Octocrab` instance plus the route to post to, and give it one async
+method mirroring today's `execute_single_request` contract: take a JSON
+payload, return `HttpResponse { status, body }` or `VkError`. Construct it from
+the existing `Endpoint`, `Token`, and `RetryConfig` values:
+
+- Split the `Endpoint` URL into a base URI and a route path (for
+  `http://127.0.0.1:9999` the route is `/`; for
+  `https://api.github.com/graphql` the base is `https://api.github.com` and the
+  route `/graphql`). This is the pure function `split_endpoint` described under
+  Interfaces below, written test-first.
+- Builder: `personal_token` only when the token is non-empty; `add_header`
+  for `User-Agent: vk` and `Accept: application/vnd.github+json` (verify during
+  the spike whether octocrab's defaults duplicate or fight these; the wire
+  assertions in `tests/auth.rs` are the arbiter);
+  `add_retry_config(octocrab::service::middleware::retry::RetryConfig::None)`;
+  read/connect timeouts from `vk`'s `RetryConfig::request_timeout`.
+- Method body: `_post(route, Some(&payload))`, read status, collect body
+  bytes to a `String`, map transport errors into `VkError::RequestContext` with
+  the same context text as today.
+
+Switch `execute_single_request` to delegate to the transport while leaving
+everything else (transcript call, status check, snippets, retry loop)
+untouched. The `reqwest::Client` field and `headers: HeaderMap` field of
+`GraphQLClient` are removed or bypassed. Acceptance: `cargo test api::client`
+(module tests) and then `make test` pass without any test edits. If raw
+status/body access or header parity cannot be achieved, stop: this is the
+go/no-go gate.
+
+Milestone 2 (parity hardening): promote the spike to final quality. Red-green
+applies to the new unit: add rstest cases for `split_endpoint` covering
+path-less endpoints, `/graphql` paths, deeper paths, and trailing slashes,
+written before the implementation and observed failing (the function is new, so
+the red stage is a compile-fail or a failing assertion against a stub). Confirm
+timeout behaviour (a hanging stub server test already exists in the retry
+tests; verify it still passes), transcript output (run the ignored `e2e_pr_42`
+transcript test locally: `cargo test --test e2e -- --ignored e2e_pr_42` — it
+replays `tests/fixtures/pr42.json`), and anonymous access (`tests/auth.rs`).
+Delete `src/api/client/helpers.rs::build_headers` and its two unit tests only
+if header construction has genuinely moved into the octocrab builder; otherwise
+keep it as the single source of header values fed to `add_header`. Update module
+`//!` comments to describe the octocrab transport. All gates green; commit.
+
+Milestone 3 (REST resolve path): replace `src/resolve/rest.rs::github_client`
+and the `RestClient` internals with a second octocrab instance whose base URI
+comes from the existing resolution (parameter, then `GITHUB_API_URL`, then
+default). Keep `post_reply`'s signature and semantics: build the same relative
+route string, call `_post`, keep 404-as-warning and other-non-2xx-as-fatal
+mapping into `VkError`. Do not adopt the typed `pulls().reply_to_comment`
+handler in this plan (see Decision Log). Acceptance:
+`cargo test --features unstable-rest-resolve` passes, including
+`tests/resolve.rs`; `make lint` (which uses `--all-features`) passes. Commit.
+
+Milestone 4 (removal and documentation): delete the `reqwest` dependency from
+`Cargo.toml` and any residual `use reqwest` imports (after Milestones 1–3 the
+only candidates are error-source downcasts; replace with hyper/http
+equivalents). Verify with `cargo tree -i reqwest` (expected: error, package not
+found). Update documentation:
+
+- `docs/vk-design.md`: rewrite the networking section to describe the
+  octocrab transport, retained facade, retry split (backon outside, octocrab
+  retry disabled), and endpoint splitting; reference the ADR.
+- `docs/vk-end-to-end-testing-guide.md`: correct the third-wheel
+  description (loopback stub via env-var override, not a MITM proxy).
+- `docs/repository-layout.md` and `docs/developers-guide.md`: only if
+  module boundaries moved (they should not).
+- `docs/contents.md`: ensure the ADR and this plan are listed.
+
+Run all gates including `make markdownlint` and `make nixie`. Complete
+`Outcomes & retrospective`. Set Status to COMPLETE. Commit.
+
+## Concrete steps
+
+All commands run from the repository root
+(`/home/leynos/Projects/vk.worktrees/adopt-octocrab`). Long outputs go through
+`tee` to a log file for review, for example:
+
+    make test 2>&1 | tee "/tmp/test-vk-adopt-octocrab.out"
+
+Per-milestone sequence (repeat for each milestone):
+
+1. Make the edits described in Plan of work.
+2. `make check-fmt` (apply `make fmt` first if needed).
+3. `make lint` — expect zero warnings; clippy runs with `-D warnings` and
+   `--all-features`, so the REST feature code is always linted.
+4. `make test` — expect all tests to pass. The suite currently passes on a
+   clean checkout; any new failure is caused by the change under test.
+5. For documentation edits: `make markdownlint` and `make nixie`.
+6. Commit with an imperative-mood message; update the `Progress` section of
+   this plan in the same commit.
+
+Useful focused commands:
+
+    cargo test api::client 2>&1 | tee /tmp/test-vk-adopt-octocrab.out
+    cargo test --features unstable-rest-resolve --test resolve 2>&1 | tee /tmp/test-vk-adopt-octocrab.out
+    cargo test --test e2e -- --ignored e2e_pr_42 2>&1 | tee /tmp/test-vk-adopt-octocrab.out
+    cargo tree -i reqwest        # Milestone 4: expect "package … not found"
+    cargo tree -d                # check duplicate transitive versions
+
+Expected shape of a passing test run (counts will drift as tests are added):
+
+    test result: ok. 0 failed; finished in …
+
+## Validation and acceptance
+
+The migration is behaviour-preserving, so the existing suite is the primary
+acceptance harness: every milestone ends with `make check-fmt`, `make lint`, and
+`make test` green with no test weakened or deleted (except the two
+`build_headers` unit tests, which may move with the code they test — see
+Milestone 2).
+
+Red-green-refactor evidence is required for the one genuinely new unit:
+
+- Red: add `split_endpoint` rstest cases in the transport module first;
+  run `cargo test api::client::transport` and observe failure (initially a
+  compile failure for the missing function, then failing assertions against a
+  todo stub).
+- Green: implement `split_endpoint` minimally; the focused test passes.
+- Refactor: tidy, then run `make lint` and `make test`.
+
+End-to-end observation: with no token and pointing at a loopback stub, the
+binary behaves identically before and after, for example:
+
+    GITHUB_GRAPHQL_URL=http://127.0.0.1:1/graphql GITHUB_TOKEN=dummy \
+      cargo run -- pr https://github.com/leynos/vk/pull/1
+
+fails with a connection-refused `RequestContext` error mentioning the operation
+name, exactly as on `main`.
+
+Quality criteria: all gates above, plus `cargo tree -i reqwest` failing to find
+the package at the end of Milestone 4, and documentation gates for the ADR and
+design-doc updates.
+
+## Idempotence and recovery
+
+Every step is an ordinary source edit gated by the test suite; re-running any
+command is safe. Each milestone is an independent commit, so a failed milestone
+is abandoned with `git restore` / `git reset --hard HEAD` without affecting
+completed work. Nothing in this plan touches user data, CI configuration, or
+anything outside the repository; the only files written outside it are `tee`
+logs under `/tmp`.
+
+## Artifacts and notes
+
+Record here, as milestones complete: the final octocrab feature set, the
+`cargo tree -d` duplicate report, a sample transcript line proving format
+parity, and the closing test counts.
+
+## Interfaces and dependencies
+
+Dependency to add (Stage A; final feature list recorded here after the spike):
+
+    # Tilde pin: octocrab has shipped breaking changes in patch releases
+    # (upstream issue 899); widen only after review.
+    octocrab = { version = "~0.54", default-features = false, features = ["rustls", "rustls-ring", "timeout"] }
+
+Dependency to remove (Milestone 4): `reqwest`.
+
+In `src/api/client/transport.rs` (new, private to `client`):
+
+    /// Owns the octocrab instance and the GraphQL route derived from the
+    /// configured endpoint.
+    pub(super) struct Transport {
+        octocrab: octocrab::Octocrab,
+        route: String,
+    }
+
+    impl Transport {
+        pub(super) fn new(
+            token: &Token,
+            endpoint: &Endpoint,
+            retry: &RetryConfig,
+        ) -> Result<Self, VkError>;
+
+        /// POST `payload` to the GraphQL route, returning status and body.
+        pub(super) async fn post_json(
+            &self,
+            payload: &serde_json::Value,
+        ) -> Result<HttpResponse, VkError>;
+    }
+
+    /// Split a full endpoint URL into (base URI, route path).
+    ///
+    /// `https://api.github.com/graphql` -> ("https://api.github.com", "/graphql")
+    /// `http://127.0.0.1:9999`          -> ("http://127.0.0.1:9999", "/")
+    pub(super) fn split_endpoint(endpoint: &Endpoint) -> Result<(String, String), VkError>;
+
+Unchanged public surface (re-exported from `src/lib.rs` and `src/api/`):
+`GraphQLClient` and its constructors/methods, `Endpoint`, `Token`, `Query`,
+`RetryConfig`, `paginate`, `PageInfo`, `CommentConnection`, `ReviewThread`,
+`ReviewComment`, `PullRequestReview`, `Issue`, `User`, and `VkError`.
+
+In `src/resolve/rest.rs`, `RestClient` keeps its `pub(crate)` construction and
+`post_reply` free function; only the inner client type changes from
+`reqwest::Client` to `octocrab::Octocrab`.
+
+## Revision note
+
+2026-07-09: initial draft, based on codebase reconnaissance (client layer,
+consumers, test infrastructure, documentation conventions) and octocrab 0.54
+research. No implementation has begun; awaiting approval.

--- a/docs/execplans/adopt-octocrab.md
+++ b/docs/execplans/adopt-octocrab.md
@@ -1,4 +1,4 @@
-# Adopt octocrab as the GitHub API transport for vk
+# Modernise GitHub API access: octocrab REST, hyper transport, typed GraphQL
 
 This ExecPlan (execution plan) is a living document. The sections `Constraints`,
 `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`, `Decision Log`,
@@ -15,23 +15,35 @@ clients built directly on the `reqwest` crate: a GraphQL client
 (`src/resolve/rest.rs`, compiled only under the `unstable-rest-resolve`
 feature) used to post a reply before resolving a review thread.
 
-This plan replaces the `reqwest` transport underneath both clients with
-[octocrab](https://docs.rs/octocrab) (version 0.54.x, the maintained GitHub API
-client for Rust), while preserving `vk`'s externally observable behaviour:
-command output, error messages, retry semantics, transcript recording,
-authentication precedence, and the environment-variable endpoint overrides that
-the entire test suite depends on.
+An earlier draft of this plan proposed routing everything through
+[octocrab](https://docs.rs/octocrab). Review concluded octocrab is a weak fit
+for the GraphQL side (its `graphql()` helper hides the raw response that `vk`'s
+transcript, error-snippet, and retry machinery depend on) but a genuine win for
+the REST side (typed pull-request APIs, maintained auth and base-URI plumbing).
+The revised programme is therefore three separable changes, delivered as three
+pull requests:
 
-After this change, a user sees no behavioural difference: `vk pr`, `vk issue`,
-and `vk resolve` work exactly as before, and `make test` passes with the same
-suite. What the project gains is a maintained transport layer (authentication
-plumbing, base-URI handling, connection management, rate-limit-aware retry
-available for future use) and a ready-made typed REST surface for future
-features, in exchange for deleting bespoke plumbing. Success is observable as:
-`cargo tree -i reqwest` reports the crate is absent from the dependency graph,
-`cargo tree -p vk | grep octocrab` shows octocrab present, and all existing
-gates (`make check-fmt`, `make lint`, `make test`, `make markdownlint`,
-`make nixie`) pass.
+1. PR 1 — adopt octocrab for the REST resolve path, replacing the bespoke
+   `reqwest`-based `RestClient`.
+2. PR 2 — replace `reqwest` inside the bespoke GraphQL client with a direct
+   hyper transport, then remove `reqwest` from the dependency graph. The binary
+   converges on one HTTP stack (hyper/rustls), shared with octocrab.
+3. PR 3 — adopt `graphql_client` codegen so every GraphQL query and its
+   variables are checked against GitHub's published schema at compile time,
+   removing the raw query-string constants and hand-maintained response
+   envelopes.
+
+`vk`'s externally observable behaviour is preserved throughout: command output,
+error messages, retry semantics, transcript recording, authentication
+precedence, and the environment-variable endpoint overrides that the entire
+test suite depends on.
+
+Success is observable per PR: after PR 1, `tests/resolve.rs` passes with
+octocrab serving the reply path; after PR 2, `cargo tree -i reqwest` reports
+the crate absent while the full suite passes; after PR 3, malforming any query
+in the vendored `.graphql` documents fails the build rather than a runtime
+request, and the suite still passes. All gates (`make check-fmt`, `make lint`,
+`make test`, `make markdownlint`, `make nixie`) pass at every commit.
 
 ## Constraints
 
@@ -49,7 +61,7 @@ escalation, not workarounds.
 - Token precedence must remain: `--github-token` flag, then
   `VK_GITHUB_TOKEN`, then `GITHUB_TOKEN`, then the config-file value
   (`src/auth.rs`).
-- Requests must keep sending `User-Agent: vk`,
+- GraphQL requests must keep sending `User-Agent: vk`,
   `Accept: application/vnd.github+json`, and `Authorization: Bearer <token>`
   (only when a token is present; anonymous access must keep working and keep
   printing the "GitHub token not set, using anonymous API access" warning).
@@ -58,78 +70,102 @@ escalation, not workarounds.
   `tests/e2e/common.rs::load_transcript` and the `tests/fixtures/pr42.json`
   fixture: one object per line with keys `operation`, `status`, `request`, and
   `response` (response body truncated to 500 characters).
-- Retry behaviour must be preserved: jittered exponential backoff via
-  `backon` with the transient-error classification in `src/api/retry.rs` (retry
-  on request errors, empty responses, HTTP 5xx, HTTP 429, and HTML-looking
-  bodies).
+- Retry behaviour on the GraphQL path must be preserved: jittered
+  exponential backoff via `backon` with the transient-error classification in
+  `src/api/retry.rs` (retry on request errors, empty responses, HTTP 5xx, HTTP
+  429, and HTML-looking bodies). The REST reply path performs no retries today
+  and must not gain any.
 - TLS must remain rustls-based; do not introduce a native-tls or OpenSSL
   dependency.
 - Dependency versions must use caret requirements unless a tilde pin is
   documented with a reason (see Decision Log for the octocrab pin).
 - The error type `VkError` and its variants remain the error surface of
-  `src/api/`; octocrab's `snafu`-based errors must be mapped at the transport
-  boundary and never leak into public signatures.
+  `src/api/`; octocrab's, hyper's, and `graphql_client`'s error types must be
+  mapped at module boundaries and never leak into public signatures.
+- The exported domain types (`ReviewThread`, `ReviewComment`,
+  `CommentConnection`, `PageInfo`, `PullRequestReview`, `Issue`, `User`) remain
+  the types consumers and the printer use; generated GraphQL types stay private
+  behind a conversion layer.
 - All commit gates pass on every commit: `make check-fmt`, `make lint`,
   `make test`, and for documentation changes `make markdownlint` and
   `make nixie`.
 - No single source file may exceed 400 lines; module-level `//!` comments
-  and en-GB-oxendict spelling are required in all new code.
+  and en-GB-oxendict spelling are required in all new code. The vendored
+  GraphQL schema is third-party generated data, not source, and is exempt.
 
 ## Tolerances (exception triggers)
 
-- Scope: if the migration requires editing more than 25 source files or a
-  net change beyond roughly 1,500 lines, stop and escalate.
+- Scope: if any single PR requires editing more than 20 source files or a
+  net change beyond roughly 1,200 lines (excluding the vendored schema and
+  `.graphql` documents), stop and escalate.
 - Interface: if a public API of the `vk` library crate (anything re-exported
-  from `src/lib.rs`, such as `GraphQLClient`, `Endpoint`, `Token`, `Query`,
-  `RetryConfig`, `CommentConnection`, `PageInfo`) must change signature, stop
-  and escalate. Internal (private or `pub(crate)`) signatures may change freely.
-- Dependencies: adding `octocrab` (and accepting its transitive hyper/tower
-  stack) is pre-approved by this plan. Any further new direct dependency
-  requires escalation.
+  from `src/lib.rs`) must change signature or be removed, stop and escalate —
+  with one pre-approved exception: PR 3 may add typed operation-execution
+  methods to `GraphQLClient` and deprecate (not remove) the string-based
+  `run_query`/`fetch_page`/`paginate_all` surface if call-site migration leaves
+  them unused.
+- Dependencies: this plan pre-approves `octocrab` (PR 1), promotion of
+  `hyper`, `hyper-util`, `hyper-rustls`, and `http-body-util` from
+  dev-dependencies to runtime dependencies (PR 2), and `graphql_client` (PR 3).
+  Any further new direct dependency requires escalation.
 - Behaviour: if preserving an asserted behaviour (error text, transcript
-  format, header set) proves impossible on top of octocrab, stop and present
+  format, header set, retry counts) proves impossible, stop and present
   options; do not weaken tests to fit.
 - Iterations: if a gate still fails after three fix attempts on the same
   failure, stop and escalate.
-- Prototype outcome: if Milestone 1 (the spike) shows octocrab cannot
-  expose raw response status and body for the transcript and error-snippet
-  machinery, stop and escalate with alternatives (see Risks).
+- Build time: if PR 3's schema-parsing derives push a clean `cargo build`
+  more than 50% above the pre-PR baseline (record the baseline first), stop and
+  escalate with options (group operations per derive, prune the schema).
 
 ## Risks
 
-- Risk: octocrab's default builder does not accept custom tower layers, so
-  the transcript recorder cannot be a middleware; the plan instead relies on
-  octocrab's raw `_post` method returning an unprocessed `http::Response` from
-  which status and body can be read. Severity: high. Likelihood: low.
-  Mitigation: Milestone 1 is a spike proving the raw-response path against the
-  existing unit tests before any consumer changes. Fallback: build the client
-  via `OctocrabBuilder::new_empty().with_service(...)` with a custom recording
-  layer, or escalate.
+- Risk: octocrab's typed REST models may not deserialize the minimal inline
+  JSON bodies used by `tests/resolve.rs`, and its error mapping may not
+  reproduce the 404-non-fatal / other-non-2xx-fatal semantics exactly.
+  Severity: medium. Likelihood: medium. Mitigation: PR 1 starts with a spike;
+  test stub bodies may be enriched to realistic fixtures (that is
+  strengthening, not weakening); fall back to octocrab's raw `_post` route
+  (which inherits auth and base-URI middleware but leaves response handling to
+  `vk`) if the typed handler cannot match semantics.
 - Risk: octocrab has shipped breaking changes in patch releases before
-  (issue 899, the 0.49.8 GraphQL return-type change). Severity: medium.
-  Likelihood: medium. Mitigation: pin with a tilde requirement (`~0.54`) and
-  record the reason in `Cargo.toml` comment and the ADR (see Decision Log).
-- Risk: unit tests construct clients with endpoints that have no path
-  (`http://127.0.0.1:PORT`), while e2e tests use
-  `http://127.0.0.1:PORT/graphql`; octocrab joins a relative route onto a base
-  URI, so the endpoint-to-(base URI, route) split must handle both. Severity:
-  medium. Likelihood: high (it will definitely arise). Mitigation: a dedicated
-  pure function with rstest coverage written test-first (Milestone 2, Stage B).
-- Risk: double-retry — octocrab's default retry layer (`Simple(3)`) would
-  stack with `backon`, tripling observed attempts and breaking the retry unit
-  tests that count requests. Severity: medium. Likelihood: high. Mitigation:
-  configure `add_retry_config(RetryConfig::None)` on the octocrab builder; keep
-  `backon` as the single retry mechanism.
-- Risk: octocrab's REST models may not deserialize the minimal inline JSON
-  bodies used by `tests/resolve.rs`, breaking the REST reply path if it moves
-  to octocrab's typed `reply_to_comment`. Severity: low. Likelihood: medium.
-  Mitigation: use the raw `_post` route for the reply as well, preserving the
-  exact path and status-code semantics (404 non-fatal, 403/500 fatal); typed
-  handlers can be adopted later.
-- Risk: binary size and compile time grow while both reqwest and octocrab
-  are present mid-migration. Severity: low. Likelihood: certain but transient.
-  Mitigation: the final milestone removes reqwest; the overlap is bounded to
-  the life of this branch.
+  (upstream issue 899). Severity: medium. Likelihood: medium. Mitigation: pin
+  with a tilde requirement (`~0.54`) and record the reason in a `Cargo.toml`
+  comment and the ADR.
+- Risk: a direct hyper transport must reassemble what `reqwest` provided
+  for free: connection pooling, TLS configuration, total-request timeout, and
+  body collection. A subtle difference (for example timeout scope or TLS root
+  store) could change behaviour under failure. Severity: medium. Likelihood:
+  medium. Mitigation: the retry and timeout unit tests in
+  `src/api/client/tests.rs` count attempts against scripted local servers and
+  act as a characterization harness; PR 2 changes nothing but the transport
+  internals, so any drift surfaces there. Root-store choice (webpki versus
+  native) is recorded in the Decision Log during implementation.
+- Risk: `graphql_client`'s generated response types may produce
+  `serde_path_to_error` paths that differ from the hand-written structs,
+  breaking the e2e assertion on `"repository.pullRequest.reviewThreads"`.
+  Severity: low. Likelihood: low (generated fields carry the same camelCase
+  serde renames). Mitigation: the e2e test is in the harness; if paths differ,
+  adjust the conversion boundary, not the test.
+- Risk: GitHub's vendored schema is ~73,000 lines (~1.5 MB) and each
+  `#[derive(GraphQLQuery)]` re-parses it at compile time. Severity: low.
+  Likelihood: medium. Mitigation: benchmark before and after (see Build time
+  tolerance); group operations into shared documents where sensible; generated
+  code is small because only selected fields are generated.
+- Risk: GitHub's custom scalars (`DateTime`, `URI`, `HTML`, `GitObjectID`)
+  need Rust type aliases in scope of each derive; a missed alias is a compile
+  error easily misread. Severity: low. Likelihood: high (it will arise).
+  Mitigation: a single shared `scalars` module
+  (`type DateTime = chrono::DateTime<chrono::Utc>`, `type URI = String`,
+  `type HTML = String`) imported by every operation module.
+- Risk: `paginate_all` currently injects the cursor into an untyped JSON
+  variables map; typed `Variables` structs break that mechanism. Severity:
+  medium. Likelihood: certain (by design). Mitigation: PR 3 introduces a small
+  `CursorVariables` trait (set the cursor on a typed variables struct)
+  implemented per paginated operation; written test-first.
+- Risk: binary size and compile time grow while both reqwest and the hyper
+  stack are present (during PR 1, and PR 2 before removal). Severity: low.
+  Likelihood: certain but transient. Mitigation: PR 2 ends with
+  `cargo tree -i reqwest` failing to find the package.
 
 ## Progress
 
@@ -138,17 +174,23 @@ escalation, not workarounds.
   plan.
 - [x] (2026-07-09 12:40Z) ExecPlan drafted and linked from
   `docs/contents.md`.
-- [ ] Stage A: author ADR `docs/adr-001-adopt-octocrab.md`; add octocrab
-  dependency; record pin rationale.
-- [ ] Milestone 1 (prototype): swap `GraphQLClient` transport to octocrab
-  behind the existing facade; `src/api/client/tests.rs` passes unchanged.
-- [ ] Milestone 2: endpoint-splitting function (test-first), transcript,
-  redaction, retry, and timeout parity; full `make test` green.
-- [ ] Milestone 3: REST resolve path on octocrab
-  (`--features unstable-rest-resolve`); `tests/resolve.rs` green.
-- [ ] Milestone 4: remove reqwest; update `docs/vk-design.md`,
-  `docs/repository-layout.md`, `docs/developers-guide.md` as needed; final
-  gates and retrospective.
+- [x] (2026-07-09 14:10Z) Scope revised after review: octocrab confined to
+  REST; GraphQL keeps the bespoke client on a hyper transport with
+  `graphql_client` codegen. `graphql_client` 0.16 researched and confirmed
+  transport-agnostic.
+- [ ] Stage A: author ADR `docs/adr-001-github-api-client-modernisation.md`
+  covering all three decisions; link from `docs/vk-design.md` and
+  `docs/contents.md`.
+- [ ] PR 1: octocrab REST resolve path
+  (`--features unstable-rest-resolve`); `tests/resolve.rs` green; octocrab
+  dependency added with pin rationale.
+- [ ] PR 2: hyper transport inside `GraphQLClient`; reqwest removed;
+  `cargo tree -i reqwest` fails; full suite green.
+- [ ] PR 3: vendored schema, `.graphql` documents, generated types behind a
+  conversion layer, typed pagination; raw query constants deleted; full suite
+  green.
+- [ ] Documentation pass per PR (`docs/vk-design.md` and the e2e guide
+  correction in whichever PR touches it first); retrospective completed.
 
 ## Surprises & discoveries
 
@@ -161,51 +203,70 @@ escalation, not workarounds.
   `third_wheel::hyper` re-exports for a plain loopback stub server driven by
   env-var endpoint overrides. Evidence: `tests/utils/mod.rs:186-192` sets
   `GITHUB_GRAPHQL_URL` and `GITHUB_API_URL`; no proxy or certificate trust is
-  configured anywhere. Impact: the migration only needs to preserve the env-var
-  overrides, not proxy semantics; the guide should be corrected during
-  Milestone 4.
+  configured anywhere. Impact: only the env-var overrides need preserving; the
+  guide should be corrected when first touched.
 - Observation: the transcript writes the raw, unredacted request payload;
   redaction (`redact_sensitive`) applies only to error-context snippets.
   Evidence: `src/api/client/transcript.rs` versus
   `src/api/client/mod.rs:126-134`. Impact: parity is the goal; do not silently
   change redaction behaviour during the migration. Flagged for a possible
   follow-up outside this plan.
+- Observation: octocrab's own GraphQL example delegates query typing to
+  `graphql_client`, confirming the two tools' division of labour matches this
+  plan's (octocrab does not provide typed GraphQL itself). Evidence:
+  `examples/graphql_issues.rs` in the octocrab repository. Impact: supports
+  confining octocrab to REST.
 
 ## Decision log
 
-- Decision: keep the `GraphQLClient` facade and `VkError` taxonomy; replace
-  only the transport internals with octocrab. Rationale: consumers
-  (`src/commands.rs`, `src/review_threads.rs`, `src/reviews.rs`,
-  `src/issues.rs`, `src/branch_pr/`, `src/resolve/`) and roughly twenty network
-  tests couple to the facade, the error text, and the env-var overrides.
-  Swapping internals preserves all of that and bounds the blast radius;
-  rewriting consumers against octocrab's typed models would triple the diff for
-  no behavioural gain. Date/Author: 2026-07-09, planning session.
-- Decision: use octocrab's raw `_post` (returning `http::Response`) for
-  GraphQL and for the REST reply, not the convenience `graphql()` method or
-  typed REST handlers. Rationale: `graphql()` swallows the raw body and
-  discards partial-success data, which would break transcript recording,
-  body-snippet error context, and the HTML-body transient-retry heuristic.
-  `_post` inherits auth and base-URI middleware while leaving response
-  processing to `vk`. Date/Author: 2026-07-09, planning session.
-- Decision: keep `backon` retry and disable octocrab's retry layer
-  (`RetryConfig::None` on the builder). Rationale: a single retry authority
-  preserves the tested attempt counts and backoff behaviour. octocrab's
-  rate-limit-aware retry cannot see GraphQL rate-limit errors (they arrive as
-  HTTP 200 with an `errors` payload), so `backon` at the operation level
-  remains necessary anyway. Date/Author: 2026-07-09, planning session.
-- Decision: pin octocrab with a tilde requirement (`~0.54`).
-  Rationale: octocrab has a documented history of breaking changes in patch
-  releases (upstream issue 899). AGENTS.md permits tilde pins where the reason
-  is documented; this is that documentation, and the ADR repeats it.
-  Date/Author: 2026-07-09, planning session.
-- Decision: record the adoption in a new ADR,
-  `docs/adr-001-adopt-octocrab.md`. Rationale: no ADRs exist; the
-  bespoke-client choice was never recorded. AGENTS.md requires substantive
+- Decision: adopt the three-part programme — octocrab for REST only, a
+  direct hyper transport for the bespoke GraphQL client, and `graphql_client`
+  codegen for typed queries — instead of routing all traffic through octocrab.
+  Rationale: the bespoke GraphQL client is heavily leveraged for
+  instrumentability (transcript recording, body-snippet error context,
+  transient-retry classification on raw bodies), all of which octocrab's
+  `graphql()` helper hides; octocrab's value concentrates in its typed REST
+  surface and maintained plumbing. This keeps the observability investment,
+  converges on one HTTP stack, and adds the compile-time query checking the
+  bespoke client always lacked. Date/Author: 2026-07-09, direction given by the
+  user in review of the first draft.
+- Decision: deliver as three pull requests in the order REST (PR 1),
+  transport (PR 2), codegen (PR 3). Rationale: PR 1 is the smallest and proves
+  octocrab in-tree with minimal blast radius; PR 2 removes reqwest early so the
+  dependency win lands before the largest change; PR 3 is type-level only and
+  benefits from a settled transport underneath it. PRs 2 and 3 are
+  order-independent if circumstances change. Date/Author: 2026-07-09, planning
+  session.
+- Decision: keep the `GraphQLClient` facade and `VkError` taxonomy
+  throughout; all three PRs change internals or add typed surface only.
+  Rationale: consumers (`src/commands.rs`, `src/review_threads.rs`,
+  `src/reviews.rs`, `src/issues.rs`, `src/branch_pr/`, `src/resolve/`) and
+  roughly twenty network tests couple to the facade, the error text, and the
+  env-var overrides. Date/Author: 2026-07-09, planning session.
+- Decision: keep `backon` retry as the single retry authority on the
+  GraphQL path; build octocrab (REST) without its retry feature so the reply
+  path stays retry-free as today. Rationale: preserves tested attempt counts;
+  octocrab's retry layer cannot see GraphQL rate-limit errors (HTTP 200 with an
+  `errors` payload) anyway. Date/Author: 2026-07-09, planning session.
+- Decision: pin octocrab with a tilde requirement (`~0.54`). Rationale:
+  octocrab has a documented history of breaking changes in patch releases
+  (upstream issue 899). AGENTS.md permits tilde pins where the reason is
+  documented; this is that documentation, and the ADR repeats it. Date/Author:
+  2026-07-09, planning session.
+- Decision: in PR 3, keep the exported domain structs and convert from
+  generated `ResponseData` types at a private boundary (`From`
+  implementations), rather than exporting generated types. Rationale: the
+  domain structs are public API (re-exported from `src/lib.rs`) and are
+  consumed by the printer and summary modules; the generated types are an
+  implementation detail of the wire format. Date/Author: 2026-07-09, planning
+  session.
+- Decision: record the programme in a new ADR,
+  `docs/adr-001-github-api-client-modernisation.md`. Rationale: no ADRs exist;
+  the bespoke-client choice was never recorded. AGENTS.md requires substantive
   decisions to be captured as ADRs following
-  `docs/documentation-style-guide.md` (Status, Date, Context and Problem
-  Statement, Options Considered, Decision Outcome, Migration Plan, Known
-  Risks). Date/Author: 2026-07-09, planning session.
+  `docs/documentation-style-guide.md`. Date/Author: 2026-07-09, planning
+  session (path renamed from `adr-001-adopt-octocrab.md` when the scope
+  changed).
 
 ## Outcomes & retrospective
 
@@ -246,7 +307,9 @@ GraphQL queries are raw string constants in `src/graphql_queries.rs`
 (`THREADS_QUERY`, `COMMENT_QUERY`, `ISSUE_QUERY`, `PR_FOR_BRANCH_QUERY`) and in
 `src/resolve/graphql.rs` (`RESOLVE_THREAD_MUTATION`, `REVIEW_COMMENTS_PAGE`).
 Responses deserialize into per-module serde structs that mirror the GraphQL
-wire shape; these structs are unchanged by this plan.
+wire shape; the exported ones (`ReviewThread`, `ReviewComment`,
+`CommentConnection`, `PageInfo`, `PullRequestReview`, `Issue`, `User`) are
+public API and survive all three PRs.
 
 The REST path: `src/resolve/rest.rs` (only compiled with
 `--features unstable-rest-resolve`) builds a second `reqwest::Client`
@@ -254,7 +317,8 @@ The REST path: `src/resolve/rest.rs` (only compiled with
 `GITHUB_API_URL` env var (default `https://api.github.com`). Its one operation,
 `post_reply`, POSTs to
 `repos/{owner}/{name}/pulls/{pull_number}/comments/{comment_id}/replies`,
-treating 404 as non-fatal and other non-2xx as fatal, with no retry.
+treating 404 as non-fatal (warn and continue) and other non-2xx as fatal, with
+no retry.
 
 Authentication: `src/auth.rs::resolve_github_token` implements the precedence
 chain; no `gh` CLI integration exists. The token is a plain string handed to
@@ -265,8 +329,8 @@ Tests that constrain this work:
 - `src/api/client/tests.rs` spins up loopback hyper servers and constructs
   clients via `with_endpoint`/`with_endpoint_retry` using endpoints without a
   path; it counts retry attempts and asserts error-text fragments.
-- `src/test_utils/test_http.rs` and `src/branch_pr/tests.rs` follow the same
-  pattern.
+- `src/test_utils/test_http.rs` and `src/branch_pr/tests.rs` follow the
+  same pattern.
 - `tests/utils/mod.rs::vk_cmd` runs the real binary with
   `GITHUB_GRAPHQL_URL=http://{addr}/graphql`, `GITHUB_API_URL=http://{addr}`,
   and `GITHUB_TOKEN=dummy`.
@@ -278,115 +342,131 @@ Tests that constrain this work:
 - `tests/e2e/common.rs::load_transcript` and `tests/fixtures/pr42.json`
   encode the transcript JSON-lines format.
 
-Key octocrab facts (version 0.54.0, MSRV 1.85, rustls + ring by default):
+Key library facts (verified 2026-07-09):
 
-- It builds on hyper 1.x and tower, not reqwest. `OctocrabBuilder`
-  provides `personal_token`, `base_uri` (a tower layer rewriting relative
-  routes, applying to REST and GraphQL alike), `add_header`,
-  `add_retry_config`, and connect/read/write timeouts.
-- `Octocrab::_post(route, body)` returns the raw `http::Response`, from
-  which status and body bytes can be read — this is the hook that preserves
-  `vk`'s transcript, snippets, and retry classification.
-- The convenience `graphql()` method deserializes internally and discards
-  the raw body and partial-success data; it is not used by this plan.
-- Resolving a review thread has no REST endpoint; the `resolveReviewThread`
-  GraphQL mutation remains the only way, so GraphQL stays central.
+- octocrab 0.54.0 (MSRV 1.85) builds on hyper 1.x and tower, rustls with
+  the ring provider by default. `OctocrabBuilder` provides `personal_token`,
+  `base_uri` (applies to all routes), `add_header`, and timeouts.
+  `pulls(owner, repo)` exposes typed review-comment operations including
+  replying to a comment; the raw `_post(route, body)` method returns an
+  unprocessed `http::Response` as a fallback. Resolving a review thread has no
+  REST endpoint; the `resolveReviewThread` GraphQL mutation is the only way.
+- `graphql_client` 0.16.0 (January 2026, maintained, MSRV 1.66):
+  `#[derive(GraphQLQuery)]` with `schema_path`/`query_path` generates
+  `Variables` and `ResponseData` types per operation.
+  `Operation::build_query(variables)` returns a `QueryBody` that serializes to
+  the standard `{"query", "variables", "operationName"}` envelope, and
+  responses are plain serde — both compose with any transport, so the bespoke
+  client's envelope handling, transcript, and `serde_path_to_error` diagnostics
+  continue to work. The reqwest features are optional and stay off. Custom
+  scalars used by GitHub (`DateTime`, `URI`, `HTML`, and friends) need type
+  aliases in scope of the derive.
+- GitHub's public GraphQL schema is published at
+  `https://docs.github.com/public/fpt/schema.docs.graphql` (~73,000 lines, ~1.5
+  MB SDL); vendoring it whole is the established practice (octocrab and
+  graphql_client both do so in their examples).
 
 ## Plan of work
 
-The work is four milestones, each ending in a commit (or small commit series)
-with all gates green. The public facade means consumers are untouched until
-Milestone 3, and most tests act as a characterization harness throughout: their
-continuing to pass is the acceptance evidence.
+Stage A (lands with PR 1): author
+`docs/adr-001-github-api-client-modernisation.md` following the ADR template in
+`docs/documentation-style-guide.md`. Status: Accepted. Context: two bespoke
+reqwest clients, an undocumented prior decision, and no compile-time query
+checking. Options Considered: keep bespoke; route everything through octocrab;
+the adopted three-part split; `graphql_client` plus reqwest without octocrab.
+Decision Outcome: the three-part programme, with the octocrab tilde pin and its
+rationale. Migration Plan: reference this ExecPlan. Reference the ADR from
+`docs/vk-design.md` and list it in `docs/contents.md`.
 
-Stage A (part of the first commit): author `docs/adr-001-adopt-octocrab.md`
-following the ADR template in `docs/documentation-style-guide.md` (Status:
-Accepted; Context: two bespoke reqwest clients, undocumented prior decision;
-Options Considered: keep bespoke, octocrab, graphql_client + reqwest codegen;
-Decision Outcome: octocrab as transport with retained facade; Migration Plan:
-reference this ExecPlan; Known Risks: semver history, hence tilde pin).
-Reference the ADR from `docs/vk-design.md` and list it in `docs/contents.md`.
-Add the dependency to `Cargo.toml`:
+### PR 1 — octocrab for the REST resolve path
 
+Add the dependency (final feature list recorded here after the spike; the
+`retry` feature is deliberately excluded so no retry layer exists, matching
+today's retry-free reply path):
+
+    # Tilde pin: octocrab has shipped breaking changes in patch releases
+    # (upstream issue 899); widen only after review.
     octocrab = { version = "~0.54", default-features = false, features = ["rustls", "rustls-ring", "timeout"] }
 
-(Feature list to be verified during the spike: the goal is rustls with the ring
-provider, timeouts available, octocrab's retry and tracing layers not required;
-adjust to the minimal set that compiles, and record the final set here.) Run
-`cargo tree -d` to check for duplicate major versions of shared transitive
-dependencies and note findings in `Surprises & discoveries`.
+Rework `src/resolve/rest.rs` behind its existing `pub(crate)` surface:
+`RestClient::new(token, api, timeout, connect_timeout)` builds an
+`octocrab::Octocrab` via `OctocrabBuilder` (`personal_token` when the token is
+non-empty, `base_uri` from the existing parameter → `GITHUB_API_URL` → default
+resolution, connect/read timeouts from the existing arguments). `post_reply`
+first attempts the typed route
+(`octocrab.pulls(owner, name).reply_to_comment(...)` or the closest current
+equivalent — verify the exact method against octocrab 0.54 during the spike);
+it must preserve the semantics `tests/resolve.rs` asserts: exact request path,
+404 mapped to a warning and success, other non-2xx mapped to a fatal `VkError`.
+If the typed model rejects the stub response bodies, enrich the stubs toward
+realistic fixtures (`tests/fixtures/review_comment.json` exists for this); if
+semantics still cannot be matched, fall back to `_post` with the hand-built
+route and record the outcome in the Decision Log. Delete `github_client` and
+the hand-rolled header constants. Acceptance:
+`cargo test --features unstable-rest-resolve` and `make lint` (all-features)
+pass; `tests/resolve.rs` unchanged in what it asserts.
 
-Milestone 1 (prototyping, go/no-go): inside `src/api/client/`, add a private
-transport module (`src/api/client/transport.rs`) that owns an
-`octocrab::Octocrab` instance plus the route to post to, and give it one async
-method mirroring today's `execute_single_request` contract: take a JSON
-payload, return `HttpResponse { status, body }` or `VkError`. Construct it from
-the existing `Endpoint`, `Token`, and `RetryConfig` values:
+### PR 2 — hyper transport; remove reqwest
 
-- Split the `Endpoint` URL into a base URI and a route path (for
-  `http://127.0.0.1:9999` the route is `/`; for
-  `https://api.github.com/graphql` the base is `https://api.github.com` and the
-  route `/graphql`). This is the pure function `split_endpoint` described under
-  Interfaces below, written test-first.
-- Builder: `personal_token` only when the token is non-empty; `add_header`
-  for `User-Agent: vk` and `Accept: application/vnd.github+json` (verify during
-  the spike whether octocrab's defaults duplicate or fight these; the wire
-  assertions in `tests/auth.rs` are the arbiter);
-  `add_retry_config(octocrab::service::middleware::retry::RetryConfig::None)`;
-  read/connect timeouts from `vk`'s `RetryConfig::request_timeout`.
-- Method body: `_post(route, Some(&payload))`, read status, collect body
-  bytes to a `String`, map transport errors into `VkError::RequestContext` with
-  the same context text as today.
+Add a private transport module `src/api/client/transport.rs` owning a pooled
+hyper client (`hyper_util::client::legacy::Client` with a `hyper_rustls` HTTPS
+connector) and exposing one method mirroring `execute_single_request`'s
+contract: take the JSON payload and headers, POST to the configured endpoint
+URL (kept whole — no base/route splitting is needed because the bespoke client
+posts to one absolute URL), enforce the total-request timeout via
+`tokio::time::timeout` (mirroring reqwest's `.timeout()` scope: connect plus
+body), collect the body with `http-body-util`, and return
+`HttpResponse { status, body }` or a `VkError::RequestContext` with today's
+context text. Promote `hyper`, `hyper-util`, `hyper-rustls`, and
+`http-body-util` to runtime dependencies; record the chosen TLS root store
+(webpki roots, matching the current `rustls-tls` posture) in the Decision Log.
+Switch `execute_single_request` to delegate to the transport; the transcript
+call, status check, snippets, retry loop, and headers logic are untouched.
+Remove `reqwest` from `Cargo.toml` and replace any residual `reqwest::header`
+imports with the `http` crate equivalents (they are the same types
+re-exported). Acceptance: `make test` passes without any test edits;
+`cargo tree -i reqwest` reports the package is not found.
 
-Switch `execute_single_request` to delegate to the transport while leaving
-everything else (transcript call, status check, snippets, retry loop)
-untouched. The `reqwest::Client` field and `headers: HeaderMap` field of
-`GraphQLClient` are removed or bypassed. Acceptance: `cargo test api::client`
-(module tests) and then `make test` pass without any test edits. If raw
-status/body access or header parity cannot be achieved, stop: this is the
-go/no-go gate.
+### PR 3 — typed GraphQL via graphql_client codegen
 
-Milestone 2 (parity hardening): promote the spike to final quality. Red-green
-applies to the new unit: add rstest cases for `split_endpoint` covering
-path-less endpoints, `/graphql` paths, deeper paths, and trailing slashes,
-written before the implementation and observed failing (the function is new, so
-the red stage is a compile-fail or a failing assertion against a stub). Confirm
-timeout behaviour (a hanging stub server test already exists in the retry
-tests; verify it still passes), transcript output (run the ignored `e2e_pr_42`
-transcript test locally: `cargo test --test e2e -- --ignored e2e_pr_42` — it
-replays `tests/fixtures/pr42.json`), and anonymous access (`tests/auth.rs`).
-Delete `src/api/client/helpers.rs::build_headers` and its two unit tests only
-if header construction has genuinely moved into the octocrab builder; otherwise
-keep it as the single source of header values fed to `add_header`. Update module
-`//!` comments to describe the octocrab transport. All gates green; commit.
+Record the build-time baseline first (`cargo build` from clean, wall clock).
+Vendor the schema at `graphql/schema.docs.graphql` with a short
+`graphql/README.md` noting the source URL and refresh procedure. Move each
+operation into a `.graphql` document under `graphql/` (thread listing, comment
+paging, issue lookup, PR-for-branch, review-comments paging, the
+`resolveReviewThread` mutation, and reviews listing), grouping related
+operations per file to amortize the per-derive schema parse. Create a shared
+scalars module (`type DateTime = chrono::DateTime<chrono::Utc>`,
+`type URI = String`, `type HTML = String`, extended as compile errors direct).
+Derive `GraphQLQuery` per operation with
+`response_derives = "Debug, Clone, PartialEq"`.
 
-Milestone 3 (REST resolve path): replace `src/resolve/rest.rs::github_client`
-and the `RestClient` internals with a second octocrab instance whose base URI
-comes from the existing resolution (parameter, then `GITHUB_API_URL`, then
-default). Keep `post_reply`'s signature and semantics: build the same relative
-route string, call `_post`, keep 404-as-warning and other-non-2xx-as-fatal
-mapping into `VkError`. Do not adopt the typed `pulls().reply_to_comment`
-handler in this plan (see Decision Log). Acceptance:
-`cargo test --features unstable-rest-resolve` passes, including
-`tests/resolve.rs`; `make lint` (which uses `--all-features`) passes. Commit.
+Client surface: add a typed method to `GraphQLClient` (see Interfaces) that
+takes an operation's `Variables`, builds the envelope with `build_query`, and
+reuses the existing POST, transcript, retry, and `serde_path_to_error`
+machinery; the codegen'd operation name replaces the string-sniffing
+`operation_name` helper on this path. For pagination, introduce a
+`CursorVariables` trait (set/replace the cursor on a typed variables struct)
+and a typed `paginate_operation` counterpart to `paginate_all`, written
+test-first against the existing scripted stub servers.
 
-Milestone 4 (removal and documentation): delete the `reqwest` dependency from
-`Cargo.toml` and any residual `use reqwest` imports (after Milestones 1–3 the
-only candidates are error-source downcasts; replace with hyper/http
-equivalents). Verify with `cargo tree -i reqwest` (expected: error, package not
-found). Update documentation:
+Conversion boundary: implement `From<ResponseData>` (or dedicated mapper
+functions where `From` is awkward) producing the existing exported domain
+structs, so `src/commands.rs`, the printer, and the summary modules do not
+change. Migrate call sites module by module (review_threads, reviews, issues,
+branch_pr, resolve/graphql), deleting each raw query constant as its operation
+moves; `src/graphql_queries.rs` is deleted at the end. Red-green applies to the
+new units (the `CursorVariables` trait, each conversion): write the rstest
+cases first against fixture JSON and observe the expected failure before
+implementing. Acceptance: full suite green; introducing a deliberate typo into
+any `.graphql` document fails `cargo build` (demonstrate once, then revert);
+build-time delta within tolerance.
 
-- `docs/vk-design.md`: rewrite the networking section to describe the
-  octocrab transport, retained facade, retry split (backon outside, octocrab
-  retry disabled), and endpoint splitting; reference the ADR.
-- `docs/vk-end-to-end-testing-guide.md`: correct the third-wheel
-  description (loopback stub via env-var override, not a MITM proxy).
-- `docs/repository-layout.md` and `docs/developers-guide.md`: only if
-  module boundaries moved (they should not).
-- `docs/contents.md`: ensure the ADR and this plan are listed.
-
-Run all gates including `make markdownlint` and `make nixie`. Complete
-`Outcomes & retrospective`. Set Status to COMPLETE. Commit.
+Documentation lands with each PR: `docs/vk-design.md` networking and resolve
+sections (PRs 1–2), the third-wheel correction in
+`docs/vk-end-to-end-testing-guide.md` (first PR that touches test docs), the
+GraphQL section rewrite and schema-refresh procedure (PR 3), and
+`docs/contents.md` whenever a document is added.
 
 ## Concrete steps
 
@@ -396,7 +476,7 @@ All commands run from the repository root
 
     make test 2>&1 | tee "/tmp/test-vk-adopt-octocrab.out"
 
-Per-milestone sequence (repeat for each milestone):
+Per-milestone sequence (repeat for each commit within each PR):
 
 1. Make the edits described in Plan of work.
 2. `make check-fmt` (apply `make fmt` first if needed).
@@ -410,11 +490,12 @@ Per-milestone sequence (repeat for each milestone):
 
 Useful focused commands:
 
-    cargo test api::client 2>&1 | tee /tmp/test-vk-adopt-octocrab.out
     cargo test --features unstable-rest-resolve --test resolve 2>&1 | tee /tmp/test-vk-adopt-octocrab.out
+    cargo test api::client 2>&1 | tee /tmp/test-vk-adopt-octocrab.out
     cargo test --test e2e -- --ignored e2e_pr_42 2>&1 | tee /tmp/test-vk-adopt-octocrab.out
-    cargo tree -i reqwest        # Milestone 4: expect "package … not found"
+    cargo tree -i reqwest        # PR 2 exit: expect "package … not found"
     cargo tree -d                # check duplicate transitive versions
+    curl -L https://docs.github.com/public/fpt/schema.docs.graphql -o graphql/schema.docs.graphql
 
 Expected shape of a passing test run (counts will drift as tests are added):
 
@@ -422,99 +503,133 @@ Expected shape of a passing test run (counts will drift as tests are added):
 
 ## Validation and acceptance
 
-The migration is behaviour-preserving, so the existing suite is the primary
-acceptance harness: every milestone ends with `make check-fmt`, `make lint`, and
-`make test` green with no test weakened or deleted (except the two
-`build_headers` unit tests, which may move with the code they test — see
-Milestone 2).
+The programme is behaviour-preserving, so the existing suite is the primary
+acceptance harness: every commit ends with `make check-fmt`, `make lint`, and
+`make test` green with no test weakened or deleted. Enriching REST stub bodies
+toward realistic fixtures (PR 1) and adding new tests is permitted; loosening
+assertions is not.
 
-Red-green-refactor evidence is required for the one genuinely new unit:
+Red-green-refactor evidence is required for the genuinely new units:
 
-- Red: add `split_endpoint` rstest cases in the transport module first;
-  run `cargo test api::client::transport` and observe failure (initially a
-  compile failure for the missing function, then failing assertions against a
-  todo stub).
-- Green: implement `split_endpoint` minimally; the focused test passes.
-- Refactor: tidy, then run `make lint` and `make test`.
+- PR 2: if any helper with observable logic is added to the transport
+  (beyond direct delegation), specify it with a failing test first; otherwise
+  the characterization harness (retry counts, error text, transcript replay)
+  stands in, and that substitution is recorded here.
+- PR 3: the `CursorVariables` trait, `paginate_operation`, and each
+  `ResponseData` → domain conversion get rstest cases against fixture JSON
+  written before the implementation; run the focused test, observe the expected
+  failure, implement, observe the pass, then run the wider gates.
 
-End-to-end observation: with no token and pointing at a loopback stub, the
-binary behaves identically before and after, for example:
+End-to-end observations per PR:
 
-    GITHUB_GRAPHQL_URL=http://127.0.0.1:1/graphql GITHUB_TOKEN=dummy \
-      cargo run -- pr https://github.com/leynos/vk/pull/1
+- PR 1: `cargo test --features unstable-rest-resolve --test resolve`
+  passes; a manual run against a loopback stub shows the reply POST hitting
+  `repos/{owner}/{name}/pulls/{n}/comments/{id}/replies` exactly as on `main`.
+- PR 2: `cargo tree -i reqwest` fails to find the package; the ignored
+  transcript-replay test (`cargo test --test e2e -- --ignored e2e_pr_42`)
+  passes, proving transcript format parity; with no server listening, running
+  `cargo run -- pr <url>` with `GITHUB_TOKEN=dummy` and
+  `GITHUB_GRAPHQL_URL=http://127.0.0.1:1/graphql` fails with a
+  connection-refused `RequestContext` error naming the operation, exactly as on
+  `main`.
+- PR 3: a deliberate field typo in a `.graphql` document turns into a
+  compile error (demonstrated once and reverted); the insta snapshots in
+  `tests/cli.rs` are byte-identical.
 
-fails with a connection-refused `RequestContext` error mentioning the operation
-name, exactly as on `main`.
-
-Quality criteria: all gates above, plus `cargo tree -i reqwest` failing to find
-the package at the end of Milestone 4, and documentation gates for the ADR and
-design-doc updates.
+Quality criteria: all gates above; documentation gates (`make markdownlint`,
+`make nixie`) for the ADR, design-doc, and `graphql/README.md` changes;
+build-time delta within the stated tolerance for PR 3.
 
 ## Idempotence and recovery
 
 Every step is an ordinary source edit gated by the test suite; re-running any
-command is safe. Each milestone is an independent commit, so a failed milestone
-is abandoned with `git restore` / `git reset --hard HEAD` without affecting
-completed work. Nothing in this plan touches user data, CI configuration, or
-anything outside the repository; the only files written outside it are `tee`
-logs under `/tmp`.
+command is safe. Each PR (and each commit within it) is independent, so a
+failed attempt is abandoned with `git restore` / `git reset --hard HEAD`
+without affecting completed work. The schema download is re-runnable and
+version-controlled once vendored. Nothing in this plan touches user data, CI
+configuration, or anything outside the repository; the only files written
+outside it are `tee` logs under `/tmp`.
 
 ## Artifacts and notes
 
 Record here, as milestones complete: the final octocrab feature set, the
-`cargo tree -d` duplicate report, a sample transcript line proving format
-parity, and the closing test counts.
+`cargo tree -d` duplicate report, the clean-build baseline and post-PR 3 delta,
+a sample transcript line proving format parity, and the closing test counts.
 
 ## Interfaces and dependencies
 
-Dependency to add (Stage A; final feature list recorded here after the spike):
+Dependencies to add:
 
-    # Tilde pin: octocrab has shipped breaking changes in patch releases
-    # (upstream issue 899); widen only after review.
+    # PR 1. Tilde pin: octocrab has shipped breaking changes in patch
+    # releases (upstream issue 899); widen only after review.
     octocrab = { version = "~0.54", default-features = false, features = ["rustls", "rustls-ring", "timeout"] }
 
-Dependency to remove (Milestone 4): `reqwest`.
+    # PR 2 (promoted from dev-dependencies; align versions with the lockfile)
+    hyper = "1"
+    hyper-util = { version = "0.1", features = ["client", "client-legacy", "http1", "tokio"] }
+    hyper-rustls = { version = "0.27", features = ["webpki-roots", "http1", "ring"] }
+    http-body-util = "0.1"
 
-In `src/api/client/transport.rs` (new, private to `client`):
+    # PR 3
+    graphql_client = "0.16"
 
-    /// Owns the octocrab instance and the GraphQL route derived from the
-    /// configured endpoint.
-    pub(super) struct Transport {
-        octocrab: octocrab::Octocrab,
-        route: String,
-    }
+Dependency to remove (PR 2): `reqwest`.
+
+In `src/api/client/transport.rs` (PR 2, new, private to `client`):
+
+    /// Owns the pooled hyper client used for GraphQL requests.
+    pub(super) struct Transport { /* hyper_util legacy client + HTTPS connector */ }
 
     impl Transport {
-        pub(super) fn new(
-            token: &Token,
-            endpoint: &Endpoint,
-            retry: &RetryConfig,
-        ) -> Result<Self, VkError>;
+        pub(super) fn new() -> Result<Self, VkError>;
 
-        /// POST `payload` to the GraphQL route, returning status and body.
+        /// POST `payload` to `endpoint` with `headers`, honouring `timeout`
+        /// across the whole request, returning status and body.
         pub(super) async fn post_json(
             &self,
+            endpoint: &Endpoint,
+            headers: &http::HeaderMap,
             payload: &serde_json::Value,
+            timeout: std::time::Duration,
         ) -> Result<HttpResponse, VkError>;
     }
 
-    /// Split a full endpoint URL into (base URI, route path).
-    ///
-    /// `https://api.github.com/graphql` -> ("https://api.github.com", "/graphql")
-    /// `http://127.0.0.1:9999`          -> ("http://127.0.0.1:9999", "/")
-    pub(super) fn split_endpoint(endpoint: &Endpoint) -> Result<(String, String), VkError>;
+In `src/api/client/mod.rs` (PR 3, added; string-based methods retained until
+unused, then deprecated per the Interface tolerance):
+
+    /// Execute a codegen'd GraphQL operation using this client.
+    pub async fn run_operation<Q: graphql_client::GraphQLQuery>(
+        &self,
+        variables: Q::Variables,
+    ) -> Result<Q::ResponseData, VkError>;
+
+In `src/api/pagination.rs` or a sibling module (PR 3):
+
+    /// Implemented by generated Variables types for paginated operations.
+    pub(crate) trait CursorVariables {
+        fn set_cursor(&mut self, cursor: Option<String>);
+    }
 
 Unchanged public surface (re-exported from `src/lib.rs` and `src/api/`):
-`GraphQLClient` and its constructors/methods, `Endpoint`, `Token`, `Query`,
+`GraphQLClient` and its constructors, `Endpoint`, `Token`, `Query`,
 `RetryConfig`, `paginate`, `PageInfo`, `CommentConnection`, `ReviewThread`,
 `ReviewComment`, `PullRequestReview`, `Issue`, `User`, and `VkError`.
 
-In `src/resolve/rest.rs`, `RestClient` keeps its `pub(crate)` construction and
-`post_reply` free function; only the inner client type changes from
-`reqwest::Client` to `octocrab::Octocrab`.
+In `src/resolve/rest.rs` (PR 1), `RestClient` keeps its `pub(crate)`
+construction and the `post_reply` free function; only the inner client type
+changes from `reqwest::Client` to `octocrab::Octocrab`.
 
 ## Revision note
 
-2026-07-09: initial draft, based on codebase reconnaissance (client layer,
-consumers, test infrastructure, documentation conventions) and octocrab 0.54
-research. No implementation has begun; awaiting approval.
+2026-07-09: initial draft proposed octocrab as the transport for both GraphQL
+and REST.
+
+2026-07-09 (second revision): scope changed on user direction after review of
+the first draft. octocrab is now confined to the REST resolve path; the bespoke
+GraphQL client is retained for its observability machinery and moves from
+reqwest to a direct hyper transport; `graphql_client` codegen adds compile-time
+query checking. Delivery is three pull requests. The planned ADR was renamed
+from `adr-001-adopt-octocrab.md` to
+`adr-001-github-api-client-modernisation.md`. Constraints, tolerances, risks,
+decisions, and interfaces were rewritten to match; no implementation has begun
+and the plan awaits approval.

--- a/docs/execplans/adopt-octocrab.md
+++ b/docs/execplans/adopt-octocrab.md
@@ -1,4 +1,4 @@
-# Modernise GitHub API access: octocrab REST, hyper transport, typed GraphQL
+# Modernize GitHub API access: octocrab REST, hyper transport, typed GraphQL
 
 This ExecPlan (execution plan) is a living document. The sections `Constraints`,
 `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`, `Decision Log`,
@@ -132,7 +132,7 @@ escalation, not workarounds.
 - Risk: octocrab has shipped breaking changes in patch releases before
   (upstream issue 899). Severity: medium. Likelihood: medium. Mitigation: pin
   with a tilde requirement (`~0.54`) and record the reason in a `Cargo.toml`
-  comment and the ADR.
+  comment and the architectural decision record (ADR).
 - Risk: a direct hyper transport must reassemble what `reqwest` provided
   for free: connection pooling, TLS configuration, total-request timeout, and
   body collection. A subtle difference (for example timeout scope or TLS root
@@ -192,6 +192,9 @@ escalation, not workarounds.
   via builder `add_header` with a direct `http` dependency; `tests/resolve.rs`
   green unchanged; design doc updated; all gates green; CodeRabbit review
   completed with zero findings; draft pull request opened as leynos/vk#194.
+- [x] (2026-07-28) Review follow-up restored the total REST reply deadline,
+  strengthened raw POST coverage for the route, body, authentication, required
+  headers, and status handling, and reconciled the documentation findings.
 - [ ] PR 2: hyper transport inside `GraphQLClient`; reqwest removed;
   `cargo tree -i reqwest` fails; full suite green.
 - [ ] PR 3: vendored schema, `.graphql` documents, generated types behind a
@@ -277,24 +280,24 @@ escalation, not workarounds.
   session.
 - Decision: design the refitted GraphQL client (PRs 2 and 3) for cheap
   future extraction into a shared crate. Rationale: the sibling project frankie
-  (a code-review TUI, currently REST-only octocrab) will need the GraphQL-only
-  review-thread surface (`isResolved`, `resolveReviewThread`) that motivated
-  this client, and the executor (transport, retry, transcript, typed
-  operations, cursor pagination) is the reusable part while query documents
-  stay per-project. Concretely: keep `VkError` and `vk::environment` coupling
-  at the edges of the transport and typed modules rather than woven through
-  them. Extraction itself is out of scope for this plan. Date/Author:
-  2026-07-09, follow-up review discussion.
+  (a code-review terminal user interface (TUI), currently REST-only octocrab)
+  will need the GraphQL-only review-thread surface (`isResolved`,
+  `resolveReviewThread`) that motivated this client, and the executor
+  (transport, retry, transcript, typed operations, cursor pagination) is the
+  reusable part while query documents stay per-project. Concretely: keep
+  `VkError` and `vk::environment` coupling at the edges of the transport and
+  typed modules rather than woven through them. Extraction itself is out of
+  scope for this plan. Date/Author: 2026-07-09, follow-up review discussion.
 - Decision: PR 1 uses octocrab's raw `_post` route for the reply, not the
   typed `pulls(...).comment(id).reply(...)` route. Rationale: the typed route
   funnels non-2xx responses through octocrab's `Error::GitHub`, whose display
   carries neither the request path nor the HTTP status code that
   `tests/resolve.rs` asserts in stderr; `_post` returns the raw
   `http::Response`, keeping the 404-non-fatal / other-non-2xx-fatal mapping and
-  error text in `vk`'s hands. Timeout mapping: reqwest's single total-request
-  timeout becomes octocrab's read plus write timeouts (closest analogue;
-  octocrab has no total-request timeout), and `connect_timeout` maps directly.
-  Date/Author: 2026-07-09, PR 1 implementation.
+  error text in `vk`'s hands. Timeout mapping: octocrab's read and write
+  timeouts remain configured, `connect_timeout` maps directly, and `post_reply`
+  additionally enforces reqwest's original total-request deadline. Date/Author:
+  2026-07-09, PR 1 implementation.
 - Decision: in PR 1, keep octocrab's own `User-Agent: octocrab` on the
   REST path (no test asserts the REST user agent, and octocrab hard-codes its
   value first in the header list), but restore the
@@ -318,9 +321,10 @@ To be completed as milestones land and at the end of the work.
 
 ## Context and orientation
 
-The repository is a single Rust crate (`vk`, edition 2024, MSRV 1.89) with
-sources under `src/` and integration tests under `tests/`. The `Makefile` is
-the canonical command runner. Read `AGENTS.md` before contributing.
+The repository is a single Rust crate (`vk`, edition 2024, minimum supported
+Rust version (MSRV) 1.89) with sources under `src/` and integration tests under
+`tests/`. The `Makefile` is the canonical command runner. Read `AGENTS.md`
+before contributing.
 
 The API layer, all under `src/api/`:
 
@@ -428,25 +432,26 @@ Add the dependency (final feature list recorded here after the spike; the
 `retry` feature is deliberately excluded so no retry layer exists, matching
 today's retry-free reply path):
 
-    # Tilde pin: octocrab has shipped breaking changes in patch releases
-    # (upstream issue 899); widen only after review.
-    octocrab = { version = "~0.54", default-features = false, features = ["rustls", "rustls-ring", "timeout"] }
+```toml
+# Tilde pin: octocrab has shipped breaking changes in patch releases
+# (upstream issue 899); widen only after review.
+octocrab = { version = "~0.54", default-features = false, features = [
+    "default-client", "jwt-rust-crypto", "rustls", "rustls-ring", "timeout",
+] }
+```
 
 Rework `src/resolve/rest.rs` behind its existing `pub(crate)` surface:
 `RestClient::new(token, api, timeout, connect_timeout)` builds an
 `octocrab::Octocrab` via `OctocrabBuilder` (`personal_token` when the token is
 non-empty, `base_uri` from the existing parameter → `GITHUB_API_URL` → default
-resolution, connect/read timeouts from the existing arguments). `post_reply`
-first attempts the typed route
-(`octocrab.pulls(owner, name).reply_to_comment(...)` or the closest current
-equivalent — verify the exact method against octocrab 0.54 during the spike);
-it must preserve the semantics `tests/resolve.rs` asserts: exact request path,
-404 mapped to a warning and success, other non-2xx mapped to a fatal `VkError`.
-If the typed model rejects the stub response bodies, enrich the stubs toward
-realistic fixtures (`tests/fixtures/review_comment.json` exists for this); if
-semantics still cannot be matched, fall back to `_post` with the hand-built
-route and record the outcome in the Decision Log. Delete `github_client` and
-the hand-rolled header constants. Acceptance:
+resolution, and connect/read/write timeouts from the existing arguments).
+`post_reply` additionally enforces the original total-request deadline and uses
+octocrab's raw `_post` route with the hand-built
+`/repos/{owner}/{name}/pulls/{pull_number}/comments/{comment_id}/replies`
+endpoint. It preserves the semantics `tests/resolve.rs` asserts: the exact
+request path, a 404 mapped to a warning and success, and every other non-2xx
+response mapped to a fatal `VkError` containing the route and status. Delete
+`github_client` and the hand-rolled header constants. Acceptance:
 `cargo test --features unstable-rest-resolve` and `make lint` (all-features)
 pass; `tests/resolve.rs` unchanged in what it asserts.
 
@@ -518,7 +523,9 @@ All commands run from the repository root
 (`/home/leynos/Projects/vk.worktrees/adopt-octocrab`). Long outputs go through
 `tee` to a log file for review, for example:
 
-    make test 2>&1 | tee "/tmp/test-vk-adopt-octocrab.out"
+```shell
+make test 2>&1 | tee "/tmp/test-vk-adopt-octocrab.out"
+```
 
 Per-milestone sequence (repeat for each commit within each PR):
 
@@ -534,16 +541,20 @@ Per-milestone sequence (repeat for each commit within each PR):
 
 Useful focused commands:
 
-    cargo test --features unstable-rest-resolve --test resolve 2>&1 | tee /tmp/test-vk-adopt-octocrab.out
-    cargo test api::client 2>&1 | tee /tmp/test-vk-adopt-octocrab.out
-    cargo test --test e2e -- --ignored e2e_pr_42 2>&1 | tee /tmp/test-vk-adopt-octocrab.out
-    cargo tree -i reqwest        # PR 2 exit: expect "package … not found"
-    cargo tree -d                # check duplicate transitive versions
-    curl -L https://docs.github.com/public/fpt/schema.docs.graphql -o graphql/schema.docs.graphql
+```shell
+cargo test --features unstable-rest-resolve --test resolve 2>&1 | tee /tmp/test-vk-adopt-octocrab.out
+cargo test api::client 2>&1 | tee /tmp/test-vk-adopt-octocrab.out
+cargo test --test e2e -- --ignored e2e_pr_42 2>&1 | tee /tmp/test-vk-adopt-octocrab.out
+cargo tree -i reqwest        # PR 2 exit: expect "package … not found"
+cargo tree -d                # check duplicate transitive versions
+curl -L https://docs.github.com/public/fpt/schema.docs.graphql -o graphql/schema.docs.graphql
+```
 
 Expected shape of a passing test run (counts will drift as tests are added):
 
-    test result: ok. 0 failed; finished in …
+```text
+test result: ok. 0 failed; finished in …
+```
 
 ## Validation and acceptance
 
@@ -604,58 +615,66 @@ a sample transcript line proving format parity, and the closing test counts.
 
 Dependencies to add:
 
-    # PR 1. Tilde pin: octocrab has shipped breaking changes in patch
-    # releases (upstream issue 899); widen only after review.
-    # jwt-rust-crypto is mandatory under default-features = false.
-    octocrab = { version = "~0.54", default-features = false, features = [
-        "default-client", "jwt-rust-crypto", "rustls", "rustls-ring", "timeout",
-    ] }
+```toml
+# PR 1. Tilde pin: octocrab has shipped breaking changes in patch
+# releases (upstream issue 899); widen only after review.
+# jwt-rust-crypto is mandatory under default-features = false.
+octocrab = { version = "~0.54", default-features = false, features = [
+    "default-client", "jwt-rust-crypto", "rustls", "rustls-ring", "timeout",
+] }
 
-    # PR 2 (promoted from dev-dependencies; align versions with the lockfile)
-    hyper = "1"
-    hyper-util = { version = "0.1", features = ["client", "client-legacy", "http1", "tokio"] }
-    hyper-rustls = { version = "0.27", features = ["webpki-roots", "http1", "ring"] }
-    http-body-util = "0.1"
+# PR 2 (promoted from dev-dependencies; align versions with the lockfile)
+hyper = "1"
+hyper-util = { version = "0.1", features = ["client", "client-legacy", "http1", "tokio"] }
+hyper-rustls = { version = "0.27", features = ["webpki-roots", "http1", "ring"] }
+http-body-util = "0.1"
 
-    # PR 3
-    graphql_client = "0.16"
+# PR 3
+graphql_client = "0.16"
+```
 
 Dependency to remove (PR 2): `reqwest`.
 
 In `src/api/client/transport.rs` (PR 2, new, private to `client`):
 
-    /// Owns the pooled hyper client used for GraphQL requests.
-    pub(super) struct Transport { /* hyper_util legacy client + HTTPS connector */ }
+```rust
+/// Owns the pooled hyper client used for GraphQL requests.
+pub(super) struct Transport { /* hyper_util legacy client + HTTPS connector */ }
 
-    impl Transport {
-        pub(super) fn new() -> Result<Self, VkError>;
+impl Transport {
+    pub(super) fn new() -> Result<Self, VkError>;
 
-        /// POST `payload` to `endpoint` with `headers`, honouring `timeout`
-        /// across the whole request, returning status and body.
-        pub(super) async fn post_json(
-            &self,
-            endpoint: &Endpoint,
-            headers: &http::HeaderMap,
-            payload: &serde_json::Value,
-            timeout: std::time::Duration,
-        ) -> Result<HttpResponse, VkError>;
-    }
+    /// POST `payload` to `endpoint` with `headers`, honouring `timeout`
+    /// across the whole request, returning status and body.
+    pub(super) async fn post_json(
+        &self,
+        endpoint: &Endpoint,
+        headers: &http::HeaderMap,
+        payload: &serde_json::Value,
+        timeout: std::time::Duration,
+    ) -> Result<HttpResponse, VkError>;
+}
+```
 
 In `src/api/client/mod.rs` (PR 3, added; string-based methods retained until
 unused, then deprecated per the Interface tolerance):
 
-    /// Execute a codegen'd GraphQL operation using this client.
-    pub async fn run_operation<Q: graphql_client::GraphQLQuery>(
-        &self,
-        variables: Q::Variables,
-    ) -> Result<Q::ResponseData, VkError>;
+```rust
+/// Execute a codegen'd GraphQL operation using this client.
+pub async fn run_operation<Q: graphql_client::GraphQLQuery>(
+    &self,
+    variables: Q::Variables,
+) -> Result<Q::ResponseData, VkError>;
+```
 
 In `src/api/pagination.rs` or a sibling module (PR 3):
 
-    /// Implemented by generated Variables types for paginated operations.
-    pub(crate) trait CursorVariables {
-        fn set_cursor(&mut self, cursor: Option<String>);
-    }
+```rust
+/// Implemented by generated Variables types for paginated operations.
+pub(crate) trait CursorVariables {
+    fn set_cursor(&mut self, cursor: Option<String>);
+}
+```
 
 Unchanged public surface (re-exported from `src/lib.rs` and `src/api/`):
 `GraphQLClient` and its constructors, `Endpoint`, `Token`, `Query`,
@@ -678,5 +697,5 @@ reqwest to a direct hyper transport; `graphql_client` codegen adds compile-time
 query checking. Delivery is three pull requests. The planned ADR was renamed
 from `adr-001-adopt-octocrab.md` to
 `adr-001-github-api-client-modernisation.md`. Constraints, tolerances, risks,
-decisions, and interfaces were rewritten to match; no implementation has begun
-and the plan awaits approval.
+decisions, and interfaces were rewritten to match. PR 1 is complete; PRs 2 and
+3 remain as authorized future work.

--- a/docs/execplans/adopt-octocrab.md
+++ b/docs/execplans/adopt-octocrab.md
@@ -610,9 +610,9 @@ Quality criteria: all gates above; documentation gates (`make markdownlint`,
 `make nixie`) for the ADR, design-doc, and `graphql/README.md` changes;
 build-time delta within the stated tolerance for PR 3.
 
-PR 1 extracts the URI-normalisation and status-classification invariants into
+PR 1 extracts the URI-normalization and status-classification invariants into
 pure helpers. `proptest` exercises arbitrary trailing-slash counts and every
-valid HTTP status code: normalisation removes all trailing slashes and is
+valid HTTP status code: normalization removes all trailing slashes and is
 idempotent, while classification treats only 404 as warn-and-continue, 2xx as
 success, and every other status as fatal. The integration tests retain exact
 route, header, body, authentication, and total-deadline coverage for the raw
@@ -644,7 +644,7 @@ outside it are `tee` logs under `/tmp`.
 
 PR 1 artifact and evidence: Octocrab is configured with the recorded feature
 set, `tests/resolve.rs` verifies the raw reply route, headers, body,
-authentication, status handling, URI normalisation, and total deadline, and the
+authentication, status handling, URI normalization, and total deadline, and the
 recorded PR 1 gate run is green. The remaining artifacts are the PR 2
 `cargo tree -d` duplicate report and clean-build comparison, followed by the PR
 3 sample transcript line, schema/code-generation evidence, and closing test

--- a/docs/execplans/adopt-octocrab.md
+++ b/docs/execplans/adopt-octocrab.md
@@ -4,7 +4,7 @@ This ExecPlan (execution plan) is a living document. The sections `Constraints`,
 `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`, `Decision Log`,
 and `Outcomes & Retrospective` must be kept up to date as work proceeds.
 
-Status: DRAFT
+Status: IN PROGRESS
 
 ## Purpose / big picture
 
@@ -178,9 +178,11 @@ escalation, not workarounds.
   REST; GraphQL keeps the bespoke client on a hyper transport with
   `graphql_client` codegen. `graphql_client` 0.16 researched and confirmed
   transport-agnostic.
-- [ ] Stage A: author ADR `docs/adr-001-github-api-client-modernisation.md`
-  covering all three decisions; link from `docs/vk-design.md` and
-  `docs/contents.md`.
+- [x] (2026-07-09 15:30Z) Stage A: ADR
+  `docs/adr-001-github-api-client-modernisation.md` authored and linked from
+  `docs/vk-design.md` and `docs/contents.md`; octocrab `~0.54` added to
+  `Cargo.toml` (default features off; `default-client`, `rustls`, `rustls-ring`,
+  `timeout`; `retry` excluded deliberately).
 - [ ] PR 1: octocrab REST resolve path
   (`--features unstable-rest-resolve`); `tests/resolve.rs` green; octocrab
   dependency added with pin rationale.
@@ -211,6 +213,13 @@ escalation, not workarounds.
   `src/api/client/mod.rs:126-134`. Impact: parity is the goal; do not silently
   change redaction behaviour during the migration. Flagged for a possible
   follow-up outside this plan.
+- Observation: octocrab 0.54 with `default-features = false` fails to
+  compile unless one of its JWT crypto features is enabled, even when app (JWT)
+  auth is unused. Evidence: `compile_error!` at octocrab's `src/lib.rs:304`
+  during the first gate run. Impact: the dependency carries `jwt-rust-crypto`
+  (pure-Rust, matching the ring/rustls posture) alongside `default-client`,
+  `rustls`, `rustls-ring`, and `timeout`; this is the final feature set
+  anticipated by the Interfaces section.
 - Observation: octocrab's own GraphQL example delegates query typing to
   `graphql_client`, confirming the two tools' division of labour matches this
   plan's (octocrab does not provide typed GraphQL itself). Evidence:
@@ -572,7 +581,10 @@ Dependencies to add:
 
     # PR 1. Tilde pin: octocrab has shipped breaking changes in patch
     # releases (upstream issue 899); widen only after review.
-    octocrab = { version = "~0.54", default-features = false, features = ["rustls", "rustls-ring", "timeout"] }
+    # jwt-rust-crypto is mandatory under default-features = false.
+    octocrab = { version = "~0.54", default-features = false, features = [
+        "default-client", "jwt-rust-crypto", "rustls", "rustls-ring", "timeout",
+    ] }
 
     # PR 2 (promoted from dev-dependencies; align versions with the lockfile)
     hyper = "1"

--- a/docs/execplans/adopt-octocrab.md
+++ b/docs/execplans/adopt-octocrab.md
@@ -104,10 +104,13 @@ escalation, not workarounds.
   methods to `GraphQLClient` and deprecate (not remove) the string-based
   `run_query`/`fetch_page`/`paginate_all` surface if call-site migration leaves
   them unused.
-- Dependencies: this plan pre-approves `octocrab` (PR 1), promotion of
-  `hyper`, `hyper-util`, `hyper-rustls`, and `http-body-util` from
-  dev-dependencies to runtime dependencies (PR 2), and `graphql_client` (PR 3).
-  Any further new direct dependency requires escalation.
+- Dependencies: this plan pre-approves `octocrab` and `http` (PR 1 —
+  `http` is already in the tree; `reqwest::header` re-exports it, and
+  octocrab's `add_header` and PR 2's transport interface both need it
+  directly), promotion of `hyper`, `hyper-util`, `hyper-rustls`, and
+  `http-body-util` from dev-dependencies to runtime dependencies (PR 2),
+  and `graphql_client` (PR 3). Any further new direct dependency requires
+  escalation.
 - Behaviour: if preserving an asserted behaviour (error text, transcript
   format, header set, retry counts) proves impossible, stop and present
   options; do not weaken tests to fit.
@@ -183,9 +186,13 @@ escalation, not workarounds.
   `docs/vk-design.md` and `docs/contents.md`; octocrab `~0.54` added to
   `Cargo.toml` (default features off; `default-client`, `rustls`, `rustls-ring`,
   `timeout`; `retry` excluded deliberately).
-- [ ] PR 1: octocrab REST resolve path
-  (`--features unstable-rest-resolve`); `tests/resolve.rs` green; octocrab
-  dependency added with pin rationale.
+- [ ] PR 1: octocrab REST resolve path (completed: `src/resolve/rest.rs`
+  reworked onto octocrab via the raw `_post` route with `RestClient::new`
+  and `post_reply` signatures and semantics preserved, `github_client`
+  deleted, `x-github-api-version` and `Accept` headers restored via
+  builder `add_header` with a direct `http` dependency,
+  `tests/resolve.rs` green unchanged; remaining: design-doc update,
+  CodeRabbit review, PR opened). (2026-07-09 16:40Z)
 - [ ] PR 2: hyper transport inside `GraphQLClient`; reqwest removed;
   `cargo tree -i reqwest` fails; full suite green.
 - [ ] PR 3: vendored schema, `.graphql` documents, generated types behind a
@@ -279,6 +286,27 @@ escalation, not workarounds.
   at the edges of the transport and typed modules rather than woven through
   them. Extraction itself is out of scope for this plan. Date/Author:
   2026-07-09, follow-up review discussion.
+- Decision: PR 1 uses octocrab's raw `_post` route for the reply, not the
+  typed `pulls(...).comment(id).reply(...)` route. Rationale: the typed
+  route funnels non-2xx responses through octocrab's `Error::GitHub`,
+  whose display carries neither the request path nor the HTTP status code
+  that `tests/resolve.rs` asserts in stderr; `_post` returns the raw
+  `http::Response`, keeping the 404-non-fatal / other-non-2xx-fatal
+  mapping and error text in `vk`'s hands. Timeout mapping: reqwest's
+  single total-request timeout becomes octocrab's read plus write
+  timeouts (closest analogue; octocrab has no total-request timeout), and
+  `connect_timeout` maps directly. Date/Author: 2026-07-09, PR 1
+  implementation.
+- Decision: in PR 1, keep octocrab's own `User-Agent: octocrab` on the
+  REST path (no test asserts the REST user agent, and octocrab hard-codes
+  its value first in the header list), but restore the
+  `x-github-api-version: 2022-11-28` pin and the
+  `Accept: application/vnd.github+json` header via the builder's
+  `add_header`, using a direct `http` dependency. Rationale: the
+  API-version pin is documented behaviour in `docs/vk-design.md` and
+  protects against GitHub changing its default API version; dropping it
+  silently would contradict the design document. Date/Author: 2026-07-09,
+  PR 1 implementation.
 - Decision: record the programme in a new ADR,
   `docs/adr-001-github-api-client-modernisation.md`. Rationale: no ADRs exist;
   the bespoke-client choice was never recorded. AGENTS.md requires substantive

--- a/docs/execplans/adopt-octocrab.md
+++ b/docs/execplans/adopt-octocrab.md
@@ -185,13 +185,13 @@ escalation, not workarounds.
   `docs/vk-design.md` and `docs/contents.md`; octocrab `~0.54` added to
   `Cargo.toml` (default features off; `default-client`, `rustls`, `rustls-ring`,
   `timeout`; `retry` excluded deliberately).
-- [ ] PR 1: octocrab REST resolve path (completed: `src/resolve/rest.rs`
-  reworked onto octocrab via the raw `_post` route with `RestClient::new` and
-  `post_reply` signatures and semantics preserved, `github_client` deleted,
-  `x-github-api-version` and `Accept` headers restored via builder `add_header`
-  with a direct `http` dependency, `tests/resolve.rs` green unchanged;
-  remaining: design-doc update, CodeRabbit review, PR opened). (2026-07-09
-  16:40Z)
+- [x] (2026-07-09 17:20Z) PR 1: octocrab REST resolve path complete.
+  `src/resolve/rest.rs` reworked onto octocrab via the raw `_post` route with
+  `RestClient::new` and `post_reply` signatures and semantics preserved,
+  `github_client` deleted, `x-github-api-version` and `Accept` headers restored
+  via builder `add_header` with a direct `http` dependency; `tests/resolve.rs`
+  green unchanged; design doc updated; all gates green; CodeRabbit review
+  completed with zero findings; draft pull request opened as leynos/vk#194.
 - [ ] PR 2: hyper transport inside `GraphQLClient`; reqwest removed;
   `cargo tree -i reqwest` fails; full suite green.
 - [ ] PR 3: vendored schema, `.graphql` documents, generated types behind a

--- a/docs/execplans/adopt-octocrab.md
+++ b/docs/execplans/adopt-octocrab.md
@@ -105,12 +105,11 @@ escalation, not workarounds.
   `run_query`/`fetch_page`/`paginate_all` surface if call-site migration leaves
   them unused.
 - Dependencies: this plan pre-approves `octocrab` and `http` (PR 1 —
-  `http` is already in the tree; `reqwest::header` re-exports it, and
-  octocrab's `add_header` and PR 2's transport interface both need it
-  directly), promotion of `hyper`, `hyper-util`, `hyper-rustls`, and
-  `http-body-util` from dev-dependencies to runtime dependencies (PR 2),
-  and `graphql_client` (PR 3). Any further new direct dependency requires
-  escalation.
+  `http` is already in the tree; `reqwest::header` re-exports it, and octocrab's
+  `add_header` and PR 2's transport interface both need it directly),
+  promotion of `hyper`, `hyper-util`, `hyper-rustls`, and `http-body-util` from
+  dev-dependencies to runtime dependencies (PR 2), and `graphql_client` (PR 3).
+  Any further new direct dependency requires escalation.
 - Behaviour: if preserving an asserted behaviour (error text, transcript
   format, header set, retry counts) proves impossible, stop and present
   options; do not weaken tests to fit.
@@ -187,12 +186,12 @@ escalation, not workarounds.
   `Cargo.toml` (default features off; `default-client`, `rustls`, `rustls-ring`,
   `timeout`; `retry` excluded deliberately).
 - [ ] PR 1: octocrab REST resolve path (completed: `src/resolve/rest.rs`
-  reworked onto octocrab via the raw `_post` route with `RestClient::new`
-  and `post_reply` signatures and semantics preserved, `github_client`
-  deleted, `x-github-api-version` and `Accept` headers restored via
-  builder `add_header` with a direct `http` dependency,
-  `tests/resolve.rs` green unchanged; remaining: design-doc update,
-  CodeRabbit review, PR opened). (2026-07-09 16:40Z)
+  reworked onto octocrab via the raw `_post` route with `RestClient::new` and
+  `post_reply` signatures and semantics preserved, `github_client` deleted,
+  `x-github-api-version` and `Accept` headers restored via builder `add_header`
+  with a direct `http` dependency, `tests/resolve.rs` green unchanged;
+  remaining: design-doc update, CodeRabbit review, PR opened). (2026-07-09
+  16:40Z)
 - [ ] PR 2: hyper transport inside `GraphQLClient`; reqwest removed;
   `cargo tree -i reqwest` fails; full suite green.
 - [ ] PR 3: vendored schema, `.graphql` documents, generated types behind a
@@ -287,26 +286,24 @@ escalation, not workarounds.
   them. Extraction itself is out of scope for this plan. Date/Author:
   2026-07-09, follow-up review discussion.
 - Decision: PR 1 uses octocrab's raw `_post` route for the reply, not the
-  typed `pulls(...).comment(id).reply(...)` route. Rationale: the typed
-  route funnels non-2xx responses through octocrab's `Error::GitHub`,
-  whose display carries neither the request path nor the HTTP status code
-  that `tests/resolve.rs` asserts in stderr; `_post` returns the raw
-  `http::Response`, keeping the 404-non-fatal / other-non-2xx-fatal
-  mapping and error text in `vk`'s hands. Timeout mapping: reqwest's
-  single total-request timeout becomes octocrab's read plus write
-  timeouts (closest analogue; octocrab has no total-request timeout), and
-  `connect_timeout` maps directly. Date/Author: 2026-07-09, PR 1
-  implementation.
+  typed `pulls(...).comment(id).reply(...)` route. Rationale: the typed route
+  funnels non-2xx responses through octocrab's `Error::GitHub`, whose display
+  carries neither the request path nor the HTTP status code that
+  `tests/resolve.rs` asserts in stderr; `_post` returns the raw
+  `http::Response`, keeping the 404-non-fatal / other-non-2xx-fatal mapping and
+  error text in `vk`'s hands. Timeout mapping: reqwest's single total-request
+  timeout becomes octocrab's read plus write timeouts (closest analogue;
+  octocrab has no total-request timeout), and `connect_timeout` maps directly.
+  Date/Author: 2026-07-09, PR 1 implementation.
 - Decision: in PR 1, keep octocrab's own `User-Agent: octocrab` on the
-  REST path (no test asserts the REST user agent, and octocrab hard-codes
-  its value first in the header list), but restore the
+  REST path (no test asserts the REST user agent, and octocrab hard-codes its
+  value first in the header list), but restore the
   `x-github-api-version: 2022-11-28` pin and the
-  `Accept: application/vnd.github+json` header via the builder's
-  `add_header`, using a direct `http` dependency. Rationale: the
-  API-version pin is documented behaviour in `docs/vk-design.md` and
-  protects against GitHub changing its default API version; dropping it
-  silently would contradict the design document. Date/Author: 2026-07-09,
-  PR 1 implementation.
+  `Accept: application/vnd.github+json` header via the builder's `add_header`,
+  using a direct `http` dependency. Rationale: the API-version pin is
+  documented behaviour in `docs/vk-design.md` and protects against GitHub
+  changing its default API version; dropping it silently would contradict the
+  design document. Date/Author: 2026-07-09, PR 1 implementation.
 - Decision: record the programme in a new ADR,
   `docs/adr-001-github-api-client-modernisation.md`. Rationale: no ADRs exist;
   the bespoke-client choice was never recorded. AGENTS.md requires substantive

--- a/docs/execplans/adopt-octocrab.md
+++ b/docs/execplans/adopt-octocrab.md
@@ -610,11 +610,24 @@ Quality criteria: all gates above; documentation gates (`make markdownlint`,
 `make nixie`) for the ADR, design-doc, and `graphql/README.md` changes;
 build-time delta within the stated tolerance for PR 3.
 
-PR 1 uses a finite integration partition. `proptest` is not used because this
-behaviour is integration-only via Octocrab, not a pure function over which
-generated inputs would add useful coverage. The bounded tests cover zero, one,
-and multiple trailing slashes in the API URI, plus representative success, 404,
-and other non-2xx status classes.
+PR 1 extracts the URI-normalisation and status-classification invariants into
+pure helpers. `proptest` exercises arbitrary trailing-slash counts and every
+valid HTTP status code: normalisation removes all trailing slashes and is
+idempotent, while classification treats only 404 as warn-and-continue, 2xx as
+success, and every other status as fatal. The integration tests retain exact
+route, header, body, authentication, and total-deadline coverage for the raw
+Octocrab request.
+
+The REST reply boundary also emits three bounded observability signals:
+`vk.resolve.rest_reply.requests.total` counts attempts,
+`vk.resolve.rest_reply.duration.seconds` records elapsed time, and
+`vk.resolve.rest_reply.timeouts.total` counts total-deadline expirations. The
+counter and histogram use only the fixed `outcome`, `status_class`, and
+`failure_category` labels. Their values are respectively `success`,
+`not_found`, or `failure`; `1xx`, `2xx`, `3xx`, `4xx`, `5xx`, `other`, or
+`none`; and `none`, `http_status`, `timeout`, or `transport`. The timeout
+counter is unlabelled; no request identifiers, routes, repository names, or raw
+errors enter metric labels.
 
 ## Idempotence and recovery
 

--- a/docs/execplans/adopt-octocrab.md
+++ b/docs/execplans/adopt-octocrab.md
@@ -260,6 +260,16 @@ escalation, not workarounds.
   consumed by the printer and summary modules; the generated types are an
   implementation detail of the wire format. Date/Author: 2026-07-09, planning
   session.
+- Decision: design the refitted GraphQL client (PRs 2 and 3) for cheap
+  future extraction into a shared crate. Rationale: the sibling project frankie
+  (a code-review TUI, currently REST-only octocrab) will need the GraphQL-only
+  review-thread surface (`isResolved`, `resolveReviewThread`) that motivated
+  this client, and the executor (transport, retry, transcript, typed
+  operations, cursor pagination) is the reusable part while query documents
+  stay per-project. Concretely: keep `VkError` and `vk::environment` coupling
+  at the edges of the transport and typed modules rather than woven through
+  them. Extraction itself is out of scope for this plan. Date/Author:
+  2026-07-09, follow-up review discussion.
 - Decision: record the programme in a new ADR,
   `docs/adr-001-github-api-client-modernisation.md`. Rationale: no ADRs exist;
   the bespoke-client choice was never recorded. AGENTS.md requires substantive

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -110,7 +110,13 @@ vk resolve https://github.com/leynos/vk/pull/191#discussion_r123456789 \
   --message "Addressed in the latest commit."
 ```
 
-If the reply fails, the command stops before resolving the thread.
+`--http-timeout SECS` sets the total deadline for the REST reply request,
+including connection, request, and response handling; its default is 10 seconds.
+`--connect-timeout SECS` sets the connection deadline; its default is 5
+seconds. A 404 response from the reply endpoint emits a warning and continues
+with GraphQL resolution. Any other non-2xx response or a timeout aborts before
+GraphQL resolution, retaining the reply route and status or deadline details in
+the diagnostic.
 
 ## Troubleshoot terminal output
 

--- a/docs/vk-design.md
+++ b/docs/vk-design.md
@@ -79,6 +79,11 @@ even when multiple comments reference the same code.
 
 ## Architecture
 
+The modernisation of `vk`'s GitHub API access — octocrab for the REST resolve
+path, a hyper transport for the bespoke GraphQL client, and `graphql_client`
+codegen for typed queries — is governed by
+[ADR 001](adr-001-github-api-client-modernisation.md).
+
 The code centres on these printing helpers:
 
 <!-- mdformat off -->

--- a/docs/vk-design.md
+++ b/docs/vk-design.md
@@ -49,20 +49,23 @@ even when multiple comments reference the same code.
 - **Resolve threads**: `vk resolve <comment-ref>` resolves the thread via the
   `resolveReviewThread` GraphQL mutation. When compiled with the
   `unstable-rest-resolve` feature and a reply message is supplied (`-m`), it
-  posts a reply via the REST API before resolving. If the REST reply fails the
-  command aborts without calling `resolveReviewThread`, does not retry, and
-  does not apply backoff; missing comments return a warning and continue. The
-  resolver pages through the pull request's `reviewComments` connection using
-  typed `serde` structures (see `src/resolve/graphql.rs`), matching the
-  requested `databaseId` and extracting the owning thread identifier.
-  Pagination detects repeated or non-advancing cursors and aborts with an error
-  rather than looping indefinitely. This subcommand requires `GITHUB_TOKEN`
-  with sufficient scopes (resolving threads and posting replies require
-  `repo`); if absent, it aborts rather than performing anonymous calls.
-  Resolution steps emit debug spans via `tracing` to aid diagnostics; the
-  binary initialises `tracing_subscriber::fmt()` with an environment filter, so
-  running with `RUST_LOG=vk=debug` (or a more specific filter) surfaces the
-  spans on stderr.
+  posts a reply via the REST API before resolving. The REST reply is served
+  through [octocrab](https://docs.rs/octocrab) (see
+  [ADR 001](adr-001-github-api-client-modernisation.md)), pinning
+  `x-github-api-version: 2022-11-28`; status handling stays in `vk` via
+  octocrab's raw request route. If the REST reply fails the command aborts
+  without calling `resolveReviewThread`, does not retry, and does not apply
+  backoff; missing comments return a warning and continue. The resolver pages
+  through the pull request's `reviewComments` connection using typed `serde`
+  structures (see `src/resolve/graphql.rs`), matching the requested
+  `databaseId` and extracting the owning thread identifier. Pagination detects
+  repeated or non-advancing cursors and aborts with an error rather than
+  looping indefinitely. This subcommand requires `GITHUB_TOKEN` with sufficient
+  scopes (resolving threads and posting replies require `repo`); if absent, it
+  aborts rather than performing anonymous calls. Resolution steps emit debug
+  spans via `tracing` to aid diagnostics; the binary initialises
+  `tracing_subscriber::fmt()` with an environment filter, so running with
+  `RUST_LOG=vk=debug` (or a more specific filter) surfaces the spans on stderr.
 
 - **Configurable timeouts**: `--http-timeout` and `--connect-timeout`
   override the default 10 s request and 5 s connection limits for REST replies.

--- a/docs/vk-design.md
+++ b/docs/vk-design.md
@@ -63,7 +63,7 @@ even when multiple comments reference the same code.
   looping indefinitely. This subcommand requires `GITHUB_TOKEN` with sufficient
   scopes (resolving threads and posting replies require `repo`); if absent, it
   aborts rather than performing anonymous calls. Resolution steps emit debug
-  spans via `tracing` to aid diagnostics; the binary initialises
+  spans via `tracing` to aid diagnostics; the binary initializes
   `tracing_subscriber::fmt()` with an environment filter, so running with
   `RUST_LOG=vk=debug` (or a more specific filter) surfaces the spans on stderr.
 
@@ -82,8 +82,8 @@ even when multiple comments reference the same code.
 
 ## Architecture
 
-The modernisation of `vk`'s GitHub API access — octocrab for the REST resolve
-path, a hyper transport for the bespoke GraphQL client, and `graphql_client`
+The modernization of `vk`'s GitHub API access — octocrab for the REST resolve
+path, hyper transport for the bespoke GraphQL client, and `graphql_client`
 codegen for typed queries — is governed by
 [ADR 001](adr-001-github-api-client-modernisation.md).
 

--- a/src/api/client/http.rs
+++ b/src/api/client/http.rs
@@ -1,7 +1,10 @@
 //! HTTP response wrapper used by the GraphQL client.
 
+/// The status and body returned by a GraphQL HTTP request.
 #[derive(Debug)]
 pub(super) struct HttpResponse {
+    /// The HTTP response status code.
     pub(super) status: u16,
+    /// The response body as text.
     pub(super) body: String,
 }

--- a/src/api/client/mod.rs
+++ b/src/api/client/mod.rs
@@ -36,10 +36,15 @@ mod tests;
 /// The client handles authentication headers and optional request
 /// transcription for debugging.
 pub struct GraphQLClient {
+    /// HTTP client used to send GraphQL requests.
     client: reqwest::Client,
+    /// Headers applied to every GraphQL request.
     headers: HeaderMap,
+    /// GraphQL endpoint targeted by this client.
     endpoint: Endpoint,
+    /// Optional writer for request and response transcripts.
     transcript: Option<std::sync::Mutex<std::io::BufWriter<std::fs::File>>>,
+    /// Retry and timeout settings for requests.
     retry: RetryConfig,
 }
 

--- a/src/api/client/pagination.rs
+++ b/src/api/client/pagination.rs
@@ -7,6 +7,7 @@ use serde::de::DeserializeOwned;
 use serde_json::{Map, Value};
 use std::borrow::Cow;
 
+/// Maximum number of pages fetched by one pagination operation.
 const MAX_PAGES: usize = 1000;
 
 impl GraphQLClient {

--- a/src/api/client/types.rs
+++ b/src/api/client/types.rs
@@ -7,10 +7,12 @@ use serde::Deserialize;
 pub struct Query(String);
 
 impl Query {
+    /// Create a query from a string-like value.
     pub fn new(query: impl Into<String>) -> Self {
         Self(query.into())
     }
 
+    /// Return the query text.
     #[must_use]
     pub fn as_str(&self) -> &str {
         &self.0
@@ -34,15 +36,18 @@ impl AsRef<str> for Query {
 pub struct Token(String);
 
 impl Token {
+    /// Create an authentication token from a string-like value.
     pub fn new(token: impl Into<String>) -> Self {
         Self(token.into())
     }
 
+    /// Return the token text.
     #[must_use]
     pub fn as_str(&self) -> &str {
         &self.0
     }
 
+    /// Return whether the token contains no characters.
     #[must_use]
     pub fn is_empty(&self) -> bool {
         self.0.is_empty()
@@ -66,10 +71,12 @@ impl AsRef<str> for Token {
 pub struct Endpoint(String);
 
 impl Endpoint {
+    /// Create an endpoint from a string-like URL.
     pub fn new(url: impl Into<String>) -> Self {
         Self(url.into())
     }
 
+    /// Return the endpoint URL.
     #[must_use]
     pub fn as_str(&self) -> &str {
         &self.0
@@ -94,15 +101,21 @@ impl Default for Endpoint {
     }
 }
 
+/// Default GitHub GraphQL API endpoint.
 const GITHUB_GRAPHQL_URL: &str = "https://api.github.com/graphql";
 
+/// A decoded GraphQL response envelope.
 #[derive(Debug, Deserialize)]
 pub(super) struct GraphQLResponse<T> {
+    /// Data returned by the operation, when present.
     pub(super) data: Option<T>,
+    /// Errors reported by the GraphQL service, when present.
     pub(super) errors: Option<Vec<GraphQLError>>,
 }
 
+/// An error reported in a GraphQL response.
 #[derive(Debug, Deserialize)]
 pub(super) struct GraphQLError {
+    /// Human-readable error message.
     pub(super) message: String,
 }

--- a/src/branch_pr/mod.rs
+++ b/src/branch_pr/mod.rs
@@ -12,36 +12,49 @@ use crate::graphql_queries::PR_FOR_BRANCH_QUERY;
 use crate::ref_parser::RepoInfo;
 use crate::{GraphQLClient, VkError};
 
+/// GraphQL data returned when looking up pull requests for a branch.
 #[derive(Debug, Deserialize)]
 pub(crate) struct PrForBranchData {
+    /// Repository containing the matching pull requests.
     repository: PrForBranchRepository,
 }
 
+/// Repository portion of a branch pull-request lookup response.
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct PrForBranchRepository {
+    /// Pull requests matching the branch query.
     pull_requests: PrConnection,
 }
 
+/// Connection containing pull requests returned by GitHub.
 #[derive(Debug, Deserialize)]
 struct PrConnection {
+    /// Pull-request nodes in the connection.
     nodes: Vec<PrNode>,
 }
 
+/// Pull-request identity and head-repository data.
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct PrNode {
+    /// Pull-request number.
     pub(crate) number: u64,
+    /// Repository from which the pull request originates, when available.
     pub(crate) head_repository: Option<HeadRepository>,
 }
 
+/// Head-repository data for a pull request.
 #[derive(Debug, Deserialize)]
 pub(crate) struct HeadRepository {
+    /// Owner of the head repository.
     pub(crate) owner: Owner,
 }
 
+/// GitHub repository-owner information.
 #[derive(Debug, Deserialize)]
 pub(crate) struct Owner {
+    /// GitHub login for the owner.
     pub(crate) login: String,
 }
 

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -29,15 +29,22 @@ use tracing::{debug, error, warn};
 #[cfg(feature = "unstable-rest-resolve")]
 use std::time::Duration;
 
+/// Default total HTTP timeout for REST comment resolution, in seconds.
 #[cfg(feature = "unstable-rest-resolve")]
 const DEFAULT_HTTP_TIMEOUT_SECS: u64 = 10;
+/// Default connection timeout for REST comment resolution, in seconds.
 #[cfg(feature = "unstable-rest-resolve")]
 const DEFAULT_CONNECT_TIMEOUT_SECS: u64 = 5;
 
+/// Context shared by the pull-request output and fetching stages.
 struct PrContext {
+    /// Repository containing the pull request.
     repo: RepoInfo,
+    /// Pull request number.
     number: u64,
+    /// Optional discussion comment used to narrow the output.
     comment_id: Option<u64>,
+    /// GraphQL client used to fetch pull-request data.
     client: GraphQLClient,
 }
 
@@ -66,6 +73,7 @@ fn build_graphql_client(
     }
 }
 
+/// Convert a printer error into the command error type.
 fn map_printer_error(err: anyhow::Error) -> VkError {
     if let Some(io) = err.downcast_ref::<std::io::Error>() {
         return VkError::Io(Box::new(std::io::Error::new(io.kind(), err)));
@@ -107,6 +115,7 @@ where
     false
 }
 
+/// Warn when authentication or a UTF-8 terminal locale is unavailable.
 fn warn_on_missing_token_and_locale(token: &str) {
     if token.is_empty() {
         warn!("GitHub token not set, using anonymous API access");
@@ -116,6 +125,7 @@ fn warn_on_missing_token_and_locale(token: &str) {
     }
 }
 
+/// Return whether an error chain contains a broken-pipe I/O error.
 fn caused_by_broken_pipe(err: &anyhow::Error) -> bool {
     err.chain().any(|c| {
         c.downcast_ref::<std::io::Error>()
@@ -123,10 +133,12 @@ fn caused_by_broken_pipe(err: &anyhow::Error) -> bool {
     })
 }
 
+/// Return whether an I/O error kind indicates a closed output pipe.
 fn is_broken_pipe_kind(kind: ErrorKind) -> bool {
     kind == ErrorKind::BrokenPipe
 }
 
+/// Print a banner and report whether output stopped because of a broken pipe.
 fn handle_banner<F>(print: F, label: &str) -> bool
 where
     F: FnOnce() -> std::io::Result<()>,
@@ -140,6 +152,7 @@ where
     false
 }
 
+/// Print the latest review decisions, stopping on a broken pipe.
 fn print_reviews_block(skin: &MadSkin, reviews: Vec<PullRequestReview>) -> bool {
     let latest = latest_reviews(reviews);
     let stdout = std::io::stdout();
@@ -153,6 +166,7 @@ fn print_reviews_block(skin: &MadSkin, reviews: Vec<PullRequestReview>) -> bool 
     false
 }
 
+/// Print review threads, stopping on a broken pipe.
 fn print_threads_block(skin: &MadSkin, threads: Vec<ReviewThread>) -> bool {
     for thread in threads {
         if let Err(e) = print_thread(skin, &thread) {
@@ -224,6 +238,7 @@ fn resolve_branch_and_repo(default_repo: Option<&str>) -> Result<BranchContext, 
     })
 }
 
+/// Format a repository as its `owner/name` path.
 fn format_repo(repo: &RepoInfo) -> String {
     format!("{}/{}", repo.owner, repo.name)
 }
@@ -497,6 +512,7 @@ pub async fn run_resolve(
     }
 }
 
+/// Return whether the first configured locale variable is UTF-8.
 fn locale_is_utf8() -> bool {
     for key in ["LC_ALL", "LC_CTYPE", "LANG"] {
         if let Ok(value) = environment::var(key) {

--- a/src/config_loader.rs
+++ b/src/config_loader.rs
@@ -42,6 +42,7 @@ fn validate_explicit_config_path() -> ortho_config::OrthoResult<()> {
     validate_explicit_config_path_value(std::env::var_os(EXPLICIT_CONFIG_PATH_ENV).as_deref())
 }
 
+/// Validate an optional explicit configuration path value.
 fn validate_explicit_config_path_value(raw: Option<&OsStr>) -> ortho_config::OrthoResult<()> {
     let Some(raw) = raw else {
         return Ok(());

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -9,6 +9,7 @@ use crate::ReviewComment;
 /// Width of the line number gutter in diff output
 pub const GUTTER_WIDTH: usize = 5;
 
+/// Recognize the line-range header at the start of a unified diff hunk.
 static HUNK_RE: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(
         r"@@ -(?P<old>\d+)(?:,(?P<old_count>\d+))? \+(?P<new>\d+)(?:,(?P<new_count>\d+))? @@",
@@ -16,6 +17,7 @@ static HUNK_RE: LazyLock<Regex> = LazyLock::new(|| {
     .expect("valid regex")
 });
 
+/// Parse diff lines while tracking their old and new line numbers.
 fn parse_diff_lines<'a, I>(
     lines: I,
     mut old_line: Option<i32>,
@@ -50,6 +52,7 @@ where
     parsed
 }
 
+/// Format a line number for the fixed-width diff gutter.
 fn num_disp(num: i32) -> String {
     let mut s = num.to_string();
     if s.len() > GUTTER_WIDTH {

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -7,8 +7,10 @@ use std::env;
 use std::ffi::{OsStr, OsString};
 use std::sync::{Mutex, MutexGuard, OnceLock};
 
+/// Lazily initialized mutex that serializes process-wide environment access.
 static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
 
+/// Acquire the process-wide environment mutex.
 fn lock() -> MutexGuard<'static, ()> {
     ENV_LOCK
         .get_or_init(|| Mutex::new(()))

--- a/src/graphql_queries.rs
+++ b/src/graphql_queries.rs
@@ -1,5 +1,6 @@
 //! GraphQL query strings used to fetch issues and review threads.
 
+/// Fetch review threads and their comments for a pull request.
 pub const THREADS_QUERY: &str = r"
     query($owner: String!, $name: String!, $number: Int!, $cursor: String) {
       repository(owner: $owner, name: $name) {
@@ -29,6 +30,7 @@ pub const THREADS_QUERY: &str = r"
     }
 ";
 
+/// Fetch comments belonging to one review thread.
 pub const COMMENT_QUERY: &str = r"
     query($id: ID!, $cursor: String) {
       node(id: $id) {
@@ -50,6 +52,7 @@ pub const COMMENT_QUERY: &str = r"
     }
 ";
 
+/// Fetch the title and body of one issue.
 pub const ISSUE_QUERY: &str = r"
     query($owner: String!, $name: String!, $number: Int!) {
       repository(owner: $owner, name: $name) {

--- a/src/html.rs
+++ b/src/html.rs
@@ -6,22 +6,12 @@ use html5ever::tendril::TendrilSink as _;
 use markup5ever_rcdom::{Handle, NodeData, RcDom};
 use std::borrow::Cow;
 use std::default::Default;
+/// Carriage-return character normalized from input text.
 const CARRIAGE_RETURN: char = '\r';
+/// Line-feed character used as the normalized line ending.
 const LINE_FEED: char = '\n';
 
-/// Collapse root `<details>` blocks in the given text.
-///
-/// Each root-level `<details>` tag is replaced by the contents of its
-/// direct `<summary>` child prefixed with a triangle marker. Nested
-/// `<details>` blocks are discarded.
-///
-/// # Examples
-///
-/// ```
-/// use vk::html::collapse_details;
-/// let input = "<details><summary>hi</summary><p>hidden</p></details>";
-/// assert_eq!(collapse_details(input), "\u{25B6} hi\n");
-/// ```
+/// Normalize carriage returns to line feeds while preserving other text.
 fn normalize_line_endings(input: &str) -> Cow<'_, str> {
     if !input.contains(CARRIAGE_RETURN) {
         return Cow::Borrowed(input);
@@ -42,6 +32,19 @@ fn normalize_line_endings(input: &str) -> Cow<'_, str> {
     Cow::Owned(owned)
 }
 
+/// Collapse root `<details>` blocks in the given text.
+///
+/// Each root-level `<details>` tag is replaced by the contents of its direct
+/// `<summary>` child prefixed with a triangle marker. Nested `<details>` blocks
+/// are discarded.
+///
+/// # Examples
+///
+/// ```
+/// use vk::html::collapse_details;
+/// let input = "<details><summary>hi</summary><p>hidden</p></details>";
+/// assert_eq!(collapse_details(input), "\u{25B6} hi\n");
+/// ```
 #[must_use]
 pub fn collapse_details(input: &str) -> String {
     let normalised = normalize_line_endings(input);
@@ -53,6 +56,7 @@ pub fn collapse_details(input: &str) -> String {
     out
 }
 
+/// Walk a node tree, preserving visible text and replacing root details.
 fn collapse_node(node: &Handle, out: &mut String, in_details: bool) {
     match &node.data {
         NodeData::Element { name, .. }
@@ -75,10 +79,12 @@ fn collapse_node(node: &Handle, out: &mut String, in_details: bool) {
     }
 }
 
+/// Return whether this details node is a collapsible root with a summary.
 fn should_collapse_details(node: &Handle, in_details: bool) -> bool {
     !in_details && find_summary_text(node).is_some()
 }
 
+/// Append a compact marker and the direct summary text for a details node.
 fn write_collapsed_summary(node: &Handle, out: &mut String) {
     if let Some(summary) = find_summary_text(node) {
         out.push('\u{25B6}');
@@ -88,6 +94,7 @@ fn write_collapsed_summary(node: &Handle, out: &mut String) {
     }
 }
 
+/// Find and collect the text from a node's direct summary child.
 fn find_summary_text(node: &Handle) -> Option<String> {
     node.children
         .borrow()
@@ -100,6 +107,7 @@ fn find_summary_text(node: &Handle) -> Option<String> {
         })
 }
 
+/// Collect descendant text in document order without rendering markup.
 fn collect_text(node: &Handle) -> String {
     let mut text = String::new();
     let mut stack = vec![node.clone()];

--- a/src/html.rs
+++ b/src/html.rs
@@ -110,14 +110,10 @@ fn find_summary_text(node: &Handle) -> Option<String> {
 /// Collect descendant text in document order without rendering markup.
 fn collect_text(node: &Handle) -> String {
     let mut text = String::new();
-    let mut stack = vec![node.clone()];
-    while let Some(current) = stack.pop() {
-        let children = current.children.borrow();
-        for child in children.iter().rev() {
-            match &child.data {
-                NodeData::Text { contents } => text.push_str(&contents.borrow()),
-                _ => stack.push(child.clone()),
-            }
+    for child in node.children.borrow().iter() {
+        match &child.data {
+            NodeData::Text { contents } => text.push_str(&contents.borrow()),
+            _ => text.push_str(&collect_text(child)),
         }
     }
     text
@@ -126,7 +122,35 @@ fn collect_text(node: &Handle) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use proptest::prelude::*;
     use std::borrow::Cow;
+
+    proptest! {
+        #[test]
+        fn collapse_preserves_inline_summary_text_order(
+            prefix in "[a-z]{1,20}",
+            before_nested in "[a-z]{1,20}",
+            nested in "[a-z]{1,20}",
+            after_nested in "[a-z]{1,20}",
+            suffix in "[a-z]{1,20}",
+        ) {
+            let input = format!(
+                concat!(
+                    "<details><summary>{}<span>{}",
+                    "<em>{}</em>{}</span>{}",
+                    "</summary>hidden</details>"
+                ),
+                prefix,
+                before_nested,
+                nested,
+                after_nested,
+                suffix,
+            );
+            let expected = format!("\u{25B6} {prefix}{before_nested}{nested}{after_nested}{suffix}\n");
+
+            prop_assert_eq!(collapse_details(&input), expected);
+        }
+    }
 
     #[test]
     fn collapse_replaces_root_details() {

--- a/src/issues.rs
+++ b/src/issues.rs
@@ -8,20 +8,28 @@ use crate::{GraphQLClient, VkError};
 use serde::Deserialize;
 use serde_json::{Map, json};
 
+/// GraphQL data returned for an issue lookup.
 #[derive(Deserialize)]
 struct IssueData {
+    /// Repository containing the requested issue.
     repository: IssueRepository,
 }
 
+/// Repository portion of an issue lookup response.
 #[derive(Deserialize)]
 struct IssueRepository {
+    /// Requested issue.
     issue: Issue,
 }
 
 /// Minimal issue representation returned by the GitHub API.
 #[derive(Deserialize)]
+///
+/// The title and body are retained for display by the command layer.
 pub struct Issue {
+    /// Issue title.
     pub title: String,
+    /// Issue body in Markdown.
     pub body: String,
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -158,7 +158,10 @@ pub enum VkError {
         /// Branch for which no pull request exists.
         branch: Box<str>,
     },
-    /// The API returned an unsuccessful response with a textual body.
+    /// An API request or local processing step failed with a textual diagnostic.
+    ///
+    /// This includes unsuccessful API responses and local failures such as
+    /// request serialization errors or pagination exceeding its page limit.
     #[error("bad response: {0}")]
     BadResponse(Box<str>),
     /// The API returned no data for a successful GraphQL operation.

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,6 +53,7 @@ use thiserror::Error;
 pub use auth::resolve_github_token;
 use commands::{run_issue, run_pr, run_resolve};
 
+/// Supported top-level command-line subcommands.
 #[derive(Subcommand, Deserialize, Serialize, Clone, Debug)]
 enum Commands {
     /// Show unresolved pull request comments
@@ -72,6 +73,7 @@ enum Commands {
     Resolve(ResolveArgs),
 }
 
+/// Parsed command-line arguments for the `vk` binary.
 #[derive(Debug, Parser)]
 #[command(
     name = "vk",
@@ -81,12 +83,15 @@ enum Commands {
     arg_required_else_help = true
 )]
 struct Cli {
+    /// Subcommand to execute.
     #[command(subcommand)]
     command: crate::Commands,
+    /// Global options shared by every subcommand.
     #[command(flatten)]
     global: GlobalArgs,
 }
 
+/// Shared ownership wrapper for configuration errors.
 type SharedConfigError = Arc<ortho_config::OrthoError>;
 
 /// Error type for the `vk` binary.
@@ -98,53 +103,91 @@ type SharedConfigError = Arc<ortho_config::OrthoError>;
 #[derive(Error, Debug)]
 #[non_exhaustive]
 pub enum VkError {
+    /// The repository could not be determined from the available references.
     #[error("unable to determine repository")]
     RepoNotFound,
+    /// A GitHub request failed before a response could be handled.
     #[error("request failed: {0}")]
     Request(#[from] Box<reqwest::Error>),
+    /// A GitHub request failed while running the named operation.
     #[error("request failed when running {context}: {source}")]
     RequestContext {
+        /// Operation being performed when the request failed.
         context: Box<str>,
+        /// Underlying request error.
         #[source]
         source: Box<dyn std::error::Error + Send + Sync>,
     },
+    /// A supplied repository or pull-request reference is invalid.
     #[error("invalid reference")]
     InvalidRef,
+    /// The repository is in detached HEAD state and has no branch to inspect.
     #[error("cannot auto-detect PR: repository is in detached HEAD state")]
     DetachedHead,
+    /// No GitHub token was supplied for an operation that requires one.
     #[error("GitHub token not set")]
     MissingAuth,
+    /// A pull-request number could not be parsed or is outside the valid range.
     #[error("pull request number out of range")]
     InvalidNumber,
+    /// A URL contained an unexpected resource segment.
     #[error("expected URL path segment in {expected:?}, found '{found}'")]
     WrongResourceType {
+        /// Resource segments accepted at this location.
         expected: &'static [&'static str],
+        /// Resource segment found in the supplied URL.
         found: Box<str>,
     },
+    /// A review thread did not contain the expected comment path.
     #[error("missing comment path at index {index} in thread {thread_id}")]
-    EmptyCommentPath { thread_id: Box<str>, index: usize },
+    EmptyCommentPath {
+        /// Review-thread identifier containing the missing path.
+        thread_id: Box<str>,
+        /// Position at which the path segment was expected.
+        index: usize,
+    },
+    /// A requested review comment was not found.
     #[error("comment {comment_id} not found")]
-    CommentNotFound { comment_id: u64 },
+    CommentNotFound {
+        /// Identifier of the missing comment.
+        comment_id: u64,
+    },
+    /// No pull request was found for the supplied branch.
     #[error("no pull request found for branch '{branch}'")]
-    NoPrForBranch { branch: Box<str> },
+    NoPrForBranch {
+        /// Branch for which no pull request exists.
+        branch: Box<str>,
+    },
+    /// The API returned an unsuccessful response with a textual body.
     #[error("bad response: {0}")]
     BadResponse(Box<str>),
+    /// The API returned no data for a successful GraphQL operation.
     #[error("empty GraphQL response (status {status}) for {operation}: {snippet}")]
     EmptyResponse {
+        /// HTTP status returned by the API.
         status: u16,
+        /// GraphQL operation that produced the response.
         operation: Box<str>,
+        /// Bounded response excerpt retained for diagnostics.
         snippet: Box<str>,
     },
+    /// The API response could not be deserialized.
     #[error("malformed response (status {status}): {message} | snippet:{snippet}")]
     BadResponseSerde {
+        /// HTTP status returned by the API.
         status: u16,
+        /// Deserialization error message.
         message: Box<str>,
+        /// Bounded response excerpt retained for diagnostics.
         snippet: Box<str>,
     },
+    /// The API returned one or more GraphQL errors.
     #[error("API errors: {0}")]
     ApiErrors(Box<str>),
+    /// An I/O operation failed.
     #[error("io error: {0}")]
     Io(#[from] Box<std::io::Error>),
+    /// Configuration loading or validation failed.
     #[error("configuration error: {0}")]
     Config(#[from] SharedConfigError),
 }
@@ -169,6 +212,7 @@ impl From<ortho_config::OrthoError> for VkError {
     }
 }
 
+/// Pattern that recognizes UTF-8 locale identifiers.
 pub(crate) static UTF8_RE: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"(?i)\bUTF-?8\b").expect("valid regex"));
 

--- a/src/printer/mod.rs
+++ b/src/printer/mod.rs
@@ -11,6 +11,7 @@ use crate::reviews::PullRequestReview;
 use crate::{ReviewComment, ReviewThread};
 use vk::icons::{ICON_COMMENT, ICON_FILE, ICON_PERMALINK, ICON_REVIEW};
 
+/// Write an author banner with its icon and suffix.
 fn write_author_line<W: std::io::Write>(
     out: &mut W,
     icon: &str,
@@ -106,6 +107,7 @@ fn collapse_excessive_newlines(input: String) -> String {
     buf
 }
 
+/// Render a [`Formattable`] item, including its author banner and body.
 fn write_formattable<W: std::io::Write, T: Formattable>(
     mut out: W,
     skin: &MadSkin,

--- a/src/ref_parser/mod.rs
+++ b/src/ref_parser/mod.rs
@@ -16,9 +16,12 @@ use parse::{GITHUB_RE, ResourceType, parse_reference, strip_git_suffix};
 /// Fragment prefix for discussion comment IDs in GitHub URLs.
 const DISCUSSION_FRAGMENT: &str = "#discussion_r";
 
+/// A parsed GitHub repository owner and name.
 #[derive(Debug, Clone)]
 pub struct RepoInfo {
+    /// Repository owner or organization.
     pub owner: String,
+    /// Repository name.
     pub name: String,
 }
 

--- a/src/ref_parser/parse.rs
+++ b/src/ref_parser/parse.rs
@@ -11,9 +11,11 @@ use url::Url;
 use super::{DefaultRepo, RepoInfo, parse_repo_str};
 use crate::VkError;
 
+/// Match the owner and repository components of a GitHub URL or remote.
 pub(super) static GITHUB_RE: LazyLock<Result<Regex, regex::Error>> =
     LazyLock::new(|| Regex::new(r"github\.com[/:](?P<owner>[^/]+)/(?P<repo>[^/]+)"));
 
+/// Remove the optional `.git` suffix from a repository name.
 pub(super) fn strip_git_suffix(name: &str) -> &str {
     name.strip_suffix(".git").unwrap_or(name)
 }
@@ -23,13 +25,17 @@ fn format_repo(repo: &RepoInfo) -> String {
     format!("{}/{}", repo.owner, repo.name)
 }
 
+/// GitHub resource kind accepted by a reference parser.
 #[derive(Clone, Copy, PartialEq)]
 pub(super) enum ResourceType {
+    /// An issue reference.
     Issues,
+    /// A pull-request reference.
     PullRequest,
 }
 
 impl ResourceType {
+    /// Return URL path segments valid for this resource kind.
     pub(super) fn allowed_segments(self) -> &'static [&'static str] {
         match self {
             Self::Issues => &["issues", "issue"],
@@ -38,6 +44,7 @@ impl ResourceType {
     }
 }
 
+/// Parse a full GitHub URL for the requested resource kind.
 pub(super) fn parse_github_url(
     input: &str,
     resource: ResourceType,
@@ -68,6 +75,7 @@ pub(super) fn parse_github_url(
     }
 }
 
+/// Parse a full URL or bare number into a repository and resource number.
 pub(super) fn parse_reference(
     input: &str,
     default_repo: DefaultRepo,

--- a/src/resolve/graphql.rs
+++ b/src/resolve/graphql.rs
@@ -46,11 +46,11 @@ pub(crate) struct ReviewCommentsQuery<'a> {
 #[allow(clippy::ref_option, reason = "automock generates &Option")]
 /// Fetches pages of review comments for a pull request.
 pub(crate) trait ReviewCommentsFetcher {
-    #[allow(
+    /// Fetch one page of review comments.
+    #[expect(
         clippy::elidable_lifetime_names,
         reason = "automock requires explicit lifetime for query struct"
     )]
-    /// Fetch one page of review comments.
     async fn fetch_review_comments<'a>(
         &self,
         query: ReviewCommentsQuery<'a>,
@@ -58,7 +58,7 @@ pub(crate) trait ReviewCommentsFetcher {
 }
 
 impl ReviewCommentsFetcher for GraphQLClient {
-    #[allow(
+    #[expect(
         clippy::elidable_lifetime_names,
         reason = "automock requires explicit lifetime for query struct"
     )]

--- a/src/resolve/graphql.rs
+++ b/src/resolve/graphql.rs
@@ -5,12 +5,14 @@ use crate::{VkError, api::GraphQLClient};
 use serde::Deserialize;
 use serde_json::json;
 
+/// GraphQL mutation used to mark a review thread as resolved.
 const RESOLVE_THREAD_MUTATION: &str = r"
     mutation($id: ID!) {
       resolveReviewThread(input: {threadId: $id}) { clientMutationId }
     }
 ";
 
+/// GraphQL query used to fetch one page of review comments.
 const REVIEW_COMMENTS_PAGE: &str = r"
     query($owner: String!, $name: String!, $number: Int!, $after: String) {
       repository(owner: $owner, name: $name) {
@@ -28,20 +30,27 @@ const REVIEW_COMMENTS_PAGE: &str = r"
 use mockall::automock;
 
 #[derive(Debug)]
+/// Variables for a paginated review-comment query.
 pub(crate) struct ReviewCommentsQuery<'a> {
+    /// Repository owner login.
     pub owner: &'a str,
+    /// Repository name.
     pub name: &'a str,
+    /// Pull-request number.
     pub number: u64,
+    /// Cursor returned by the preceding page, if any.
     pub after: Option<String>,
 }
 
 #[cfg_attr(test, automock)]
 #[allow(clippy::ref_option, reason = "automock generates &Option")]
+/// Fetches pages of review comments for a pull request.
 pub(crate) trait ReviewCommentsFetcher {
     #[allow(
         clippy::elidable_lifetime_names,
         reason = "automock requires explicit lifetime for query struct"
     )]
+    /// Fetch one page of review comments.
     async fn fetch_review_comments<'a>(
         &self,
         query: ReviewCommentsQuery<'a>,
@@ -71,60 +80,82 @@ impl ReviewCommentsFetcher for GraphQLClient {
 }
 
 #[derive(Clone, Deserialize)]
+/// GraphQL response containing one page of review comments.
 pub(crate) struct ReviewCommentsPage {
+    /// Repository data, when the repository exists.
     repository: Option<Repository>,
 }
 
 #[derive(Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
+/// Repository portion of a review-comment response.
 pub(crate) struct Repository {
+    /// Pull request data, when the pull request exists.
     pull_request: Option<PullRequest>,
 }
 
 #[derive(Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
+/// Pull-request portion of a review-comment response.
 pub(crate) struct PullRequest {
+    /// Review comments connection, when available.
     review_comments: Option<ReviewComments>,
 }
 
 #[derive(Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
+/// Review-comment connection and pagination information.
 pub(crate) struct ReviewComments {
+    /// Pagination metadata.
     page_info: PageInfo,
+    /// Comments in this page.
     nodes: Vec<CommentNode>,
 }
 
 #[derive(Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
+/// Cursor metadata for a review-comment page.
 pub(crate) struct PageInfo {
+    /// Cursor for the next page, when present.
     end_cursor: Option<String>,
+    /// Whether another page is available.
     has_next_page: bool,
 }
 
 #[derive(Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
+/// Review-comment node carrying its database and thread identifiers.
 pub(crate) struct CommentNode {
+    /// GitHub database identifier for the comment.
     database_id: u64,
+    /// Thread associated with the comment.
     pull_request_review_thread: ReviewThread,
 }
 
 #[derive(Clone, Deserialize)]
+/// GraphQL representation of a review thread.
 pub(crate) struct ReviewThread {
+    /// Global GraphQL identifier for the thread.
     id: String,
 }
 
 #[derive(Clone, Deserialize)]
+/// Response returned by the resolve-thread mutation.
 pub(crate) struct ResolveThreadResponse {
     #[serde(rename = "resolveReviewThread")]
+    /// Mutation payload, when GitHub returns one.
     _resolve_review_thread: Option<ResolveThreadInner>,
 }
 
 #[derive(Clone, Deserialize)]
+/// Payload returned by the resolve-thread mutation.
 pub(crate) struct ResolveThreadInner {
     #[serde(rename = "clientMutationId")]
+    /// Client mutation identifier returned by GitHub.
     _client_mutation_id: Option<String>,
 }
 
+/// Find the GraphQL thread identifier for a review comment.
 pub(crate) async fn get_thread_id(
     gql: &impl ReviewCommentsFetcher,
     reference: CommentRef<'_>,
@@ -172,6 +203,7 @@ pub(crate) async fn get_thread_id(
     })
 }
 
+/// Mark a GraphQL review thread as resolved.
 pub(crate) async fn resolve_thread(gql: &GraphQLClient, thread_id: &str) -> Result<(), VkError> {
     let _: ResolveThreadResponse = gql
         .run_query(RESOLVE_THREAD_MUTATION, json!({ "id": thread_id }))

--- a/src/resolve/mod.rs
+++ b/src/resolve/mod.rs
@@ -21,8 +21,11 @@ mod rest_metrics;
 /// Comment location within a pull request review thread.
 #[derive(Copy, Clone, Debug)]
 pub struct CommentRef<'a> {
+    /// Repository containing the comment.
     pub repo: &'a RepoInfo,
+    /// Pull-request number containing the comment.
     pub pull_number: u64,
+    /// Database identifier of the comment.
     pub comment_id: u64,
 }
 

--- a/src/resolve/mod.rs
+++ b/src/resolve/mod.rs
@@ -13,6 +13,10 @@ use std::time::Duration;
 mod graphql;
 #[cfg(feature = "unstable-rest-resolve")]
 mod rest;
+#[cfg(feature = "unstable-rest-resolve")]
+mod rest_invariants;
+#[cfg(feature = "unstable-rest-resolve")]
+mod rest_metrics;
 
 /// Comment location within a pull request review thread.
 #[derive(Copy, Clone, Debug)]

--- a/src/resolve/rest.rs
+++ b/src/resolve/rest.rs
@@ -26,7 +26,9 @@ use vk::environment;
 /// Wraps an [`Octocrab`] instance built from the resolved base URI and the
 /// caller's authentication token.
 pub(crate) struct RestClient {
+    /// Configured Octocrab transport.
     client: Octocrab,
+    /// Total deadline applied to each reply request.
     timeout: Duration,
     #[cfg(test)]
     request_count: AtomicUsize,

--- a/src/resolve/rest.rs
+++ b/src/resolve/rest.rs
@@ -12,7 +12,10 @@ use super::{
     rest_metrics::{ReplyAttemptOutcome, record_reply_attempt},
 };
 use crate::{VkError, boxed::BoxedStr};
-use http::header::{ACCEPT, HeaderName};
+use http::{
+    StatusCode,
+    header::{ACCEPT, HeaderName},
+};
 use octocrab::Octocrab;
 use serde_json::json;
 #[cfg(test)]
@@ -145,7 +148,16 @@ pub(crate) async fn post_reply(
             });
         }
     };
-    let status = response.status();
+    handle_reply_response(response.status(), started_at, reference, route.as_str())
+}
+
+/// Record and map a completed reply response according to its HTTP status.
+fn handle_reply_response(
+    status: StatusCode,
+    started_at: Instant,
+    reference: CommentRef<'_>,
+    route: &str,
+) -> Result<(), VkError> {
     match classify_reply_status(status) {
         ReplyStatus::NotFound => {
             record_reply_attempt(

--- a/src/resolve/rest.rs
+++ b/src/resolve/rest.rs
@@ -154,11 +154,13 @@ pub(crate) async fn post_reply(
                 },
             );
             warn!(
-                "reply target not found (route={route}): {}/{} comment {} in PR #{}",
-                reference.repo.owner,
-                reference.repo.name,
-                reference.comment_id,
-                reference.pull_number
+                route = %route,
+                owner = reference.repo.owner,
+                repo = reference.repo.name,
+                pull_number = reference.pull_number,
+                comment_id = reference.comment_id,
+                state = "not_found",
+                "reply target not found"
             );
             // Treat missing original comment as non-fatal: continue to resolve.
             Ok(())

--- a/src/resolve/rest.rs
+++ b/src/resolve/rest.rs
@@ -1,9 +1,15 @@
 //! REST helpers for replying to review comments.
+//!
+//! The reply path is served by [`octocrab`], whose builder supplies the
+//! authentication and base-URI plumbing previously hand-rolled on `reqwest`.
+//! Only the raw `_post` route is used, so status-code handling stays under
+//! `vk`'s control: a 404 is non-fatal (warn and continue), and any other
+//! non-2xx status is fatal.
 
 use super::CommentRef;
 use crate::{VkError, boxed::BoxedStr};
-use reqwest::header::{ACCEPT, AUTHORIZATION, HeaderMap, HeaderName, HeaderValue, USER_AGENT};
-use reqwest::{StatusCode, Url};
+use http::header::{ACCEPT, HeaderName};
+use octocrab::Octocrab;
 use serde_json::json;
 #[cfg(test)]
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -11,71 +17,32 @@ use std::time::Duration;
 use tracing::warn;
 use vk::environment;
 
-/// Build an authenticated client with GitHub headers.
-///
-/// Returns [`VkError::RequestContext`] when the client cannot be built.
-///
-/// # Examples
-///
-/// ```ignore
-/// # use crate::resolve::rest::github_client;
-/// use std::time::Duration;
-/// let client = github_client("token", Duration::from_secs(10), Duration::from_secs(5))?;
-/// # Ok::<(), VkError>(())
-/// ```
-pub(crate) fn github_client(
-    token: &str,
-    timeout: Duration,
-    connect_timeout: Duration,
-) -> Result<reqwest::Client, VkError> {
-    let mut headers = HeaderMap::new();
-    let parse_value = |value: &str, context: &str| -> Result<HeaderValue, VkError> {
-        HeaderValue::from_str(value).map_err(|e| VkError::RequestContext {
-            context: context.boxed(),
-            source: e.into(),
-        })
-    };
-    headers.insert(USER_AGENT, parse_value("vk", "build user agent header")?);
-    let auth_header = format!("Bearer {token}");
-    headers.insert(
-        AUTHORIZATION,
-        parse_value(&auth_header, "build authorization header")?,
-    );
-    headers.insert(
-        ACCEPT,
-        parse_value("application/vnd.github+json", "build accept header")?,
-    );
-    let api_version_header =
-        HeaderName::from_bytes(b"x-github-api-version").map_err(|e| VkError::RequestContext {
-            context: "build x-github-api-version header name".boxed(),
-            source: e.into(),
-        })?;
-    headers.insert(
-        api_version_header,
-        parse_value("2022-11-28", "build x-github-api-version header value")?,
-    );
-    reqwest::Client::builder()
-        .default_headers(headers)
-        .timeout(timeout)
-        .connect_timeout(connect_timeout)
-        .build()
-        .map_err(|e| VkError::RequestContext {
-            context: "build client".into(),
-            source: Box::new(e),
-        })
-}
-
 /// GitHub REST client configuration.
+///
+/// Wraps an [`Octocrab`] instance built from the resolved base URI and the
+/// caller's authentication token.
 pub(crate) struct RestClient {
-    api: Url,
-    client: reqwest::Client,
+    client: Octocrab,
     #[cfg(test)]
     request_count: AtomicUsize,
 }
 
 impl RestClient {
     /// Create a REST client targeting the provided `api` base URL.
-    /// Falls back to `GITHUB_API_URL` or the public GitHub endpoint when `api` is `None`.
+    ///
+    /// The base URI is resolved in order: the explicit `api` parameter, then the
+    /// `GITHUB_API_URL` environment variable, then the public GitHub endpoint.
+    /// Plain `http://` loopback addresses are accepted so tests can redirect the
+    /// client at a local stub server.
+    ///
+    /// `personal_token` is only set when `token` is non-empty, preserving
+    /// anonymous access. The `connect_timeout` maps directly onto octocrab's
+    /// connect timeout; octocrab exposes no single total-request timeout, so the
+    /// former reqwest total `timeout` is applied as the read and write timeouts,
+    /// the closest analogue octocrab offers.
+    ///
+    /// Returns [`VkError::RequestContext`] when the base URI cannot be parsed or
+    /// the client cannot be built.
     pub(crate) fn new(
         token: &str,
         api: Option<&str>,
@@ -89,18 +56,35 @@ impl RestClient {
         while base.ends_with('/') {
             base.pop();
         }
-        let mut api = Url::parse(&base).map_err(|e| VkError::RequestContext {
-            context: format!("parse API base URL from {base}").boxed(),
-            source: Box::new(e),
-        })?;
-        let normalised_path = match api.path().trim_end_matches('/') {
-            "" => "/".to_owned(),
-            path => format!("{path}/"),
-        };
-        api.set_path(&normalised_path);
-        let client = github_client(token, timeout, connect_timeout)?;
+        let mut builder =
+            Octocrab::builder()
+                .base_uri(base.as_str())
+                .map_err(|e| VkError::RequestContext {
+                    context: format!("parse API base URL from {base}").boxed(),
+                    source: Box::new(e),
+                })?;
+        if !token.is_empty() {
+            builder = builder.personal_token(token.to_owned());
+        }
+        // Restore the behaviourally meaningful headers the reqwest client
+        // sent: the pinned REST API version and the GitHub JSON media type.
+        // octocrab's default `User-Agent: octocrab` is left alone (decision
+        // recorded in the ExecPlan).
+        let client = builder
+            .add_header(
+                HeaderName::from_static("x-github-api-version"),
+                "2022-11-28".to_owned(),
+            )
+            .add_header(ACCEPT, "application/vnd.github+json".to_owned())
+            .set_connect_timeout(Some(connect_timeout))
+            .set_read_timeout(Some(timeout))
+            .set_write_timeout(Some(timeout))
+            .build()
+            .map_err(|e| VkError::RequestContext {
+                context: "build client".boxed(),
+                source: Box::new(e),
+            })?;
         Ok(Self {
-            api,
             client,
             #[cfg(test)]
             request_count: AtomicUsize::new(0),
@@ -109,6 +93,11 @@ impl RestClient {
 }
 
 /// Post a reply to a review comment using the REST API.
+///
+/// A 404 response is treated as non-fatal: the original comment is assumed to
+/// have gone away, so the caller continues to resolve the thread. Any other
+/// non-2xx status is mapped to [`VkError::RequestContext`], whose message names
+/// the reply route and the failing status.
 pub(crate) async fn post_reply(
     rest: &RestClient,
     reference: CommentRef<'_>,
@@ -116,49 +105,42 @@ pub(crate) async fn post_reply(
 ) -> Result<(), VkError> {
     let body = body.trim();
     if body.is_empty() {
-        // Avoid GitHub 422s by skipping empty replies
+        // Avoid GitHub 422s by skipping empty replies.
         return Ok(());
     }
 
-    let path = format!(
-        "repos/{}/{}/pulls/{}/comments/{}/replies",
+    let route = format!(
+        "/repos/{}/{}/pulls/{}/comments/{}/replies",
         reference.repo.owner, reference.repo.name, reference.pull_number, reference.comment_id
     );
-    let url = rest.api.join(&path).map_err(|e| VkError::RequestContext {
-        context: format!(
-            "build reply URL for comment {} in repo {}/{}",
-            reference.comment_id, reference.repo.owner, reference.repo.name
-        )
-        .boxed(),
-        source: Box::new(e),
-    })?;
     #[cfg(test)]
     rest.request_count.fetch_add(1, Ordering::SeqCst);
-    let res = rest
+    let response = rest
         .client
-        .post(url)
-        .json(&json!({ "body": body }))
-        .send()
+        ._post(route.as_str(), Some(&json!({ "body": body })))
         .await
         .map_err(|e| VkError::RequestContext {
-            context: "post reply".into(),
+            context: "post reply".boxed(),
             source: Box::new(e),
         })?;
-    if res.status() == StatusCode::NOT_FOUND {
+    let status = response.status();
+    if status.as_u16() == 404 {
         warn!(
-            "reply target not found (url={}): {}/{} comment {} in PR #{}",
-            res.url(),
-            reference.repo.owner,
-            reference.repo.name,
-            reference.comment_id,
-            reference.pull_number
+            "reply target not found (route={route}): {}/{} comment {} in PR #{}",
+            reference.repo.owner, reference.repo.name, reference.comment_id, reference.pull_number
         );
         // Treat missing original comment as non-fatal: continue to resolve.
         return Ok(());
     }
-    res.error_for_status()
-        .map(|_| ())
-        .map_err(|e| VkError::Request(Box::new(e)))
+    if status.is_success() {
+        return Ok(());
+    }
+    Err(VkError::RequestContext {
+        context: format!("post reply to {route}").boxed(),
+        source: Box::new(std::io::Error::other(format!(
+            "unexpected HTTP status {status}"
+        ))),
+    })
 }
 
 #[cfg(test)]

--- a/src/resolve/rest.rs
+++ b/src/resolve/rest.rs
@@ -6,14 +6,18 @@
 //! `vk`'s control: a 404 is non-fatal (warn and continue), and any other
 //! non-2xx status is fatal.
 
-use super::CommentRef;
+use super::{
+    CommentRef,
+    rest_invariants::{ReplyStatus, classify_reply_status, normalize_api_base_url},
+    rest_metrics::{ReplyAttemptOutcome, record_reply_attempt},
+};
 use crate::{VkError, boxed::BoxedStr};
 use http::header::{ACCEPT, HeaderName};
 use octocrab::Octocrab;
 use serde_json::json;
 #[cfg(test)]
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use tracing::warn;
 use vk::environment;
 
@@ -50,13 +54,11 @@ impl RestClient {
         timeout: Duration,
         connect_timeout: Duration,
     ) -> Result<Self, VkError> {
-        let mut base = api
-            .map(str::to_owned)
-            .or_else(|| environment::var("GITHUB_API_URL").ok())
-            .unwrap_or_else(|| "https://api.github.com".into());
-        while base.ends_with('/') {
-            base.pop();
-        }
+        let base = normalize_api_base_url(
+            api.map(str::to_owned)
+                .or_else(|| environment::var("GITHUB_API_URL").ok())
+                .unwrap_or_else(|| "https://api.github.com".into()),
+        );
         let mut builder =
             Octocrab::builder()
                 .base_uri(base.as_str())
@@ -117,38 +119,76 @@ pub(crate) async fn post_reply(
     );
     #[cfg(test)]
     rest.request_count.fetch_add(1, Ordering::SeqCst);
+    let started_at = Instant::now();
     let response = tokio::time::timeout(
         rest.timeout,
         rest.client
             ._post(route.as_str(), Some(&json!({ "body": body }))),
     )
-    .await
-    .map_err(|e| VkError::RequestContext {
-        context: format!("post reply to {route}").boxed(),
-        source: Box::new(e),
-    })?
-    .map_err(|e| VkError::RequestContext {
-        context: "post reply".boxed(),
-        source: Box::new(e),
-    })?;
+    .await;
+    let response = match response {
+        Ok(Ok(response)) => response,
+        Ok(Err(error)) => {
+            record_reply_attempt(started_at, ReplyAttemptOutcome::TransportFailure);
+            return Err(VkError::RequestContext {
+                context: "post reply".boxed(),
+                source: Box::new(error),
+            });
+        }
+        Err(error) => {
+            record_reply_attempt(started_at, ReplyAttemptOutcome::Timeout);
+            return Err(VkError::RequestContext {
+                context: format!("post reply to {route}").boxed(),
+                source: Box::new(error),
+            });
+        }
+    };
     let status = response.status();
-    if status.as_u16() == 404 {
-        warn!(
-            "reply target not found (route={route}): {}/{} comment {} in PR #{}",
-            reference.repo.owner, reference.repo.name, reference.comment_id, reference.pull_number
-        );
-        // Treat missing original comment as non-fatal: continue to resolve.
-        return Ok(());
+    match classify_reply_status(status) {
+        ReplyStatus::NotFound => {
+            record_reply_attempt(
+                started_at,
+                ReplyAttemptOutcome::Response {
+                    status,
+                    result: ReplyStatus::NotFound,
+                },
+            );
+            warn!(
+                "reply target not found (route={route}): {}/{} comment {} in PR #{}",
+                reference.repo.owner,
+                reference.repo.name,
+                reference.comment_id,
+                reference.pull_number
+            );
+            // Treat missing original comment as non-fatal: continue to resolve.
+            Ok(())
+        }
+        ReplyStatus::Success => {
+            record_reply_attempt(
+                started_at,
+                ReplyAttemptOutcome::Response {
+                    status,
+                    result: ReplyStatus::Success,
+                },
+            );
+            Ok(())
+        }
+        ReplyStatus::Failure => {
+            record_reply_attempt(
+                started_at,
+                ReplyAttemptOutcome::Response {
+                    status,
+                    result: ReplyStatus::Failure,
+                },
+            );
+            Err(VkError::RequestContext {
+                context: format!("post reply to {route}").boxed(),
+                source: Box::new(std::io::Error::other(format!(
+                    "unexpected HTTP status {status}"
+                ))),
+            })
+        }
     }
-    if status.is_success() {
-        return Ok(());
-    }
-    Err(VkError::RequestContext {
-        context: format!("post reply to {route}").boxed(),
-        source: Box::new(std::io::Error::other(format!(
-            "unexpected HTTP status {status}"
-        ))),
-    })
 }
 
 #[cfg(test)]

--- a/src/resolve/rest.rs
+++ b/src/resolve/rest.rs
@@ -23,6 +23,7 @@ use vk::environment;
 /// caller's authentication token.
 pub(crate) struct RestClient {
     client: Octocrab,
+    timeout: Duration,
     #[cfg(test)]
     request_count: AtomicUsize,
 }
@@ -37,9 +38,9 @@ impl RestClient {
     ///
     /// `personal_token` is only set when `token` is non-empty, preserving
     /// anonymous access. The `connect_timeout` maps directly onto octocrab's
-    /// connect timeout; octocrab exposes no single total-request timeout, so the
-    /// former reqwest total `timeout` is applied as the read and write timeouts,
-    /// the closest analogue octocrab offers.
+    /// connect timeout. The read and write timeouts are configured on octocrab,
+    /// and the original total-request deadline is retained for the complete
+    /// reply operation.
     ///
     /// Returns [`VkError::RequestContext`] when the base URI cannot be parsed or
     /// the client cannot be built.
@@ -86,6 +87,7 @@ impl RestClient {
             })?;
         Ok(Self {
             client,
+            timeout,
             #[cfg(test)]
             request_count: AtomicUsize::new(0),
         })
@@ -115,14 +117,20 @@ pub(crate) async fn post_reply(
     );
     #[cfg(test)]
     rest.request_count.fetch_add(1, Ordering::SeqCst);
-    let response = rest
-        .client
-        ._post(route.as_str(), Some(&json!({ "body": body })))
-        .await
-        .map_err(|e| VkError::RequestContext {
-            context: "post reply".boxed(),
-            source: Box::new(e),
-        })?;
+    let response = tokio::time::timeout(
+        rest.timeout,
+        rest.client
+            ._post(route.as_str(), Some(&json!({ "body": body }))),
+    )
+    .await
+    .map_err(|e| VkError::RequestContext {
+        context: format!("post reply to {route}").boxed(),
+        source: Box::new(e),
+    })?
+    .map_err(|e| VkError::RequestContext {
+        context: "post reply".boxed(),
+        source: Box::new(e),
+    })?;
     let status = response.status();
     if status.as_u16() == 404 {
         warn!(

--- a/src/resolve/rest_invariants.rs
+++ b/src/resolve/rest_invariants.rs
@@ -1,0 +1,98 @@
+//! Pure invariants for the REST review-comment reply boundary.
+//!
+//! The REST transport owns HTTP I/O, while this module owns the two stable
+//! decisions that are useful to test independently: base-URI normalisation and
+//! reply-status handling.
+
+use http::StatusCode;
+
+/// The application outcome assigned to an HTTP response.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub(super) enum ReplyStatus {
+    /// A successful response permits resolution to continue.
+    Success,
+    /// A missing reply target is warned about and permits resolution to continue.
+    NotFound,
+    /// Any other response aborts resolution.
+    Failure,
+}
+
+/// Removes every trailing slash from an API base URI.
+pub(super) fn normalize_api_base_url(mut base: String) -> String {
+    while base.ends_with('/') {
+        base.pop();
+    }
+    base
+}
+
+/// Classifies a reply response according to `vk`'s documented semantics.
+pub(super) fn classify_reply_status(status: StatusCode) -> ReplyStatus {
+    if status == StatusCode::NOT_FOUND {
+        ReplyStatus::NotFound
+    } else if status.is_success() {
+        ReplyStatus::Success
+    } else {
+        ReplyStatus::Failure
+    }
+}
+
+/// Returns the bounded HTTP status-class label for a response.
+pub(super) fn status_class(status: StatusCode) -> &'static str {
+    match status.as_u16() {
+        100..=199 => "1xx",
+        200..=299 => "2xx",
+        300..=399 => "3xx",
+        400..=499 => "4xx",
+        500..=599 => "5xx",
+        _ => "other",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::prelude::*;
+
+    proptest! {
+        #[test]
+        fn normalizes_every_trailing_slash_count(
+            host in "[a-z]{1,20}",
+            path_segments in proptest::collection::vec("[a-z]{1,20}", 0..4),
+            trailing_slashes in 0_usize..65,
+        ) {
+            let mut base = format!("https://{host}");
+            for segment in path_segments {
+                base.push('/');
+                base.push_str(&segment);
+            }
+            let normalized = normalize_api_base_url(format!(
+                "{base}{}",
+                "/".repeat(trailing_slashes),
+            ));
+
+            prop_assert_eq!(normalized.clone(), base);
+            prop_assert_eq!(normalize_api_base_url(normalized.clone()), normalized);
+        }
+
+        #[test]
+        fn classifies_every_valid_http_status(status_code in 100_u16..1000) {
+            let status = StatusCode::from_u16(status_code).expect("generated standard status");
+            let expected_outcome = match status_code {
+                404 => ReplyStatus::NotFound,
+                200..=299 => ReplyStatus::Success,
+                _ => ReplyStatus::Failure,
+            };
+            let expected_class = match status_code {
+                100..=199 => "1xx",
+                200..=299 => "2xx",
+                300..=399 => "3xx",
+                400..=499 => "4xx",
+                500..=599 => "5xx",
+                _ => "other",
+            };
+
+            prop_assert_eq!(classify_reply_status(status), expected_outcome);
+            prop_assert_eq!(status_class(status), expected_class);
+        }
+    }
+}

--- a/src/resolve/rest_invariants.rs
+++ b/src/resolve/rest_invariants.rs
@@ -1,7 +1,7 @@
 //! Pure invariants for the REST review-comment reply boundary.
 //!
 //! The REST transport owns HTTP I/O, while this module owns the two stable
-//! decisions that are useful to test independently: base-URI normalisation and
+//! decisions that are useful to test independently: base-URI normalization and
 //! reply-status handling.
 
 use http::StatusCode;
@@ -50,6 +50,8 @@ pub(super) fn status_class(status: StatusCode) -> &'static str {
 
 #[cfg(test)]
 mod tests {
+    //! Tests for REST reply invariants.
+
     use super::*;
     use proptest::prelude::*;
 

--- a/src/resolve/rest_metrics.rs
+++ b/src/resolve/rest_metrics.rs
@@ -1,0 +1,134 @@
+//! Bounded metrics emitted by the REST review-comment reply boundary.
+//!
+//! This private module records one observation per non-empty reply attempt.
+//! Its labels deliberately exclude repository, pull-request, comment, route,
+//! and error values so an application recorder has a fixed cardinality.
+
+use super::rest_invariants::{ReplyStatus, status_class};
+use http::StatusCode;
+use metrics::{Unit, counter, histogram};
+use std::time::Instant;
+
+const REQUEST_COUNT: &str = "vk.resolve.rest_reply.requests.total";
+const REQUEST_DURATION: &str = "vk.resolve.rest_reply.duration.seconds";
+const TIMEOUT_COUNT: &str = "vk.resolve.rest_reply.timeouts.total";
+
+/// Result of one request attempt, expressed with bounded labels.
+pub(super) enum ReplyAttemptOutcome {
+    /// The REST server returned a response.
+    Response {
+        status: StatusCode,
+        result: ReplyStatus,
+    },
+    /// The total request deadline expired.
+    Timeout,
+    /// The REST transport failed before receiving a response.
+    TransportFailure,
+}
+
+impl ReplyAttemptOutcome {
+    fn labels(self) -> (&'static str, &'static str, &'static str) {
+        match self {
+            Self::Response {
+                status,
+                result: ReplyStatus::Success,
+            } => ("success", status_class(status), "none"),
+            Self::Response {
+                status,
+                result: ReplyStatus::NotFound,
+            } => ("not_found", status_class(status), "none"),
+            Self::Response {
+                status,
+                result: ReplyStatus::Failure,
+            } => ("failure", status_class(status), "http_status"),
+            Self::Timeout => ("failure", "none", "timeout"),
+            Self::TransportFailure => ("failure", "none", "transport"),
+        }
+    }
+}
+
+/// Records one REST reply attempt and its elapsed duration.
+pub(super) fn record_reply_attempt(started_at: Instant, outcome: ReplyAttemptOutcome) {
+    let (outcome, status_class, failure_category) = outcome.labels();
+    counter!(
+        description: "Count REST review-comment reply attempts by bounded outcome.",
+        REQUEST_COUNT,
+        "outcome" => outcome,
+        "status_class" => status_class,
+        "failure_category" => failure_category,
+    )
+    .increment(1);
+    histogram!(
+        description: "Measure elapsed seconds for REST review-comment reply attempts.",
+        unit: Unit::Seconds,
+        REQUEST_DURATION,
+        "outcome" => outcome,
+        "status_class" => status_class,
+        "failure_category" => failure_category,
+    )
+    .record(started_at.elapsed().as_secs_f64());
+    if matches!(failure_category, "timeout") {
+        counter!(
+            description: "Count REST review-comment replies whose total deadline expired.",
+            TIMEOUT_COUNT,
+        )
+        .increment(1);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use metrics::{Key, Label, with_local_recorder};
+    use metrics_util::{
+        MetricKind,
+        debugging::{DebugValue, DebuggingRecorder},
+    };
+
+    #[test]
+    fn records_bounded_response_and_timeout_metrics() {
+        let recorder = DebuggingRecorder::new();
+        let snapshotter = recorder.snapshotter();
+        with_local_recorder(&recorder, || {
+            record_reply_attempt(
+                Instant::now(),
+                ReplyAttemptOutcome::Response {
+                    status: StatusCode::NOT_FOUND,
+                    result: ReplyStatus::NotFound,
+                },
+            );
+            record_reply_attempt(Instant::now(), ReplyAttemptOutcome::Timeout);
+        });
+
+        let snapshot = snapshotter.snapshot().into_vec();
+        let reply_labels = vec![
+            Label::new("outcome", "not_found"),
+            Label::new("status_class", "4xx"),
+            Label::new("failure_category", "none"),
+        ];
+        let timeout_labels = vec![
+            Label::new("outcome", "failure"),
+            Label::new("status_class", "none"),
+            Label::new("failure_category", "timeout"),
+        ];
+        assert!(snapshot.iter().any(|(key, _, _, value)| {
+            *key == metrics_util::CompositeKey::new(
+                MetricKind::Counter,
+                Key::from_parts(REQUEST_COUNT, reply_labels.clone()),
+            ) && *value == DebugValue::Counter(1)
+        }));
+        assert!(snapshot.iter().any(|(key, unit, _, value)| {
+            *key == metrics_util::CompositeKey::new(
+                MetricKind::Histogram,
+                Key::from_parts(REQUEST_DURATION, timeout_labels.clone()),
+            ) && *unit == Some(Unit::Seconds)
+                && matches!(value, DebugValue::Histogram(samples) if samples.len() == 1)
+        }));
+        assert!(snapshot.iter().any(|(key, _, _, value)| {
+            *key == metrics_util::CompositeKey::new(
+                MetricKind::Counter,
+                Key::from_name(TIMEOUT_COUNT),
+            ) && *value == DebugValue::Counter(1)
+        }));
+    }
+}

--- a/src/resolve/rest_metrics.rs
+++ b/src/resolve/rest_metrics.rs
@@ -78,38 +78,139 @@ pub(super) fn record_reply_attempt(started_at: Instant, outcome: ReplyAttemptOut
 
 #[cfg(test)]
 mod tests {
+    //! Tests for REST reply metrics.
+
     use super::*;
+    use crate::{
+        ref_parser::RepoInfo,
+        resolve::{
+            CommentRef,
+            rest::{RestClient, post_reply},
+        },
+    };
+    use bytes::Bytes;
+    use http_body_util::Full;
+    use hyper::{Response, service::service_fn};
+    use hyper_util::{
+        rt::{TokioExecutor, TokioIo},
+        server::conn::auto,
+    };
     use metrics::{Key, Label, with_local_recorder};
     use metrics_util::{
         MetricKind,
         debugging::{DebugValue, DebuggingRecorder},
     };
+    use rstest::rstest;
+    use std::{convert::Infallible, time::Duration};
+    use tokio::{net::TcpListener, runtime::Builder};
 
-    #[test]
-    fn records_bounded_response_and_timeout_metrics() {
+    #[derive(Copy, Clone)]
+    enum ReplyAttempt {
+        Success,
+        NotFound,
+        Failure,
+        Timeout,
+        TransportFailure,
+    }
+
+    impl ReplyAttempt {
+        fn expected_labels(self) -> (&'static str, &'static str, &'static str) {
+            match self {
+                Self::Success => ("success", "2xx", "none"),
+                Self::NotFound => ("not_found", "4xx", "none"),
+                Self::Failure => ("failure", "5xx", "http_status"),
+                Self::Timeout => ("failure", "none", "timeout"),
+                Self::TransportFailure => ("failure", "none", "transport"),
+            }
+        }
+
+        fn should_succeed(self) -> bool {
+            matches!(self, Self::Success | Self::NotFound)
+        }
+
+        fn is_timeout(self) -> bool {
+            matches!(self, Self::Timeout)
+        }
+
+        async fn serve(self, listener: TcpListener) {
+            let (stream, _) = listener.accept().await.expect("accept REST request");
+            match self {
+                Self::Success => serve_response(stream, StatusCode::OK).await,
+                Self::NotFound => serve_response(stream, StatusCode::NOT_FOUND).await,
+                Self::Failure => serve_response(stream, StatusCode::INTERNAL_SERVER_ERROR).await,
+                Self::Timeout => {
+                    tokio::time::sleep(Duration::from_secs(1)).await;
+                    drop(stream);
+                }
+                Self::TransportFailure => drop(stream),
+            }
+        }
+    }
+
+    async fn serve_response(stream: tokio::net::TcpStream, status: StatusCode) {
+        let service = service_fn(move |_| async move {
+            Ok::<_, Infallible>(
+                Response::builder()
+                    .status(status)
+                    .body(Full::new(Bytes::new()))
+                    .expect("build REST response"),
+            )
+        });
+        let _ = auto::Builder::new(TokioExecutor::new())
+            .serve_connection(TokioIo::new(stream), service)
+            .await;
+    }
+
+    #[rstest]
+    #[case::success(ReplyAttempt::Success)]
+    #[case::not_found(ReplyAttempt::NotFound)]
+    #[case::failure(ReplyAttempt::Failure)]
+    #[case::timeout(ReplyAttempt::Timeout)]
+    #[case::transport_failure(ReplyAttempt::TransportFailure)]
+    fn records_bounded_metrics_for_each_reply_outcome(#[case] attempt: ReplyAttempt) {
         let recorder = DebuggingRecorder::new();
         let snapshotter = recorder.snapshotter();
         with_local_recorder(&recorder, || {
-            record_reply_attempt(
-                Instant::now(),
-                ReplyAttemptOutcome::Response {
-                    status: StatusCode::NOT_FOUND,
-                    result: ReplyStatus::NotFound,
-                },
-            );
-            record_reply_attempt(Instant::now(), ReplyAttemptOutcome::Timeout);
+            let runtime = Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("build test runtime");
+            let result = runtime.block_on(async {
+                let listener = TcpListener::bind("127.0.0.1:0")
+                    .await
+                    .expect("bind REST stub");
+                let address = listener.local_addr().expect("get REST stub address");
+                let server = tokio::spawn(attempt.serve(listener));
+                let rest = RestClient::new(
+                    "token",
+                    Some(&format!("http://{address}")),
+                    Duration::from_millis(20),
+                    Duration::from_secs(1),
+                )
+                .expect("build REST client");
+                let repo = RepoInfo {
+                    owner: "octocat".into(),
+                    name: "hello-world".into(),
+                };
+                let reference = CommentRef {
+                    repo: &repo,
+                    pull_number: 1,
+                    comment_id: 42,
+                };
+                let result = post_reply(&rest, reference, "reply").await;
+                server.abort();
+                let _ = server.await;
+                result
+            });
+            assert_eq!(result.is_ok(), attempt.should_succeed());
         });
 
         let snapshot = snapshotter.snapshot().into_vec();
+        let (outcome, status_class, failure_category) = attempt.expected_labels();
         let reply_labels = vec![
-            Label::new("outcome", "not_found"),
-            Label::new("status_class", "4xx"),
-            Label::new("failure_category", "none"),
-        ];
-        let timeout_labels = vec![
-            Label::new("outcome", "failure"),
-            Label::new("status_class", "none"),
-            Label::new("failure_category", "timeout"),
+            Label::new("outcome", outcome),
+            Label::new("status_class", status_class),
+            Label::new("failure_category", failure_category),
         ];
         assert!(snapshot.iter().any(|(key, _, _, value)| {
             *key == metrics_util::CompositeKey::new(
@@ -120,15 +221,16 @@ mod tests {
         assert!(snapshot.iter().any(|(key, unit, _, value)| {
             *key == metrics_util::CompositeKey::new(
                 MetricKind::Histogram,
-                Key::from_parts(REQUEST_DURATION, timeout_labels.clone()),
+                Key::from_parts(REQUEST_DURATION, reply_labels.clone()),
             ) && *unit == Some(Unit::Seconds)
                 && matches!(value, DebugValue::Histogram(samples) if samples.len() == 1)
         }));
-        assert!(snapshot.iter().any(|(key, _, _, value)| {
+        let has_timeout_counter = snapshot.iter().any(|(key, _, _, value)| {
             *key == metrics_util::CompositeKey::new(
                 MetricKind::Counter,
                 Key::from_name(TIMEOUT_COUNT),
             ) && *value == DebugValue::Counter(1)
-        }));
+        });
+        assert_eq!(has_timeout_counter, attempt.is_timeout());
     }
 }

--- a/src/resolve/rest_metrics.rs
+++ b/src/resolve/rest_metrics.rs
@@ -9,15 +9,20 @@ use http::StatusCode;
 use metrics::{Unit, counter, histogram};
 use std::time::Instant;
 
+/// Metric counting REST reply attempts.
 const REQUEST_COUNT: &str = "vk.resolve.rest_reply.requests.total";
+/// Metric recording REST reply duration in seconds.
 const REQUEST_DURATION: &str = "vk.resolve.rest_reply.duration.seconds";
+/// Metric counting REST reply attempts that exceed the total deadline.
 const TIMEOUT_COUNT: &str = "vk.resolve.rest_reply.timeouts.total";
 
 /// Result of one request attempt, expressed with bounded labels.
 pub(super) enum ReplyAttemptOutcome {
     /// The REST server returned a response.
     Response {
+        /// HTTP status returned by the REST server.
         status: StatusCode,
+        /// Classification applied to the HTTP status.
         result: ReplyStatus,
     },
     /// The total request deadline expired.
@@ -27,6 +32,7 @@ pub(super) enum ReplyAttemptOutcome {
 }
 
 impl ReplyAttemptOutcome {
+    /// Return the bounded metric labels for this outcome.
     fn labels(self) -> (&'static str, &'static str, &'static str) {
         match self {
             Self::Response {

--- a/src/review_threads.rs
+++ b/src/review_threads.rs
@@ -18,64 +18,90 @@ use crate::ref_parser::RepoInfo;
 use crate::{GraphQLClient, VkError};
 
 #[derive(Debug, Deserialize, Default)]
+/// Top-level response for the review-thread query.
 struct ThreadData {
+    /// Repository response data.
     repository: Repository,
 }
 
 #[derive(Debug, Deserialize, Default)]
+/// Repository response data for a pull request.
 struct Repository {
     #[serde(rename = "pullRequest")]
+    /// Pull-request response data.
     pull_request: PullRequest,
 }
 
 #[derive(Debug, Deserialize, Default)]
+/// Pull-request response data for review threads.
 struct PullRequest {
     #[serde(rename = "reviewThreads")]
+    /// Review-thread connection returned by GitHub.
     review_threads: ReviewThreadConnection,
 }
 
 #[derive(Debug, Deserialize, Default)]
+/// Wrapper for a nullable GraphQL node.
 struct NodeWrapper<T> {
+    /// Node value, when the requested node exists.
     node: Option<T>,
 }
 
 #[derive(Debug, Deserialize, Default)]
+/// Comment node containing its comment connection.
 struct CommentNode {
+    /// Comments attached to the node.
     comments: CommentConnection,
 }
 
 #[derive(Debug, Deserialize, Default)]
+/// A paginated GraphQL connection.
 pub struct Connection<T> {
+    /// Items returned in this page.
     pub nodes: Vec<T>,
     #[serde(rename = "pageInfo")]
+    /// Pagination metadata for this page.
     pub page_info: PageInfo,
 }
 
+/// Connection containing review threads.
 type ReviewThreadConnection = Connection<ReviewThread>;
+/// Connection containing review comments.
 pub type CommentConnection = Connection<ReviewComment>;
 
 /// Details of a single review thread.
 #[derive(Debug, Deserialize, Default)]
 pub struct ReviewThread {
+    /// Global identifier of the review thread.
     pub id: String,
     #[serde(rename = "isResolved")]
+    /// Whether the thread has been resolved.
     pub is_resolved: bool,
     #[serde(default, rename = "isOutdated")]
+    /// Whether the thread refers to an outdated diff.
     pub is_outdated: bool,
+    /// Comments belonging to the thread.
     pub comments: CommentConnection,
 }
 
 /// A single review comment.
 #[derive(Debug, Deserialize, Default)]
 pub struct ReviewComment {
+    /// Comment body in Markdown.
     pub body: String,
     #[serde(rename = "diffHunk")]
+    /// Diff hunk surrounding the comment.
     pub diff_hunk: String,
     #[serde(rename = "originalPosition")]
+    /// Original line position before later diffs moved the comment.
     pub original_position: Option<i32>,
+    /// Current line position, when GitHub provides one.
     pub position: Option<i32>,
+    /// Repository-relative path containing the comment.
     pub path: String,
+    /// Web URL for the comment.
     pub url: String,
+    /// Author of the comment, when available.
     pub author: Option<User>,
 }
 
@@ -83,8 +109,10 @@ pub struct ReviewComment {
 #[derive(Debug, Deserialize, Default, Clone)]
 pub struct PageInfo {
     #[serde(rename = "hasNextPage")]
+    /// Whether another page is available.
     pub has_next_page: bool,
     #[serde(rename = "endCursor")]
+    /// Cursor to use when requesting the next page.
     pub end_cursor: Option<String>,
 }
 
@@ -132,6 +160,7 @@ impl PageInfo {
 /// Minimal user representation for authorship information.
 #[derive(Debug, Deserialize, Default, Clone)]
 pub struct User {
+    /// GitHub login for the user.
     pub login: String,
 }
 

--- a/src/reviews.rs
+++ b/src/reviews.rs
@@ -10,44 +10,58 @@ use serde_json::{Map, json};
 use crate::{GraphQLClient, PageInfo, User, VkError, ref_parser::RepoInfo};
 use std::collections::{HashMap, hash_map::Entry};
 
+/// A pull-request review returned by the GitHub API.
 #[derive(Debug, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct PullRequestReview {
+    /// Review body in Markdown.
     pub body: String,
     /// Timestamp when the review was formally submitted.
     ///
     /// This may be `None` when the timestamp is missing or unknown.
     pub submitted_at: Option<DateTime<Utc>>,
+    /// GitHub review state, such as `APPROVED` or `COMMENTED`.
     pub state: String,
+    /// Author of the review, when available.
     pub author: Option<User>,
 }
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
+/// Top-level response for the review query.
 struct ReviewData {
+    /// Repository response data.
     repository: RepositoryReviews,
 }
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
+/// Repository response data for reviews.
 struct RepositoryReviews {
     #[serde(rename = "pullRequest")]
+    /// Pull-request response data.
     pull_request: PullRequestReviews,
 }
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
+/// Pull-request response data for reviews.
 struct PullRequestReviews {
+    /// Review connection returned by GitHub.
     reviews: ReviewConnection,
 }
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
+/// A paginated connection of pull-request reviews.
 struct ReviewConnection {
+    /// Reviews returned in this page.
     nodes: Vec<PullRequestReview>,
+    /// Pagination metadata for this page.
     page_info: PageInfo,
 }
 
+/// GraphQL query used to retrieve pull-request reviews.
 const REVIEWS_QUERY: &str = r"
     query($owner: String!, $name: String!, $number: Int!, $cursor: String) {
       repository(owner: $owner, name: $name) {

--- a/src/summary.rs
+++ b/src/summary.rs
@@ -87,6 +87,7 @@ pub fn print_summary(summary: &[(String, usize)]) {
     }
 }
 
+/// Write one banner line to the provided writer.
 fn write_banner<W: Write>(mut out: W, text: &str) -> std::io::Result<()> {
     writeln!(out, "{text}")
 }

--- a/src/test_utils_env.rs
+++ b/src/test_utils_env.rs
@@ -102,6 +102,7 @@ pub fn strip_ansi_codes(input: &str) -> String {
     out
 }
 
+/// Consume a control-sequence introducer and report whether it terminates.
 fn skip_ansi_sequence(chars: &mut impl Iterator<Item = char>) -> bool {
     if !matches!(chars.next(), Some('[')) {
         return false;

--- a/tests/resolve.rs
+++ b/tests/resolve.rs
@@ -3,9 +3,10 @@
 #![cfg(feature = "unstable-rest-resolve")]
 
 use assert_cmd::prelude::*;
+use bytes::Bytes;
 use http_body_util::Full;
 use hyper::{
-    Response, StatusCode,
+    Request, Response, StatusCode,
     header::{ACCEPT, AUTHORIZATION, CONTENT_TYPE},
 };
 use predicates::prelude::*;
@@ -134,6 +135,28 @@ async fn resolve_flows(#[case] pages: Vec<Page>, #[case] expected_posts: usize) 
     run_resolve_flow(pages, expected_posts).await;
 }
 
+fn assert_reply_request(req: &Request<Bytes>) {
+    assert_eq!(req.body().as_ref(), br#"{"body":"done"}"#);
+    assert_eq!(
+        req.headers().get(AUTHORIZATION).expect("authorization"),
+        "Bearer dummy"
+    );
+    assert_eq!(
+        req.headers().get(ACCEPT).expect("accept"),
+        "application/vnd.github+json"
+    );
+    assert_eq!(
+        req.headers()
+            .get("x-github-api-version")
+            .expect("GitHub API version"),
+        "2022-11-28"
+    );
+    assert_eq!(
+        req.headers().get(CONTENT_TYPE).expect("content type"),
+        "application/json"
+    );
+}
+
 async fn run_reply_flow(
     rest_status: StatusCode,
     api_uri_suffix: &str,
@@ -146,25 +169,7 @@ async fn run_reply_flow(
         let gql_calls = vec.iter().filter(|c| c.ends_with("/graphql")).count();
         vec.push(format!("{} {}", req.method(), req.uri().path()));
         if req.uri().path().ends_with("/replies") {
-            assert_eq!(req.body().as_ref(), br#"{"body":"done"}"#);
-            assert_eq!(
-                req.headers().get(AUTHORIZATION).expect("authorization"),
-                "Bearer dummy"
-            );
-            assert_eq!(
-                req.headers().get(ACCEPT).expect("accept"),
-                "application/vnd.github+json"
-            );
-            assert_eq!(
-                req.headers()
-                    .get("x-github-api-version")
-                    .expect("GitHub API version"),
-                "2022-11-28"
-            );
-            assert_eq!(
-                req.headers().get(CONTENT_TYPE).expect("content type"),
-                "application/json"
-            );
+            assert_reply_request(req);
         }
         let status = if req.uri().path().ends_with("/replies") {
             rest_status

--- a/tests/resolve.rs
+++ b/tests/resolve.rs
@@ -4,6 +4,7 @@
 
 use assert_cmd::prelude::*;
 use bytes::Bytes;
+use futures::FutureExt as _;
 use http_body_util::Full;
 use hyper::{
     Request, Response, StatusCode,
@@ -15,6 +16,7 @@ use std::borrow::ToOwned;
 use std::collections::VecDeque;
 use std::sync::{Arc, Mutex};
 
+mod resolve_async_mitm;
 mod utils;
 use utils::{start_mitm, start_mitm_capture, vk_cmd};
 
@@ -24,7 +26,6 @@ struct Page {
     comment_id: u32,
     thread_id: &'static str,
 }
-
 impl Page {
     fn next(end_cursor: &'static str, comment_id: u32, thread_id: &'static str) -> Self {
         Self {
@@ -33,7 +34,6 @@ impl Page {
             thread_id,
         }
     }
-
     fn last_with(comment_id: u32, thread_id: &'static str) -> Self {
         Self {
             end_cursor: None,
@@ -41,7 +41,6 @@ impl Page {
             thread_id,
         }
     }
-
     fn body(&self) -> String {
         self.end_cursor.map_or_else(
             || {
@@ -302,23 +301,27 @@ async fn resolve_normalizes_api_uri_trailing_slashes(#[case] api_uri_suffix: &st
 
 #[tokio::test(flavor = "multi_thread")]
 async fn resolve_reply_honours_total_http_timeout() {
-    let (addr, handler, shutdown) = start_mitm().await.expect("start server");
+    let (addr, handler, shutdown) = resolve_async_mitm::start_async_mitm()
+        .await
+        .expect("start server");
     *handler.lock().expect("lock handler") = Box::new(move |req| {
-        if req.uri().path().ends_with("/replies") {
-            tokio::task::block_in_place(|| {
-                std::thread::sleep(std::time::Duration::from_secs(2));
-            });
-        }
+        let is_reply = req.uri().path().ends_with("/replies");
         let body = if req.uri().path() == "/graphql" {
             r#"{"data":{"repository":{"pullRequest":{"reviewComments":{"pageInfo":{"endCursor":null,"hasNextPage":false},"nodes":[{"databaseId":1,"pullRequestReviewThread":{"id":"t"}}]}}}}}"#
         } else {
             "{}"
         };
-        Response::builder()
-            .status(StatusCode::OK)
-            .header(CONTENT_TYPE, "application/json")
-            .body(Full::from(body))
-            .expect("response")
+        async move {
+            if is_reply {
+                tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+            }
+            Response::builder()
+                .status(StatusCode::OK)
+                .header(CONTENT_TYPE, "application/json")
+                .body(Full::from(body))
+                .expect("response")
+        }
+        .boxed()
     });
     let output = tokio::task::spawn_blocking(move || {
         vk_cmd(addr)

--- a/tests/resolve.rs
+++ b/tests/resolve.rs
@@ -136,6 +136,7 @@ async fn resolve_flows(#[case] pages: Vec<Page>, #[case] expected_posts: usize) 
 
 async fn run_reply_flow(
     rest_status: StatusCode,
+    api_uri_suffix: &str,
 ) -> (Vec<String>, Vec<u8>, Vec<u8>, std::process::ExitStatus) {
     let (addr, handler, shutdown) = start_mitm_capture().await.expect("start server");
     let calls = Arc::new(Mutex::new(Vec::<String>::new()));
@@ -185,8 +186,10 @@ async fn run_reply_flow(
             .body(Full::from(body))
             .expect("response")
     });
+    let api_uri = format!("http://{addr}{api_uri_suffix}");
     let (stdout, stderr, status) = tokio::task::spawn_blocking(move || {
         let output = vk_cmd(addr)
+            .env("GITHUB_API_URL", api_uri)
             .args([
                 "resolve",
                 "https://github.com/o/r/pull/83#discussion_r1",
@@ -224,6 +227,20 @@ async fn run_reply_flow(
     ],
 )]
 #[case(
+    StatusCode::NO_CONTENT,
+    true,
+    &[
+        "POST /repos/o/r/pulls/83/comments/1/replies",
+        "POST /graphql",
+        "POST /graphql",
+    ],
+)]
+#[case(
+    StatusCode::MULTIPLE_CHOICES,
+    false,
+    &["POST /repos/o/r/pulls/83/comments/1/replies"],
+)]
+#[case(
     StatusCode::FORBIDDEN,
     false,
     &["POST /repos/o/r/pulls/83/comments/1/replies"],
@@ -238,7 +255,7 @@ async fn resolve_flows_reply(
     #[case] should_succeed: bool,
     #[case] expected: &'static [&'static str],
 ) {
-    let (calls, stdout, stderr, status) = run_reply_flow(rest_status).await;
+    let (calls, stdout, stderr, status) = run_reply_flow(rest_status, "").await;
     let stdout = String::from_utf8_lossy(&stdout);
     let stderr = String::from_utf8_lossy(&stderr);
     let code = rest_status.as_u16().to_string();
@@ -256,6 +273,26 @@ async fn resolve_flows_reply(
         );
     }
     assert_eq!(calls.as_slice(), expected);
+}
+
+#[tokio::test]
+#[rstest::rstest]
+#[case::without_trailing_slash("")]
+#[case::with_one_trailing_slash("/")]
+#[case::with_multiple_trailing_slashes("///")]
+async fn resolve_normalizes_api_uri_trailing_slashes(#[case] api_uri_suffix: &str) {
+    let (calls, stdout, stderr, status) = run_reply_flow(StatusCode::OK, api_uri_suffix).await;
+    assert!(status.success(), "status: {status:?}, stderr: {stderr:?}");
+    assert!(stdout.is_empty(), "unexpected stdout: {stdout:?}");
+    assert!(stderr.is_empty(), "unexpected stderr: {stderr:?}");
+    assert_eq!(
+        calls.as_slice(),
+        &[
+            "POST /repos/o/r/pulls/83/comments/1/replies",
+            "POST /graphql",
+            "POST /graphql",
+        ]
+    );
 }
 
 #[tokio::test]

--- a/tests/resolve.rs
+++ b/tests/resolve.rs
@@ -4,7 +4,10 @@
 
 use assert_cmd::prelude::*;
 use http_body_util::Full;
-use hyper::{Response, StatusCode};
+use hyper::{
+    Response, StatusCode,
+    header::{ACCEPT, AUTHORIZATION, CONTENT_TYPE},
+};
 use predicates::prelude::*;
 use serde_json::Value;
 use std::borrow::ToOwned;
@@ -134,13 +137,34 @@ async fn resolve_flows(#[case] pages: Vec<Page>, #[case] expected_posts: usize) 
 async fn run_reply_flow(
     rest_status: StatusCode,
 ) -> (Vec<String>, Vec<u8>, Vec<u8>, std::process::ExitStatus) {
-    let (addr, handler, shutdown) = start_mitm().await.expect("start server");
+    let (addr, handler, shutdown) = start_mitm_capture().await.expect("start server");
     let calls = Arc::new(Mutex::new(Vec::<String>::new()));
     let clone = Arc::clone(&calls);
     *handler.lock().expect("lock handler") = Box::new(move |req| {
         let mut vec = clone.lock().expect("lock");
         let gql_calls = vec.iter().filter(|c| c.ends_with("/graphql")).count();
         vec.push(format!("{} {}", req.method(), req.uri().path()));
+        if req.uri().path().ends_with("/replies") {
+            assert_eq!(req.body().as_ref(), br#"{"body":"done"}"#);
+            assert_eq!(
+                req.headers().get(AUTHORIZATION).expect("authorization"),
+                "Bearer dummy"
+            );
+            assert_eq!(
+                req.headers().get(ACCEPT).expect("accept"),
+                "application/vnd.github+json"
+            );
+            assert_eq!(
+                req.headers()
+                    .get("x-github-api-version")
+                    .expect("GitHub API version"),
+                "2022-11-28"
+            );
+            assert_eq!(
+                req.headers().get(CONTENT_TYPE).expect("content type"),
+                "application/json"
+            );
+        }
         let status = if req.uri().path().ends_with("/replies") {
             rest_status
         } else {
@@ -157,7 +181,7 @@ async fn run_reply_flow(
         };
         Response::builder()
             .status(status)
-            .header("Content-Type", "application/json")
+            .header(CONTENT_TYPE, "application/json")
             .body(Full::from(body))
             .expect("response")
     });
@@ -232,6 +256,53 @@ async fn resolve_flows_reply(
         );
     }
     assert_eq!(calls.as_slice(), expected);
+}
+
+#[tokio::test]
+async fn resolve_reply_honours_total_http_timeout() {
+    let (addr, handler, shutdown) = start_mitm().await.expect("start server");
+    *handler.lock().expect("lock handler") = Box::new(move |req| {
+        if req.uri().path().ends_with("/replies") {
+            std::thread::sleep(std::time::Duration::from_secs(2));
+        }
+        let body = if req.uri().path() == "/graphql" {
+            r#"{"data":{"repository":{"pullRequest":{"reviewComments":{"pageInfo":{"endCursor":null,"hasNextPage":false},"nodes":[{"databaseId":1,"pullRequestReviewThread":{"id":"t"}}]}}}}}"#
+        } else {
+            "{}"
+        };
+        Response::builder()
+            .status(StatusCode::OK)
+            .header(CONTENT_TYPE, "application/json")
+            .body(Full::from(body))
+            .expect("response")
+    });
+    let output = tokio::task::spawn_blocking(move || {
+        vk_cmd(addr)
+            .args([
+                "--http-timeout",
+                "1",
+                "resolve",
+                "https://github.com/o/r/pull/83#discussion_r1",
+                "-m",
+                "done",
+            ])
+            .output()
+            .expect("run command")
+    })
+    .await
+    .expect("spawn blocking");
+    shutdown.shutdown().await;
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !output.status.success(),
+        "expected timeout; stderr: {stderr}"
+    );
+    assert!(
+        predicate::str::contains("post reply to /repos/o/r/pulls/83/comments/1/replies")
+            .and(predicate::str::contains("deadline has elapsed"))
+            .eval(&stderr),
+        "stderr: {stderr}"
+    );
 }
 
 #[cfg(feature = "unstable-rest-resolve")]

--- a/tests/resolve.rs
+++ b/tests/resolve.rs
@@ -295,12 +295,14 @@ async fn resolve_normalizes_api_uri_trailing_slashes(#[case] api_uri_suffix: &st
     );
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn resolve_reply_honours_total_http_timeout() {
     let (addr, handler, shutdown) = start_mitm().await.expect("start server");
     *handler.lock().expect("lock handler") = Box::new(move |req| {
         if req.uri().path().ends_with("/replies") {
-            std::thread::sleep(std::time::Duration::from_secs(2));
+            tokio::task::block_in_place(|| {
+                std::thread::sleep(std::time::Duration::from_secs(2));
+            });
         }
         let body = if req.uri().path() == "/graphql" {
             r#"{"data":{"repository":{"pullRequest":{"reviewComments":{"pageInfo":{"endCursor":null,"hasNextPage":false},"nodes":[{"databaseId":1,"pullRequestReviewThread":{"id":"t"}}]}}}}}"#

--- a/tests/resolve_async_mitm/mod.rs
+++ b/tests/resolve_async_mitm/mod.rs
@@ -1,0 +1,90 @@
+//! Asynchronous MITM fixture used by resolve timeout integration tests.
+
+use super::utils::ShutdownHandle;
+use bytes::Bytes;
+use futures::future::BoxFuture;
+use http_body_util::Full;
+use hyper::{Request, Response, body::Incoming, service::service_fn};
+use hyper_util::{rt::TokioExecutor, server::conn::auto};
+use std::{
+    io::ErrorKind,
+    net::SocketAddr,
+    sync::{Arc, Mutex},
+};
+use tokio::{net::TcpListener, sync::oneshot};
+
+/// Shared asynchronous handler type invoked for each incoming request.
+type AsyncHandler = Arc<
+    Mutex<Box<dyn FnMut(Request<Incoming>) -> BoxFuture<'static, Response<Full<Bytes>>> + Send>>,
+>;
+
+/// Start an HTTP server forwarding requests to an asynchronous shared handler.
+///
+/// # Errors
+///
+/// Returns an error if the server fails to bind to a local port.
+///
+/// # Panics
+///
+/// Panics if the default response cannot be constructed.
+#[expect(
+    clippy::integer_division_remainder_used,
+    reason = "tokio::select! uses % internally"
+)]
+pub(super) async fn start_async_mitm()
+-> Result<(SocketAddr, AsyncHandler, ShutdownHandle), std::io::Error> {
+    let handler: AsyncHandler = Arc::new(Mutex::new(Box::new(|_req| {
+        Box::pin(async {
+            Response::builder()
+                .status(404)
+                .body(Full::from("No handler"))
+                .expect("failed to create default response")
+        })
+    })));
+    let handler_clone = handler.clone();
+
+    let listener = TcpListener::bind("127.0.0.1:0").await?;
+    let addr = listener.local_addr()?;
+    let (tx, mut rx) = oneshot::channel();
+
+    let join = tokio::spawn(async move {
+        let builder = auto::Builder::new(TokioExecutor::new());
+        loop {
+            tokio::select! {
+                res = listener.accept() => match res {
+                    Ok((stream, _)) => {
+                        let io = hyper_util::rt::TokioIo::new(stream);
+                        let handler = handler_clone.clone();
+                        let service = service_fn(move |request: Request<Incoming>| {
+                            let handler = handler.clone();
+                            async move {
+                                let response = {
+                                    let mut handler = handler.lock().expect("lock handler in service");
+                                    (handler)(request)
+                                };
+                                Ok::<_, std::convert::Infallible>(response.await)
+                            }
+                        });
+                        let builder = builder.clone();
+                        tokio::spawn(async move {
+                            let _ = builder.serve_connection(io, service).await;
+                        });
+                    }
+                    Err(error) => {
+                        eprintln!("accept error: {error}");
+                        match error.kind() {
+                            ErrorKind::ConnectionAborted
+                            | ErrorKind::ConnectionReset
+                            | ErrorKind::Interrupted
+                            | ErrorKind::WouldBlock => {}
+                            _ => break,
+                        }
+                    }
+                },
+                _ = &mut rx => break,
+            }
+        }
+    });
+
+    Ok((addr, handler, ShutdownHandle::new(join, tx)))
+}

--- a/tests/utils/mod.rs
+++ b/tests/utils/mod.rs
@@ -31,6 +31,11 @@ pub struct ShutdownHandle {
 }
 
 impl ShutdownHandle {
+    /// Create a shutdown handle for a running MITM server.
+    pub(super) fn new(join: JoinHandle<()>, stop: oneshot::Sender<()>) -> Self {
+        Self { join, stop }
+    }
+
     /// Signal the server to stop and await shutdown.
     pub async fn shutdown(self) {
         let _ = self.stop.send(());
@@ -99,7 +104,7 @@ pub async fn start_mitm() -> Result<(SocketAddr, Handler, ShutdownHandle), std::
         }
     });
 
-    Ok((addr, handler, ShutdownHandle { join, stop: tx }))
+    Ok((addr, handler, ShutdownHandle::new(join, tx)))
 }
 
 /// Start an HTTP server forwarding requests to a shared handler while capturing request bodies for assertions.
@@ -171,7 +176,7 @@ pub async fn start_mitm_capture()
         }
     });
 
-    Ok((addr, handler, ShutdownHandle { join, stop: tx }))
+    Ok((addr, handler, ShutdownHandle::new(join, tx)))
 }
 /// Create a `vk` command configured for testing.
 ///


### PR DESCRIPTION
## Summary

This branch delivers the first of three planned pull requests modernising
`vk`'s GitHub API access: the REST resolve path now rides
[octocrab](https://docs.rs/octocrab) instead of a bespoke `reqwest` client.
It also carries the programme's foundations: the repository's first ADR,
[docs/adr-001-github-api-client-modernisation.md](https://github.com/leynos/vk/blob/adopt-octocrab/docs/adr-001-github-api-client-modernisation.md),
recording the accepted three-part decision (octocrab for REST, a hyper
transport for the bespoke GraphQL client, and `graphql_client` codegen for
typed queries), and the living ExecPlan.

Execplan: [docs/execplans/adopt-octocrab.md](https://github.com/leynos/vk/blob/adopt-octocrab/docs/execplans/adopt-octocrab.md)
— PR 1 of its three phases lands here; the hyper transport (PR 2) and typed
GraphQL (PR 3) phases remain as authorized future work.

Observable behaviour is unchanged: the reply still POSTs to
`repos/{owner}/{name}/pulls/{n}/comments/{id}/replies`, a 404 remains a
warn-and-continue, other non-2xx statuses remain fatal with the route and
status code in the error text, and `tests/resolve.rs` passes without any
assertion change.

## Review walkthrough

- Start with
  [docs/adr-001-github-api-client-modernisation.md](https://github.com/leynos/vk/blob/adopt-octocrab/docs/adr-001-github-api-client-modernisation.md)
  for the decision context, options considered, and known risks.
- Then review
  [src/resolve/rest.rs](https://github.com/leynos/vk/blob/adopt-octocrab/src/resolve/rest.rs)
  — `RestClient` now wraps `octocrab::Octocrab` built with `base_uri` from
  the existing `GITHUB_API_URL` resolution, `personal_token` only when a
  token is present, restored `x-github-api-version: 2022-11-28` and
  `Accept` headers, and the raw `_post` route so status handling stays in
  `vk` (the typed reply route reports errors without the path and status
  fragments the tests assert).
- Check
  [Cargo.toml](https://github.com/leynos/vk/blob/adopt-octocrab/Cargo.toml)
  for the tilde-pinned `octocrab ~0.54` (patch releases have broken
  builds upstream; see the ADR) with `retry` deliberately excluded so the
  reply path stays retry-free, plus the new direct `http` dependency
  (already in the tree via hyper).
- Finish with
  [docs/execplans/adopt-octocrab.md](https://github.com/leynos/vk/blob/adopt-octocrab/docs/execplans/adopt-octocrab.md)
  for the decision log (raw-`_post` rationale, timeout mapping,
  `User-Agent` note) and the remaining phases.

## Validation

- `make check-fmt`: pass
- `make lint` (`cargo clippy --all-targets --all-features -- -D warnings`): pass
- `make test` (`RUSTFLAGS="-D warnings" cargo test --all-targets --all-features`): 297 tests pass, 1 ignored (requires a recorded network transcript)
- `cargo test --features unstable-rest-resolve --test resolve`: 8 passed
- `make markdownlint` / `make nixie`: pass
- `coderabbit review --agent`: completed, zero findings

## Notes

- The REST path's `User-Agent` becomes `octocrab` (octocrab hard-codes it;
  no test asserts the REST user agent). GraphQL requests keep
  `User-Agent: vk`.
- reqwest's single total-request timeout is preserved around the complete
  octocrab reply request; octocrab also receives read and write timeouts,
  while `connect_timeout` maps directly.
- `reqwest` itself remains in the dependency graph until PR 2, which moves
  the GraphQL client onto a direct hyper transport and removes it.

## Summary by Sourcery

Modernize the REST resolve reply path with Octocrab while preserving its existing behaviour and strengthening observability, validation, and project documentation.

New Features:
- Route REST review-comment replies through Octocrab while preserving authentication, endpoint overrides, headers, timeout handling, and status semantics.
- Add bounded metrics for REST reply attempts, durations, failures, and timeouts.
- Add property-based coverage and expanded integration coverage for REST request and response behaviour.

Bug Fixes:
- Preserve the total request deadline and API compatibility while migrating REST reply handling to the new client.

Enhancements:
- Centralize GitHub API client modernization decisions and migration planning in an ADR and ExecPlan.
- Strengthen Rust documentation and linting requirements across the crate.

Build:
- Add Octocrab and supporting HTTP, metrics, and property-testing dependencies, and enable Tokio time support.

CI:
- Extend linting to include rustdoc warnings and add a type-check Make target.

Documentation:
- Document the GitHub API client modernization, REST resolve architecture, timeout behaviour, and 404 handling.

Tests:
- Expand resolve tests to verify routes, authentication, headers, URI normalization, status handling, and total timeouts.

Chores:
- Update dependency lockfiles and repository documentation indexes.

## References

- https://lody.ai/leynos/sessions/1980fff4-2b14-46a6-ae24-a3b84a49c5bc