### PR TITLE
Wire the CodeScene coverage gate into CI

### DIFF
--- a/.github/workflows/coverage-main.yml
+++ b/.github/workflows/coverage-main.yml
@@ -1,0 +1,46 @@
+name: Coverage (main)
+
+# CodeScene accepts `cs-coverage upload` only for analysed branches, so
+# main-branch coverage is uploaded here on push; pull requests only
+# generate coverage in coverage.yml (the changed-line gate is deferred
+# until CodeScene enables the coverage-gates configuration for project
+# 70277 — see the comment in coverage.yml). This workflow also advances
+# the coverage ratchet baseline: caches saved on main are readable by
+# every pull-request run, so the baseline written here is the one PR
+# ratchet checks compare against.
+#
+# workflow_dispatch lets the upload be re-run on demand: merges
+# performed by the automerge workflow's GITHUB_TOKEN do not fire
+# push-event workflows, so automerged changes to main only get coverage
+# via a manual dispatch.
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  coverage-upload:
+    runs-on: ubuntu-latest
+    env:
+      CARGO_TERM_COLOR: always
+      CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN }}
+      CODESCENE_CLI_SHA256: ${{ vars.CODESCENE_CLI_SHA256 }}
+    steps:
+      - uses: actions/checkout@v5
+      - name: Setup Rust
+        uses: leynos/shared-actions/.github/actions/setup-rust@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
+      - name: Generate coverage
+        uses: leynos/shared-actions/.github/actions/generate-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
+        with:
+          output-path: lcov.info
+          format: lcov
+          use-cargo-nextest: 'false'
+          with-ratchet: 'true'
+      - name: Upload coverage data to CodeScene
+        if: ${{ env.CS_ACCESS_TOKEN != '' }}
+        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
+        with:
+          format: lcov
+          access-token: ${{ env.CS_ACCESS_TOKEN }}
+          installer-checksum: ${{ vars.CODESCENE_CLI_SHA256 }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -13,24 +13,34 @@ jobs:
       CODESCENE_CLI_SHA256: ${{ vars.CODESCENE_CLI_SHA256 }}
     steps:
       - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
       - name: Setup Rust
-        uses: leynos/shared-actions/.github/actions/setup-rust@69f9c29d18a28b6bdf4b02dcd743ef416817ba18
+        uses: leynos/shared-actions/.github/actions/setup-rust@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
       - name: Format
         run: make check-fmt
       - name: Lint
         run: make lint
       - name: Generate coverage
-        uses: leynos/shared-actions/.github/actions/generate-coverage@69f9c29d18a28b6bdf4b02dcd743ef416817ba18
+        uses: leynos/shared-actions/.github/actions/generate-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
         with:
           output-path: lcov.info
           format: lcov
-      - name: Upload coverage data to CodeScene
-        if: ${{ env.CS_ACCESS_TOKEN != '' }}
-        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@69f9c29d18a28b6bdf4b02dcd743ef416817ba18
-        with:
-          format: lcov
-          access-token: ${{ env.CS_ACCESS_TOKEN }}
-          installer-checksum: ${{ vars.CODESCENE_CLI_SHA256 }}
+          use-cargo-nextest: 'false'
+          with-ratchet: 'true'
+      # The `mode: check` step is deliberately not wired in yet: CodeScene
+      # project 70277 has no coverage-gates configuration, so
+      # `cs-coverage check` would fail every run with "HTTP call
+      # succeeded, but the received project-config isn't valid. Lacks the
+      # gates configuration." — a CodeScene-side per-project setting, not
+      # a CI defect (see ddlint#287 and chutoro#156, which hit the
+      # byte-identical error). Add the check step in a fast-follow PR
+      # once coverage-main.yml has uploaded to main at least once and the
+      # gate is confirmed to resolve, or once CodeScene confirms the
+      # project's coverage gate is enabled. `cs-coverage upload` is not
+      # run here either: CodeScene only accepts uploads for branches it
+      # analyses (main), so uploading from a pull-request head fails;
+      # main-branch coverage is uploaded by coverage-main.yml instead.
 
   # Exercise the experimental REST-based resolve path, ensuring lints and tests
   # pass when the `unstable-rest-resolve` feature is enabled.
@@ -39,7 +49,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - name: Setup Rust
-        uses: leynos/shared-actions/.github/actions/setup-rust@69f9c29d18a28b6bdf4b02dcd743ef416817ba18
+        uses: leynos/shared-actions/.github/actions/setup-rust@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
       - name: Install OpenSSL
         run: sudo apt-get update && sudo apt-get install -y openssl ca-certificates
       - name: Lint (feature-gated)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
           fi
           echo "Release tag $tag matches Cargo.toml version."
       - name: Setup Rust
-        uses: leynos/shared-actions/.github/actions/setup-rust@69f9c29d18a28b6bdf4b02dcd743ef416817ba18
+        uses: leynos/shared-actions/.github/actions/setup-rust@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
       - name: Add Rust target
         run: rustup target add ${{ matrix.target }}
       - name: Install AArch64 linker


### PR DESCRIPTION
## Summary

- Onboard vk (CodeScene project [70277](https://codescene.io/projects/70277)) to the estate CodeScene coverage-upload pattern. CodeScene already posts a `Code Health Review` check on vk's pull requests; this PR gets coverage data flowing so the `Code Coverage` check can eventually be enabled without repeating the netsuke/mxd timed-out-check jam.
- Bump the `leynos/shared-actions` pin repo-wide from `69f9c29d` to `927edd45ae77be4251a8a18ca9eb5613a2e32cbd` (shared-actions [#333](https://github.com/leynos/shared-actions/pull/333)/[#334](https://github.com/leynos/shared-actions/pull/334): fixes the coverage-upload CLI-version bug and adds per-line coverage records plus `mode: check` support).
- Enable the coverage ratchet (`with-ratchet: 'true'`) in the PR generation step so the changed baseline gates future PRs once uploads exist.
- Add `.github/workflows/coverage-main.yml`: on push to `main` (and `workflow_dispatch`, so automerged pushes that skip the push event can be re-triggered manually), it regenerates coverage and uploads it to CodeScene with `mode: upload`, and writes the authoritative ratchet baseline that PR runs compare against.
- **Deliberately not wired**: the pull-request `mode: check` changed-line gate. A read-only probe of `GET /v2/code-coverage/projects/70277/config` with the estate PAT returns an empty body, matching the pattern found on ddlint/chutoro — CodeScene has not enabled the coverage-gates configuration for this project yet, and `cs-coverage check` fails unconditionally without it (`"received project-config isn't valid. Lacks the gates configuration."`). The deferral is documented inline in `coverage.yml`. `mode: upload` is likewise not run from the PR job (CodeScene only accepts uploads for branches it analyses; from a PR head it fails outright) — this is why the existing guarded step had to be removed rather than left in place once secrets go live.

### Why the existing step had to change, not just gain new inputs

vk's coverage.yml already had a guarded `upload-codescene-coverage` step, but it used the action's default `mode: upload` and `CS_ACCESS_TOKEN` was unset in both secret stores, so it always skipped silently. Setting the secret without first fixing this would have broken every open pull request the instant the token was set (`cs-coverage upload` rejects non-analysed branches). This PR removes that step from the PR job entirely; uploads now only happen from `coverage-main.yml`, which runs on `main`.

## Review walkthrough

- [`.github/workflows/coverage.yml`](https://github.com/leynos/vk/blob/codescene-coverage-gate/.github/workflows/coverage.yml) — pin bump, `fetch-depth: 0` (so a future `mode: check` step can diff against the merge base without another checkout change), `use-cargo-nextest: 'false'` (vk's Makefile runs plain `cargo test`, not nextest, so this preserves existing test behaviour), `with-ratchet: 'true'`, and the guarded upload step replaced with an explanatory comment.
- [`.github/workflows/coverage-main.yml`](https://github.com/leynos/vk/blob/codescene-coverage-gate/.github/workflows/coverage-main.yml) — new workflow, modelled on ddlint's, generating and uploading coverage on push to `main` plus manual dispatch.
- [`.github/workflows/release.yml`](https://github.com/leynos/vk/blob/codescene-coverage-gate/.github/workflows/release.yml) — same pin bump for consistency (single repo-wide shared-actions pin).

## Validation

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/coverage.yml'))"` and the same for `coverage-main.yml` and `release.yml` — all parse.
- No workflow-contract tests exist in this repo to update (checked for references to `.github/workflows` filenames in Rust sources and the Makefile).
- Full CI run on this PR's own head is the functional validation: coverage generation must succeed under `use-cargo-nextest: 'false'` and the ratchet-enabled step must not fail on first run (no baseline cached yet).

### About the CodeScene checks

The `CodeScene Code Health Review` check you may see on this PR is unrelated to this change — it runs independently of coverage. There is no branch-protection ruleset on this repository (`gh api repos/leynos/vk/rules/branches/main` returns `[]`), so no check here is a required check; CodeScene checks (health review or, in future, coverage) affect the status rollup but not mergeability directly.

**Secrets**: `CS_ACCESS_TOKEN` will be set in both the Actions and Dependabot secret stores immediately before this PR merges (not before), to avoid breaking the several other open pull requests (#194, #195, #196, #186) whose heads still carry the old, unguarded-by-branch upload step until they rebase onto the new main.
